### PR TITLE
chore: clean unnecessary vitest imports

### DIFF
--- a/src/signer.spec.ts
+++ b/src/signer.spec.ts
@@ -1,4 +1,4 @@
-import {afterEach, beforeEach, describe, type MockInstance} from 'vitest';
+import {type MockInstance} from 'vitest';
 import {Signer, type SignerParameters} from './signer';
 
 describe('Signer', () => {

--- a/src/types/icrc-requests.spec.ts
+++ b/src/types/icrc-requests.spec.ts
@@ -1,4 +1,3 @@
-import {describe, expect, it} from 'vitest';
 import {ICRC27_ACCOUNTS} from './icrc';
 import {
   IcrcWalletPermissionsRequest,

--- a/src/types/icrc-responses.spec.ts
+++ b/src/types/icrc-responses.spec.ts
@@ -1,4 +1,3 @@
-import {describe, expect, it} from 'vitest';
 import {ICRC25_PERMISSION_GRANTED, ICRC27_ACCOUNTS} from './icrc';
 import {
   IcrcReadyResponse,

--- a/src/types/rpc.spec.ts
+++ b/src/types/rpc.spec.ts
@@ -1,4 +1,3 @@
-import {describe, expect, it} from 'vitest';
 import {z} from 'zod';
 import {
   JSON_RPC_VERSION_2,


### PR DESCRIPTION
# Motivation

`vitest` is set to be known globally.

