### PR TITLE
feat: parse and validate wallet url for origin comparison

### DIFF
--- a/src/wallet.spec.ts
+++ b/src/wallet.spec.ts
@@ -8,18 +8,18 @@ import {Wallet, type WalletOptions} from './wallet';
 describe('Wallet', () => {
   const mockParameters: WalletOptions = {url: 'https://test.com'};
 
+  const messageEventReady = new MessageEvent('message', {
+    origin: mockParameters.url,
+    data: {
+      jsonrpc: JSON_RPC_VERSION_2,
+      id: '123',
+      result: 'ready'
+    }
+  });
+
   let originalOpen: typeof window.open;
 
   describe('Window success', () => {
-    const messageEventReady = new MessageEvent('message', {
-      origin: mockParameters.url,
-      data: {
-        jsonrpc: JSON_RPC_VERSION_2,
-        id: '123',
-        result: 'ready'
-      }
-    });
-
     beforeEach(() => {
       originalOpen = window.open;
 
@@ -71,6 +71,18 @@ describe('Wallet', () => {
 
         await expect(promise).rejects.toThrow(
           `The response origin ${hackerOrigin} does not match the requested wallet URL ${mockParameters.url}.`
+        );
+      });
+
+      it('should throw error if the wallet url is not well formatted', async () => {
+        const incorrectOrigin = 'test';
+
+        const promise = Wallet.connect({url: incorrectOrigin});
+
+        window.dispatchEvent(messageEventReady);
+
+        await expect(promise).rejects.toThrow(
+          `The origin ${mockParameters.url} of the wallet URL ${incorrectOrigin} cannot be parsed.`
         );
       });
     });

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -94,8 +94,21 @@ export class Wallet {
         return;
       }
 
+      let expectedOrigin: string;
+
+      try {
+        const {origin: walletOrigin} = new URL(url);
+        expectedOrigin = walletOrigin;
+      } catch (err: unknown) {
+        // Unlikely to happen if window.open succeeded
+        response = new MessageError(
+          `The origin ${origin} of the wallet URL ${url} cannot be parsed.`
+        );
+        return;
+      }
+
       // In our test suite, origin is set to empty string when the message originate from the same window - i.e. when retryRequestStatus are emitted.// In our test suite, the origin is set to an empty string when the message originates from the same window. This occurs when `retryRequestStatus` events are emitted to `*`.
-      if (notEmptyString(origin) && origin !== url) {
+      if (notEmptyString(origin) && origin !== expectedOrigin) {
         response = new MessageError(
           `The response origin ${origin} does not match the requested wallet URL ${url}.`
         );


### PR DESCRIPTION
# Motivation

This is useful if for some reason the wallet takes query parameters. So it's useful to extract the origin from the wallet url for comparison purpose.
