### PR TITLE
feat: replace nanoid by crypto.randomUUID

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
       "name": "@dfinity/oisy-wallet-signer",
       "version": "0.0.1",
       "license": "Apache-2.0",
-      "dependencies": {
-        "nanoid": "^5.0.7"
-      },
       "devDependencies": {
         "@dfinity/internet-identity-playwright": "^0.0.2",
         "@playwright/test": "^1.45.3",
@@ -4523,24 +4520,6 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/nanoid": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.0.7.tgz",
-      "integrity": "sha512-oLxFY2gd2IqnjcYyOXD8XGCftpGtZP2AbHbOkthDkvRywH5ayNtPVy9YlOPcHckXzbLTCHpkb7FB+yuxKV13pQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "bin": {
-        "nanoid": "bin/nanoid.js"
-      },
-      "engines": {
-        "node": "^18 || >=20"
-      }
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -82,8 +82,5 @@
   "peerDependencies": {
     "@dfinity/utils": "^2.3.1",
     "zod": "^3.23.8"
-  },
-  "dependencies": {
-    "nanoid": "^5.0.7"
   }
 }

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -1,5 +1,4 @@
 import {assertNonNullish, nonNullish, notEmptyString} from '@dfinity/utils';
-import {nanoid} from 'nanoid';
 import {
   WALLET_CONNECT_DEFAULT_TIMEOUT_IN_MILLISECONDS,
   WALLET_CONNECT_TIMEOUT_REQUEST_SUPPORTED_STANDARD
@@ -111,7 +110,7 @@ export class Wallet {
         popup,
         isReady: (): ReadyOrError | 'pending' =>
           nonNullish(response) ? (response instanceof Wallet ? 'ready' : 'error') : 'pending',
-        id: nanoid(),
+        id: crypto.randomUUID(),
         timeoutInMilliseconds:
           connectionOptions?.timeoutInMilliseconds ??
           WALLET_CONNECT_DEFAULT_TIMEOUT_IN_MILLISECONDS,
@@ -196,7 +195,7 @@ export class Wallet {
       const timeoutInMilliseconds =
         userTimeoutInMilliseconds ?? WALLET_CONNECT_TIMEOUT_REQUEST_SUPPORTED_STANDARD;
 
-      const requestId = userRequestId ?? nanoid();
+      const requestId = userRequestId ?? crypto.randomUUID();
 
       const timeoutId = setTimeout(() => {
         reject(


### PR DESCRIPTION
# Motivation

The length of the ID is not important in the message context therefore we can replace `nanoid` by [crypto.randomUUID](https://developer.mozilla.org/en-US/docs/Web/API/Crypto/randomUUID).