### PR TITLE
feat: rename and extract enum for scoped methods

### DIFF
--- a/src/types/icrc-requests.ts
+++ b/src/types/icrc-requests.ts
@@ -3,7 +3,7 @@ import {
   ICRC25_PERMISSIONS,
   ICRC25_REQUEST_PERMISSIONS,
   ICRC25_SUPPORTED_STANDARDS,
-  IcrcWalletRequestMethod
+  IcrcWalletScopedMethod
 } from './icrc';
 import {inferRpcRequestWithParams, inferRpcRequestWithoutParams} from './rpc';
 
@@ -13,7 +13,7 @@ const IcrcWalletScopesParams = z.object({
   scopes: z
     .array(
       z.object({
-        method: IcrcWalletRequestMethod
+        method: IcrcWalletScopedMethod
       })
     )
     .min(1)

--- a/src/types/icrc-responses.ts
+++ b/src/types/icrc-responses.ts
@@ -1,12 +1,12 @@
 import {z} from 'zod';
-import {IcrcWalletPermissionState, IcrcWalletRequestMethod, IcrcWalletStandard} from './icrc';
+import {IcrcWalletPermissionState, IcrcWalletScopedMethod, IcrcWalletStandard} from './icrc';
 import {inferRpcResponse} from './rpc';
 
 const IcrcWalletScopesResult = z.object({
   scopes: z.array(
     z.object({
       scope: z.object({
-        method: IcrcWalletRequestMethod
+        method: IcrcWalletScopedMethod
       }),
       state: IcrcWalletPermissionState
     })

--- a/src/types/icrc.ts
+++ b/src/types/icrc.ts
@@ -13,11 +13,7 @@ export const IcrcWalletMethod = z.enum([
   ICRC27_ACCOUNTS
 ]);
 
-export const IcrcWalletRequestMethod = IcrcWalletMethod.exclude([
-  ICRC25_REQUEST_PERMISSIONS,
-  ICRC25_PERMISSIONS,
-  ICRC25_SUPPORTED_STANDARDS
-]);
+export const IcrcWalletScopedMethod = IcrcWalletMethod.extract([ICRC27_ACCOUNTS]);
 
 export const ICRC25_PERMISSION_GRANTED = 'granted';
 export const ICRC25_PERMISSION_DENIED = 'denied';


### PR DESCRIPTION
# Motivation

There might be future iteration but, using `extract` instead of `excluse` and renaming the enum makes it purpose a bit more clear.
