### PR TITLE
fix: infer rpc request types

### DIFF
--- a/src/types/icrc-requests.spec.ts
+++ b/src/types/icrc-requests.spec.ts
@@ -5,8 +5,7 @@ import {
   IcrcWalletStatusRequest,
   IcrcWalletSupportedStandardsRequest,
   type IcrcWalletPermissionsRequestType,
-  type IcrcWalletRequestPermissionsRequestType,
-  type IcrcWalletSupportedStandardsRequestType
+  type IcrcWalletRequestPermissionsRequestType
 } from './icrc-requests';
 import {JSON_RPC_VERSION_2} from './rpc';
 
@@ -35,6 +34,7 @@ describe('icrc-requests', () => {
         params: {
           scopes: [
             {
+              // @ts-expect-error: we are testing this on purpose
               method: 'test'
             }
           ]
@@ -56,6 +56,7 @@ describe('icrc-requests', () => {
     it('should throw if request has no scopes', () => {
       const invalidRequest: IcrcWalletRequestPermissionsRequestType = {
         ...validRequest,
+        // @ts-expect-error: we are testing this on purpose
         params: {}
       };
       expect(() => IcrcWalletRequestPermissionsRequest.parse(invalidRequest)).toThrow();
@@ -64,6 +65,7 @@ describe('icrc-requests', () => {
     it('should throw if request has no params', () => {
       const {params: _, ...rest} = validRequest;
 
+      // @ts-expect-error: we are testing this on purpose
       const invalidRequest: IcrcWalletRequestPermissionsRequestType = rest;
       expect(() => IcrcWalletRequestPermissionsRequest.parse(invalidRequest)).toThrow();
     });
@@ -71,6 +73,7 @@ describe('icrc-requests', () => {
     it('should throw if request has invalid method', () => {
       const invalidRequest: IcrcWalletRequestPermissionsRequestType = {
         ...validRequest,
+        // @ts-expect-error: we are testing this on purpose
         method: 'test'
       };
       expect(() => IcrcWalletRequestPermissionsRequest.parse(invalidRequest)).toThrow();
@@ -105,6 +108,7 @@ describe('icrc-requests', () => {
     it('should throw if request has params', () => {
       const invalidRequest: IcrcWalletPermissionsRequestType = {
         ...validRequest,
+        // @ts-expect-error: we are testing this on purpose
         params: {}
       };
       expect(() => IcrcWalletPermissionsRequest.parse(invalidRequest)).toThrow();
@@ -113,6 +117,7 @@ describe('icrc-requests', () => {
     it('should throw if request has invalid method', () => {
       const invalidRequest: IcrcWalletPermissionsRequestType = {
         ...validRequest,
+        // @ts-expect-error: we are testing this on purpose
         method: 'test'
       };
       expect(() => IcrcWalletPermissionsRequest.parse(invalidRequest)).toThrow();
@@ -139,7 +144,7 @@ describe('icrc-requests', () => {
   ];
 
   describe.each(requestWithoutParamsSchemas)('$method', ({schema, method}) => {
-    const validRequest: IcrcWalletSupportedStandardsRequestType = {
+    const validRequest = {
       jsonrpc: JSON_RPC_VERSION_2,
       id: 1,
       method

--- a/src/types/rpc.ts
+++ b/src/types/rpc.ts
@@ -27,13 +27,10 @@ export const RpcRequest = Rpc.extend({
   )
   .strict();
 
-type RpcRequestType = z.infer<typeof RpcRequest>;
+type _RpcRequestType = z.infer<typeof RpcRequest>;
 
-export const inferRpcRequestWithoutParams = ({
-  method
-}: {
-  method: string;
-}): z.ZodType<RpcRequestType> =>
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+export const inferRpcRequestWithoutParams = <M extends string>({method}: {method: M}) =>
   RpcRequest.omit({method: true, params: true})
     .strict()
     .extend({
@@ -41,13 +38,20 @@ export const inferRpcRequestWithoutParams = ({
       method: z.literal(method)
     });
 
-export const inferRpcRequestWithParams = <T extends z.ZodTypeAny>({
+type RpcRequestWithoutParamsReturnType<M extends string> = ReturnType<
+  typeof inferRpcRequestWithoutParams<M>
+>;
+
+type _RpcRequestWithoutParamsType<M extends string> = z.infer<RpcRequestWithoutParamsReturnType<M>>;
+
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+export const inferRpcRequestWithParams = <T extends z.ZodTypeAny, M extends string>({
   params,
   method
 }: {
   params: T;
-  method: string;
-}): z.ZodType<RpcRequestType> =>
+  method: M;
+}) =>
   RpcRequest.omit({method: true})
     .extend({
       id: RpcId,
@@ -58,6 +62,7 @@ export const inferRpcRequestWithParams = <T extends z.ZodTypeAny>({
         params
       })
     );
+/* eslint-enable */
 
 export const RpcNotification = RpcRequest.omit({id: true}).strict();
 


### PR DESCRIPTION
# Motivation

The `method` of Rpc request was not properly interferred which could led the TypeScript compiler to not notice that a method should be named according its interface.

This used to compiles:

```
const msg: IcrcWalletSupportedStandardsRequestType = {
    jsonrpc: JSON_RPC_VERSION_2,
    id,
    method: "yolo" // <---- only ICRC25_SUPPORTED_STANDARDS should be accepted here
  };
```