### PR TITLE
refactor: supported standards interface options as object

### DIFF
--- a/src/wallet.spec.ts
+++ b/src/wallet.spec.ts
@@ -262,10 +262,10 @@ describe('Wallet', () => {
 
       describe('Request errors', () => {
         it('should throw error if the wallet request options are not well formatted', async () => {
-          // @ts-expect-error: we are testing this on purpose
-          await expect(wallet.supportedStandards({timeoutInMilliseconds: 'test'})).rejects.toThrow(
-            'Wallet request options cannot be parsed:'
-          );
+          await expect(
+            // @ts-expect-error: we are testing this on purpose
+            wallet.supportedStandards({options: {timeoutInMilliseconds: 'test'}})
+          ).rejects.toThrow('Wallet request options cannot be parsed:');
         });
 
         const options = [
@@ -288,7 +288,7 @@ describe('Wallet', () => {
               const timeout =
                 options?.timeoutInMilliseconds ?? WALLET_CONNECT_TIMEOUT_REQUEST_SUPPORTED_STANDARD;
 
-              wallet.supportedStandards(options).catch((err: Error) => {
+              wallet.supportedStandards({options}).catch((err: Error) => {
                 expect(err.message).toBe(
                   `Request to wallet timed out after ${timeout} milliseconds.`
                 );
@@ -387,7 +387,7 @@ describe('Wallet', () => {
       it('should respond with the supported standards', async () => {
         const requestId = '12345';
 
-        const promise = wallet.supportedStandards({requestId});
+        const promise = wallet.supportedStandards({options: {requestId}});
 
         const messageEventSupportedStandards = new MessageEvent('message', {
           origin: mockParameters.url,

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -255,9 +255,9 @@ export class Wallet {
    * @returns {Promise<IcrcSupportedStandards>} A promise that resolves to an object containing the supported ICRC standards by the wallet. This includes details about each standard that the wallet can handle.
    * @see [ICRC25 Supported Standards](https://github.com/dfinity/wg-identity-authentication/blob/main/topics/icrc_25_signer_interaction_standard.md#icrc25_supported_standards)
    */
-  supportedStandards = async (
-    options: WalletRequestOptions = {}
-  ): Promise<IcrcSupportedStandards> => {
+  supportedStandards = async ({
+    options = {}
+  }: {options?: WalletRequestOptions} = {}): Promise<IcrcSupportedStandards> => {
     const handleMessage = async ({
       data,
       id


### PR DESCRIPTION
# Motivation

For consistency reasons, given that other functions such as request permissions might or will require more than the options, it's useful to pass those as object to request supported standards.
