### PR TITLE
chore: disable eslint rpc response builder

### DIFF
--- a/src/types/rpc.ts
+++ b/src/types/rpc.ts
@@ -108,50 +108,14 @@ const RpcResponse = Rpc.extend({
 
 export type RpcResponseType = z.infer<typeof RpcResponse>;
 
-const RpcResponseContent = <T extends z.ZodTypeAny>(
-  result: T
-): z.ZodObject<{
-  result: z.ZodOptional<T>;
-  error: z.ZodOptional<typeof RpcResponseError>;
-}> =>
-  z
-    .object({
-      result,
-      error: RpcResponseError
-    })
-    .partial();
-
-// TODO: Maybe we can use this type in inferRpcResponse?
-type _RpcResponseContentType<T extends z.ZodTypeAny> = z.infer<
-  ReturnType<typeof RpcResponseContent<T>>
->;
-
 const RpcResponseWithError = RpcResponse.extend({
   error: RpcResponseError
 });
 
 export type RpcResponseWithErrorType = z.infer<typeof RpcResponseWithError>;
 
-// TODO: Simplify the return type to avoid redundancy with other types. Consider using a more concise or existing type definition.
-export const inferRpcResponse = <T extends z.ZodTypeAny>(
-  result: T
-): z.ZodEffects<
-  z.ZodObject<
-    {
-      jsonrpc: z.ZodLiteral<'2.0'>;
-      id: z.ZodUnion<[z.ZodString, z.ZodNumber, z.ZodNull]>;
-      result: z.ZodOptional<T>;
-      error: z.ZodOptional<
-        z.ZodObject<{
-          code: z.ZodUnion<[z.ZodNumber, z.ZodNativeEnum<typeof RpcErrorCode>]>;
-          message: z.ZodString;
-          data: z.ZodOptional<z.ZodNever>;
-        }>
-      >;
-    },
-    'strict'
-  >
-> =>
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+export const inferRpcResponse = <T extends z.ZodTypeAny>(result: T) =>
   RpcResponseWithError.omit({error: true})
     .merge(
       z


### PR DESCRIPTION
# Motivation

For simplicity reason and given that the types are interferred anyway, we can just disable the eslint rule `@typescript-eslint/explicit-function-return-type` for `inferRpcResponse`. This makes the code cleaner while not alterating type safety.
