### PR TITLE
feat: assert relying party origin in signer listener

### DIFF
--- a/src/signer.ts
+++ b/src/signer.ts
@@ -1,8 +1,12 @@
-import type {
-  IcrcWalletPermissionsRequestType,
-  IcrcWalletRequestPermissionsRequestType,
-  IcrcWalletSupportedStandardsRequestType
+import {nonNullish} from '@dfinity/utils';
+import {SignerErrorCode} from './constants/signer.constants';
+import {notifyError} from './handlers/signer.handlers';
+import {
+  type IcrcWalletPermissionsRequestType,
+  type IcrcWalletRequestPermissionsRequestType,
+  type IcrcWalletSupportedStandardsRequestType
 } from './types/icrc-requests';
+import {RpcRequest} from './types/rpc';
 
 /**
  * The parameters to initialize a signer.
@@ -11,16 +15,16 @@ import type {
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface SignerParameters {}
 
-type SignerMessageEvent = MessageEvent<
-  Partial<
-    | IcrcWalletRequestPermissionsRequestType
-    | IcrcWalletPermissionsRequestType
-    | IcrcWalletSupportedStandardsRequestType
-  >
+type SignerMessageEventData = Partial<
+  | IcrcWalletRequestPermissionsRequestType
+  | IcrcWalletPermissionsRequestType
+  | IcrcWalletSupportedStandardsRequestType
 >;
 
+type SignerMessageEvent = MessageEvent<SignerMessageEventData>;
+
 export class Signer {
-  readonly #walletOrigin: string | undefined;
+  #walletOrigin: string | undefined | null;
 
   private constructor(_parameters: SignerParameters) {
     window.addEventListener('message', this.onMessageListener);
@@ -44,11 +48,50 @@ export class Signer {
    */
   disconnect = (): void => {
     window.removeEventListener('message', this.onMessageListener);
+    this.#walletOrigin = null;
   };
 
   private readonly onMessageListener = (message: SignerMessageEvent): void => {
     void this.onMessage(message);
   };
 
-  private readonly onMessage = async (_message: SignerMessageEvent): Promise<void> => {};
+  private readonly onMessage = async ({
+    data: msgData,
+    origin
+  }: SignerMessageEvent): Promise<void> => {
+    // TODO: ignore messages that are not Rpc Requests.
+    // TODO: assert messages to notify error if methods are not supported.
+
+    this.assertAndSetOrigin({msgData, origin});
+  };
+
+  private assertAndSetOrigin({
+    msgData,
+    origin
+  }: {
+    origin: string;
+    msgData: SignerMessageEventData;
+  }): void {
+    if (nonNullish(this.#walletOrigin) && this.#walletOrigin !== origin) {
+      const {data} = RpcRequest.safeParse(msgData);
+
+      notifyError({
+        id: data?.id ?? null,
+        origin,
+        error: {
+          code: SignerErrorCode.ORIGIN_ERROR,
+          message: `The relying party's origin is not allowed to interact with the signer.`
+        }
+      });
+
+      return;
+    }
+
+    // We do not reassign the origin with the same value if it is already set. It is not a significant performance win.
+    if (nonNullish(this.#walletOrigin)) {
+      return;
+    }
+
+    this.#walletOrigin = origin;
+  }
 }


### PR DESCRIPTION
# Motivation

The signer should process a single origin at a time.

# Changes

- Assert and keep track of the origin of the calls in the signer
- Dispatch an error to the caller if their origin is rejected
- Add TODOs for additional assertions

