### PR TITLE
feat: observable

### DIFF
--- a/src/utils/observable.spec.ts
+++ b/src/utils/observable.spec.ts
@@ -1,0 +1,70 @@
+import {Observable} from './observable';
+
+describe('Observable', () => {
+  it('should notify all subscribers with the correct data', () => {
+    const observable = new Observable<number>();
+    const callback1 = vi.fn();
+    const callback2 = vi.fn();
+
+    observable.subscribe({callback: callback1});
+    observable.subscribe({callback: callback2});
+
+    observable.next(5);
+
+    expect(callback1).toHaveBeenNthCalledWith(1, 5);
+    expect(callback2).toHaveBeenNthCalledWith(1, 5);
+  });
+
+  it('should allow subscribers to unsubscribe', () => {
+    const observable = new Observable<number>();
+    const callback = vi.fn();
+
+    const unsubscribe = observable.subscribe({callback});
+
+    observable.next(1);
+    unsubscribe();
+    observable.next(2);
+
+    expect(callback).toHaveBeenNthCalledWith(1, 1);
+  });
+
+  it('should not notify unsubscribed observers', () => {
+    const observable = new Observable<number>();
+    const callback1 = vi.fn();
+    const callback2 = vi.fn();
+
+    const unsubscribe1 = observable.subscribe({callback: callback1});
+    observable.subscribe({callback: callback2});
+
+    unsubscribe1();
+    observable.next(10);
+
+    expect(callback1).not.toHaveBeenCalled();
+    expect(callback2).toHaveBeenNthCalledWith(1, 10);
+  });
+
+  it('should handle multiple subscriptions and unsubscriptions', () => {
+    const observable = new Observable<number>();
+    const callback1 = vi.fn();
+    const callback2 = vi.fn();
+    const callback3 = vi.fn();
+
+    const unsubscribe1 = observable.subscribe({callback: callback1});
+    const unsubscribe2 = observable.subscribe({callback: callback2});
+    observable.subscribe({callback: callback3});
+
+    observable.next(20);
+
+    unsubscribe1();
+    unsubscribe2();
+
+    observable.next(30);
+
+    expect(callback1).toHaveBeenNthCalledWith(1, 20);
+    expect(callback2).toHaveBeenNthCalledWith(1, 20);
+
+    expect(callback3).toHaveBeenCalledTimes(2);
+    expect(callback3).toHaveBeenCalledWith(20);
+    expect(callback3).toHaveBeenCalledWith(30);
+  });
+});

--- a/src/utils/observable.ts
+++ b/src/utils/observable.ts
@@ -1,0 +1,21 @@
+interface Observer<T> {
+  id: symbol;
+  callback: (data: T) => void;
+}
+
+export class Observable<T> {
+  #observers: Observer<T>[] = [];
+
+  next(data: T): void {
+    this.#observers.forEach(({callback}) => {
+      callback(data);
+    });
+  }
+
+  subscribe({callback}: Pick<Observer<T>, 'callback'>): () => void {
+    const observedId = Symbol();
+    this.#observers.push({id: observedId, callback});
+
+    return () => (this.#observers = this.#observers.filter(({id}) => id !== observedId));
+  }
+}


### PR DESCRIPTION
# Motivation

We need an observable in #51. This will allow consumers of the signer to subscribe multiple times to the same events. For example, one developer might want to subscribe to request permissions in various places of their dApps simultaneously.

# Changes

- Implement an observable.

# Notes

The implementation contains a subset of all observable features. For example, it does not include a `complete` method, as we will not require it in our implementation.
