### PR TITLE
feat: permissions response IcrcScopesResponse

### DIFF
--- a/src/types/icrc-responses.spec.ts
+++ b/src/types/icrc-responses.spec.ts
@@ -1,8 +1,7 @@
 import {ICRC25_PERMISSION_GRANTED, ICRC27_ACCOUNTS} from '../constants/icrc.constants';
 import {
-  IcrcPermissionsResponseSchema,
   IcrcReadyResponseSchema,
-  IcrcRequestPermissionsResponseSchema,
+  IcrcScopesResponseSchema,
   IcrcSupportedStandardsResponseSchema,
   type IcrcReadyResponse,
   type IcrcSupportedStandardsResponse
@@ -11,8 +10,8 @@ import {JSON_RPC_VERSION_2} from './rpc';
 
 describe('icrc-responses', () => {
   const responseSchemas = [
-    {icrc: 'icrc25_request_permissions', schema: IcrcRequestPermissionsResponseSchema},
-    {icrc: 'icrc25_permissions', schema: IcrcPermissionsResponseSchema}
+    {icrc: 'icrc25_request_permissions', schema: IcrcScopesResponseSchema},
+    {icrc: 'icrc25_permissions', schema: IcrcScopesResponseSchema}
   ];
 
   describe.each(responseSchemas)('$icrc', ({schema}) => {

--- a/src/types/icrc-responses.ts
+++ b/src/types/icrc-responses.ts
@@ -23,17 +23,12 @@ const IcrcScopesSchema = z.object({
 
 export type IcrcScopes = z.infer<typeof IcrcScopesSchema>;
 
-// icrc25_request_permissions
+// icrc25_request_permissions and icrc25_permissions
 // https://github.com/dfinity/wg-identity-authentication/blob/main/topics/icrc_25_signer_interaction_standard.md#icrc25_request_permissions
-export const IcrcRequestPermissionsResponseSchema = inferRpcResponseSchema(IcrcScopesSchema);
-
-export type IcrcRequestPermissionsResponse = z.infer<typeof IcrcRequestPermissionsResponseSchema>;
-
-// icrc25_permissions
 // https://github.com/dfinity/wg-identity-authentication/blob/main/topics/icrc_25_signer_interaction_standard.md#icrc25_permissions
-export const IcrcPermissionsResponseSchema = IcrcRequestPermissionsResponseSchema;
+export const IcrcScopesResponseSchema = inferRpcResponseSchema(IcrcScopesSchema);
 
-export type IcrcPermissionsResponse = z.infer<typeof IcrcPermissionsResponseSchema>;
+export type IcrcScopesResponse = z.infer<typeof IcrcScopesResponseSchema>;
 
 // icrc25_supported_standards
 // https://github.com/dfinity/wg-identity-authentication/blob/main/topics/icrc_25_signer_interaction_standard.md#icrc25_supported_standards


### PR DESCRIPTION
# Motivation

Both [icrc25_request_permissions](https://github.com/dfinity/wg-identity-authentication/blob/main/topics/icrc_25_signer_interaction_standard.md#icrc25_request_permissions) and [icrc25_permissions](https://github.com/dfinity/wg-identity-authentication/blob/main/topics/icrc_25_signer_interaction_standard.md#icrc25_permissions) have the same response type therefore we can have a single types as well.

# Changes

- Simplify types to a unique answer `IcrcScopesResponse`
