### PR TITLE
feat: create a generic request function to call the wallet

### DIFF
--- a/src/types/icrc-responses.ts
+++ b/src/types/icrc-responses.ts
@@ -17,6 +17,8 @@ const IcrcScopesSchema = z.object({
   )
 });
 
+export type IcrcScopes = z.infer<typeof IcrcScopesSchema>;
+
 // icrc25_request_permissions
 // https://github.com/dfinity/wg-identity-authentication/blob/main/topics/icrc_25_signer_interaction_standard.md#icrc25_request_permissions
 export const IcrcRequestPermissionsResponseSchema = inferRpcResponseSchema(IcrcScopesSchema);

--- a/src/types/signer.ts
+++ b/src/types/signer.ts
@@ -12,4 +12,4 @@ export type SignerMessageEventData = Partial<
   | IcrcSupportedStandardsRequest
 >;
 
-export type SignerMessageEvent = MessageEvent<SignerMessageEventData>;
+export type SignerMessageEvent = MessageEvent<SignerMessageEventData | never>;

--- a/src/types/wallet.ts
+++ b/src/types/wallet.ts
@@ -1,0 +1,5 @@
+import type {IcrcScopes, IcrcSupportedStandards} from './icrc-responses';
+
+export type WalletMessageEventData = Partial<IcrcSupportedStandards | IcrcScopes>;
+
+export type WalletMessageEvent = MessageEvent<WalletMessageEventData | never>;

--- a/src/wallet.spec.ts
+++ b/src/wallet.spec.ts
@@ -290,7 +290,7 @@ describe('Wallet', () => {
 
               wallet.supportedStandards(options).catch((err: Error) => {
                 expect(err.message).toBe(
-                  `Supported standards request to wallet timed out after ${timeout} milliseconds.`
+                  `Request to wallet timed out after ${timeout} milliseconds.`
                 );
 
                 vi.useRealTimers();
@@ -303,7 +303,7 @@ describe('Wallet', () => {
           }
         );
 
-        it('should timeout if response ID is not the same as requst ID', async () => {
+        it('should timeout if response ID is not the same as request ID', async () => {
           // eslint-disable-next-line @typescript-eslint/return-await, no-async-promise-executor, @typescript-eslint/no-misused-promises
           return new Promise<void>(async (resolve) => {
             vi.useFakeTimers();
@@ -312,7 +312,7 @@ describe('Wallet', () => {
 
             wallet.supportedStandards().catch((err: Error) => {
               expect(err.message).toBe(
-                `Supported standards request to wallet timed out after ${WALLET_CONNECT_TIMEOUT_REQUEST_SUPPORTED_STANDARD} milliseconds.`
+                `Request to wallet timed out after ${WALLET_CONNECT_TIMEOUT_REQUEST_SUPPORTED_STANDARD} milliseconds.`
               );
 
               expect(spy).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
# Motivation

We gonna have to implement more request for the wallet, for example the request permissions. So it's good to create a generic function to do so given that all request follow the same flow.

# Changes

- Refactor supported standards to extract generic function
- Add few types to define the message event for the wallet. Similarly to what's done for the signer.
