### PR TITLE
feat: notify error for signer

### DIFF
--- a/src/constants/signer.constants.ts
+++ b/src/constants/signer.constants.ts
@@ -1,0 +1,6 @@
+export enum SignerErrorCode {
+  /**
+   * The relying party's origin is not allowed to interact with the signer.
+   */
+  ORIGIN_ERROR = 500
+}

--- a/src/handlers/signer.handlers.spec.ts
+++ b/src/handlers/signer.handlers.spec.ts
@@ -1,9 +1,13 @@
 import type {Mock} from 'vitest';
+import {SignerErrorCode} from '../constants/signer.constants';
 import type {IcrcReadyResponseType} from '../types/icrc-responses';
-import {JSON_RPC_VERSION_2, type RpcIdType} from '../types/rpc';
-import {notifyReady} from './signer.handlers';
+import {JSON_RPC_VERSION_2, type RpcIdType, type RpcResponseWithErrorType} from '../types/rpc';
+import {notifyError, notifyReady} from './signer.handlers';
 
 describe('Signer handlers', () => {
+  const id: RpcIdType = 'test-123';
+  const origin = 'https://hello.com';
+
   let originalOpener: typeof window.opener;
 
   let postMessageMock: Mock;
@@ -24,15 +28,31 @@ describe('Signer handlers', () => {
 
   describe('notifyReady', () => {
     it('should post a message with the msg', () => {
-      const id: RpcIdType = 'test-123';
-      const origin = 'https://hello.com';
-
       notifyReady({id, origin});
 
       const expectedMessage: IcrcReadyResponseType = {
         jsonrpc: JSON_RPC_VERSION_2,
         id,
         result: 'ready'
+      };
+
+      expect(postMessageMock).toHaveBeenCalledWith(expectedMessage, origin);
+    });
+  });
+
+  describe('notifyError', () => {
+    it('should post the error', () => {
+      const error = {
+        code: SignerErrorCode.ORIGIN_ERROR,
+        message: 'This is an error test.'
+      };
+
+      notifyError({id, origin, error});
+
+      const expectedMessage: RpcResponseWithErrorType = {
+        jsonrpc: JSON_RPC_VERSION_2,
+        id,
+        error
       };
 
       expect(postMessageMock).toHaveBeenCalledWith(expectedMessage, origin);

--- a/src/handlers/signer.handlers.ts
+++ b/src/handlers/signer.handlers.ts
@@ -1,12 +1,42 @@
 import type {IcrcReadyResponseType} from '../types/icrc-responses';
-import {JSON_RPC_VERSION_2, type RpcIdType} from '../types/rpc';
+import {
+  JSON_RPC_VERSION_2,
+  type RpcIdType,
+  type RpcResponseErrorType,
+  type RpcResponseType,
+  type RpcResponseWithErrorType
+} from '../types/rpc';
 
-export const notifyReady = ({id, origin}: {id: RpcIdType; origin: string}): void => {
+interface Notify {
+  id: RpcIdType;
+  origin: string;
+}
+
+export const notifyReady = ({id, origin}: Notify): void => {
   const msg: IcrcReadyResponseType = {
     jsonrpc: JSON_RPC_VERSION_2,
     id,
     result: 'ready'
   };
 
-  window.opener.postMessage(msg, origin);
+  notify({msg, origin});
 };
+
+export const notifyError = ({
+  id,
+  error,
+  origin
+}: {
+  error: RpcResponseErrorType;
+} & Notify): void => {
+  const msg: RpcResponseWithErrorType = {
+    jsonrpc: JSON_RPC_VERSION_2,
+    id,
+    error
+  };
+
+  notify({msg, origin});
+};
+
+const notify = ({msg, origin}: {msg: RpcResponseType} & Pick<Notify, 'origin'>): void =>
+  window.opener.postMessage(msg, origin);


### PR DESCRIPTION
# Motivation

The signer will throws error if for example types or origins are not allowed.

# Changes

- Add a handler to throw error
