### PR TITLE
feat: rename Signer.connect into Signer.init

### DIFF
--- a/demo/src/wallet_frontend/src/routes/+page.svelte
+++ b/demo/src/wallet_frontend/src/routes/+page.svelte
@@ -10,7 +10,7 @@
 			return;
 		}
 
-		signer = Signer.connect({});
+		signer = Signer.init({});
 	});
 </script>
 

--- a/src/signer.spec.ts
+++ b/src/signer.spec.ts
@@ -5,7 +5,7 @@ describe('Signer', () => {
   const mockParameters: SignerParameters = {};
 
   it('should init a signer', () => {
-    const signer = Signer.connect(mockParameters);
+    const signer = Signer.init(mockParameters);
     expect(signer).toBeInstanceOf(Signer);
     signer.disconnect();
   });
@@ -13,7 +13,7 @@ describe('Signer', () => {
   it('should add event listener for message on connect', () => {
     const addEventListenerSpy = vi.spyOn(window, 'addEventListener');
 
-    const signer = Signer.connect(mockParameters);
+    const signer = Signer.init(mockParameters);
     expect(addEventListenerSpy).toHaveBeenCalledWith('message', expect.any(Function));
     signer.disconnect();
   });
@@ -21,7 +21,7 @@ describe('Signer', () => {
   it('should remove event listener for message on connect', () => {
     const removeEventListenerSpy = vi.spyOn(window, 'removeEventListener');
 
-    const signer = Signer.connect(mockParameters);
+    const signer = Signer.init(mockParameters);
     signer.disconnect();
 
     expect(removeEventListenerSpy).toHaveBeenCalledWith('message', expect.any(Function));
@@ -38,7 +38,7 @@ describe('Signer', () => {
     let signer: Signer;
 
     beforeEach(() => {
-      signer = Signer.connect(mockParameters);
+      signer = Signer.init(mockParameters);
       onMessageListenerSpy = vi.spyOn(signer as unknown as {onMessage: () => void}, 'onMessage');
     });
 

--- a/src/signer.ts
+++ b/src/signer.ts
@@ -33,7 +33,7 @@ export class Signer {
    * @param {SignerParameters} parameters - The parameters for the signer.
    * @returns {Signer} The connected signer.
    */
-  static connect(parameters: SignerParameters): Signer {
+  static init(parameters: SignerParameters): Signer {
     const signer = new Signer(parameters);
     return signer;
   }


### PR DESCRIPTION
# Motivation

We really "just" init a signer, we don't connect it. The relying party does, therefore we can rename the `connect` method that actually `init` the `Signer` object.
