### PR TITLE
refactor: move icrc constants

### DIFF
--- a/src/constants/icrc.constants.ts
+++ b/src/constants/icrc.constants.ts
@@ -1,0 +1,13 @@
+export const ICRC25_REQUEST_PERMISSIONS = 'icrc25_request_permissions';
+export const ICRC25_PERMISSIONS = 'icrc25_permissions';
+export const ICRC25_SUPPORTED_STANDARDS = 'icrc25_supported_standards';
+// TODO: ICRC27 to be defined
+export const ICRC27_ACCOUNTS = 'icrc27_accounts';
+export const ICRC29_STATUS = 'icrc29_status';
+
+export const ICRC25_PERMISSION_GRANTED = 'granted';
+export const ICRC25_PERMISSION_DENIED = 'denied';
+export const ICRC25_PERMISSION_ASK_ON_USE = 'ask_on_user';
+
+export const ICRC25 = 'ICRC-25';
+export const ICRC29 = 'ICRC-29';

--- a/src/handlers/wallet.handlers.ts
+++ b/src/handlers/wallet.handlers.ts
@@ -1,5 +1,5 @@
 import {DEFAULT_POLLING_INTERVAL_IN_MILLISECONDS} from '../constants/core.constants';
-import {ICRC25_SUPPORTED_STANDARDS, ICRC29_STATUS} from '../types/icrc';
+import {ICRC25_SUPPORTED_STANDARDS, ICRC29_STATUS} from '../constants/icrc.constants';
 import type {
   IcrcWalletStatusRequest,
   IcrcWalletSupportedStandardsRequest

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,15 @@
+export {
+  ICRC25,
+  ICRC25_PERMISSIONS,
+  ICRC25_PERMISSION_ASK_ON_USE,
+  ICRC25_PERMISSION_DENIED,
+  ICRC25_PERMISSION_GRANTED,
+  ICRC25_REQUEST_PERMISSIONS,
+  ICRC25_SUPPORTED_STANDARDS,
+  ICRC27_ACCOUNTS,
+  ICRC29,
+  ICRC29_STATUS
+} from './constants/icrc.constants';
 export type * from './types/icrc';
 export type * from './types/icrc-requests';
 export type * from './types/icrc-responses';

--- a/src/signer.spec.ts
+++ b/src/signer.spec.ts
@@ -1,8 +1,8 @@
 import {describe, type MockInstance} from 'vitest';
+import {ICRC25_SUPPORTED_STANDARDS, ICRC29_STATUS} from './constants/icrc.constants';
 import {SIGNER_SUPPORTED_STANDARDS, SignerErrorCode} from './constants/signer.constants';
 import * as signerHandlers from './handlers/signer.handlers';
 import {Signer, type SignerParameters} from './signer';
-import {ICRC25_SUPPORTED_STANDARDS, ICRC29_STATUS} from './types/icrc';
 import {JSON_RPC_VERSION_2} from './types/rpc';
 import type {SignerMessageEventData} from './types/signer';
 

--- a/src/types/icrc-requests.spec.ts
+++ b/src/types/icrc-requests.spec.ts
@@ -1,4 +1,4 @@
-import {ICRC27_ACCOUNTS} from './icrc';
+import {ICRC27_ACCOUNTS} from '../constants/icrc.constants';
 import {
   IcrcWalletPermissionsRequestSchema,
   IcrcWalletRequestPermissionsRequestSchema,

--- a/src/types/icrc-requests.ts
+++ b/src/types/icrc-requests.ts
@@ -3,9 +3,9 @@ import {
   ICRC25_PERMISSIONS,
   ICRC25_REQUEST_PERMISSIONS,
   ICRC25_SUPPORTED_STANDARDS,
-  ICRC29_STATUS,
-  IcrcWalletScopedMethodSchema
-} from './icrc';
+  ICRC29_STATUS
+} from '../constants/icrc.constants';
+import {IcrcWalletScopedMethodSchema} from './icrc';
 import {inferRpcRequestWithParamsSchema, inferRpcRequestWithoutParamsSchema} from './rpc';
 
 // icrc25_request_permissions

--- a/src/types/icrc-responses.spec.ts
+++ b/src/types/icrc-responses.spec.ts
@@ -1,4 +1,4 @@
-import {ICRC25_PERMISSION_GRANTED, ICRC27_ACCOUNTS} from './icrc';
+import {ICRC25_PERMISSION_GRANTED, ICRC27_ACCOUNTS} from '../constants/icrc.constants';
 import {
   IcrcReadyResponseSchema,
   IcrcSupportedStandardsResponseSchema,

--- a/src/types/icrc.ts
+++ b/src/types/icrc.ts
@@ -1,11 +1,16 @@
 import {z} from 'zod';
-
-export const ICRC25_REQUEST_PERMISSIONS = 'icrc25_request_permissions';
-export const ICRC25_PERMISSIONS = 'icrc25_permissions';
-export const ICRC25_SUPPORTED_STANDARDS = 'icrc25_supported_standards';
-// TODO: ICRC27 to be defined
-export const ICRC27_ACCOUNTS = 'icrc27_accounts';
-export const ICRC29_STATUS = 'icrc29_status';
+import {
+  ICRC25,
+  ICRC25_PERMISSION_ASK_ON_USE,
+  ICRC25_PERMISSION_DENIED,
+  ICRC25_PERMISSION_GRANTED,
+  ICRC25_PERMISSIONS,
+  ICRC25_REQUEST_PERMISSIONS,
+  ICRC25_SUPPORTED_STANDARDS,
+  ICRC27_ACCOUNTS,
+  ICRC29,
+  ICRC29_STATUS
+} from '../constants/icrc.constants';
 
 export const IcrcWalletMethodSchema = z.enum([
   ICRC25_REQUEST_PERMISSIONS,
@@ -17,17 +22,10 @@ export const IcrcWalletMethodSchema = z.enum([
 
 export const IcrcWalletScopedMethodSchema = IcrcWalletMethodSchema.extract([ICRC27_ACCOUNTS]);
 
-export const ICRC25_PERMISSION_GRANTED = 'granted';
-export const ICRC25_PERMISSION_DENIED = 'denied';
-export const ICRC25_PERMISSION_ASK_ON_USE = 'ask_on_user';
-
 export const IcrcWalletPermissionStateSchema = z.enum([
   ICRC25_PERMISSION_GRANTED,
   ICRC25_PERMISSION_DENIED,
   ICRC25_PERMISSION_ASK_ON_USE
 ]);
-
-export const ICRC25 = 'ICRC-25';
-export const ICRC29 = 'ICRC-29';
 
 export const IcrcWalletStandardSchema = z.enum([ICRC25, ICRC29]);

--- a/src/wallet.spec.ts
+++ b/src/wallet.spec.ts
@@ -1,7 +1,7 @@
 import {afterEach, beforeEach, describe} from 'vitest';
+import {ICRC25_SUPPORTED_STANDARDS, ICRC29_STATUS} from './constants/icrc.constants';
 import {WALLET_CONNECT_TIMEOUT_REQUEST_SUPPORTED_STANDARD} from './constants/wallet.constants';
 import * as walletHandlers from './handlers/wallet.handlers';
-import {ICRC25_SUPPORTED_STANDARDS, ICRC29_STATUS} from './types/icrc';
 import {IcrcSupportedStandardsResponseSchema} from './types/icrc-responses';
 import {JSON_RPC_VERSION_2, RpcResponseWithResultOrErrorSchema} from './types/rpc';
 import type {WalletOptions} from './types/wallet';


### PR DESCRIPTION
# Motivation

The consumers of the library need to access the icrc constants so, before exposing those, we moved them to to a dedicated module.
