### PR TITLE
feat: request permissions subscribers with scopes and request id

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ export type * from './types/icrc';
 export type * from './types/icrc-requests';
 export type * from './types/icrc-responses';
 export type * from './types/rpc';
+export type * from './types/signer-subscribers';
 export type * from './types/wallet-options';
 export type * from './types/wallet-request';
 

--- a/src/types/icrc-responses.spec.ts
+++ b/src/types/icrc-responses.spec.ts
@@ -1,6 +1,7 @@
 import {ICRC25_PERMISSION_GRANTED, ICRC27_ACCOUNTS} from '../constants/icrc.constants';
 import {
   IcrcReadyResponseSchema,
+  IcrcScopeSchema,
   IcrcScopesResponseSchema,
   IcrcSupportedStandardsResponseSchema,
   type IcrcReadyResponse,
@@ -156,6 +157,71 @@ describe('icrc-responses', () => {
       const response = rest;
 
       expect(() => schema.parse(response)).toThrow();
+    });
+  });
+
+  describe('IcrcScopeSchema', () => {
+    it('should validate a correct IcrcScope payload', () => {
+      const validPayload = {
+        scope: {
+          method: ICRC27_ACCOUNTS
+        },
+        state: ICRC25_PERMISSION_GRANTED
+      };
+
+      expect(() => IcrcScopeSchema.parse(validPayload)).not.toThrow();
+    });
+
+    it('should invalidate a payload with missing scope', () => {
+      const invalidPayload = {
+        state: ICRC25_PERMISSION_GRANTED
+      };
+
+      expect(() => IcrcScopeSchema.parse(invalidPayload)).toThrow();
+    });
+
+    it('should invalidate a payload with missing state', () => {
+      const invalidPayload = {
+        scope: {
+          method: ICRC27_ACCOUNTS
+        }
+      };
+
+      expect(() => IcrcScopeSchema.parse(invalidPayload)).toThrow();
+    });
+
+    it('should invalidate a payload with an incorrect method', () => {
+      const invalidPayload = {
+        scope: {
+          method: 'INVALID_METHOD'
+        },
+        state: ICRC25_PERMISSION_GRANTED
+      };
+
+      expect(() => IcrcScopeSchema.parse(invalidPayload)).toThrow();
+    });
+
+    it('should invalidate a payload with an incorrect state', () => {
+      const invalidPayload = {
+        scope: {
+          method: ICRC27_ACCOUNTS
+        },
+        state: 'INVALID_STATE'
+      };
+
+      expect(() => IcrcScopeSchema.parse(invalidPayload)).toThrow();
+    });
+
+    it('should invalidate a payload with additional fields', () => {
+      const invalidPayload = {
+        scope: {
+          method: ICRC27_ACCOUNTS
+        },
+        state: ICRC25_PERMISSION_GRANTED,
+        extraField: 'EXTRA' // Unwanted field
+      };
+
+      expect(() => IcrcScopeSchema.parse(invalidPayload)).toThrow();
     });
   });
 

--- a/src/types/icrc-responses.ts
+++ b/src/types/icrc-responses.ts
@@ -10,10 +10,12 @@ const IcrcScopeMethodSchema = z.object({
   method: IcrcWalletScopedMethodSchema
 });
 
-const IcrcScopeSchema = z.object({
-  scope: IcrcScopeMethodSchema,
-  state: IcrcWalletPermissionStateSchema
-});
+export const IcrcScopeSchema = z
+  .object({
+    scope: IcrcScopeMethodSchema,
+    state: IcrcWalletPermissionStateSchema
+  })
+  .strict();
 
 export type IcrcScope = z.infer<typeof IcrcScopeSchema>;
 

--- a/src/types/signer-subscribers.spec.ts
+++ b/src/types/signer-subscribers.spec.ts
@@ -1,0 +1,73 @@
+import {describe} from 'vitest';
+import {ICRC25_PERMISSION_ASK_ON_USE, ICRC27_ACCOUNTS} from '../constants/icrc.constants';
+import {RequestPermissionPayloadSchema} from './signer-subscribers';
+
+describe('signer-subscribers', () => {
+  describe('RequestPermissionPayloadSchema', () => {
+    it('should validate a correct payload', () => {
+      const validPayload = {
+        requestId: '123',
+        scopes: [
+          {
+            scope: {method: ICRC27_ACCOUNTS},
+            state: ICRC25_PERMISSION_ASK_ON_USE
+          }
+        ]
+      };
+
+      const result = RequestPermissionPayloadSchema.safeParse(validPayload);
+      expect(result.success).toBe(true);
+    });
+
+    it('should fail with missing requestId', () => {
+      const invalidPayload = {
+        scopes: [
+          {
+            scope: {method: ICRC27_ACCOUNTS},
+            state: ICRC25_PERMISSION_ASK_ON_USE
+          }
+        ]
+      };
+
+      const result = RequestPermissionPayloadSchema.safeParse(invalidPayload);
+      expect(result.success).toBe(false);
+    });
+
+    it('should fail with invalid scopes method', () => {
+      const invalidPayload = {
+        scopes: [
+          {
+            scope: {method: 'test'},
+            state: ICRC25_PERMISSION_ASK_ON_USE
+          }
+        ]
+      };
+
+      const result = RequestPermissionPayloadSchema.safeParse(invalidPayload);
+      expect(result.success).toBe(false);
+    });
+
+    it('should fail with invalid scopes state', () => {
+      const invalidPayload = {
+        scopes: [
+          {
+            scope: {method: ICRC27_ACCOUNTS},
+            state: 'test'
+          }
+        ]
+      };
+
+      const result = RequestPermissionPayloadSchema.safeParse(invalidPayload);
+      expect(result.success).toBe(false);
+    });
+
+    it('should fail with missing scopes', () => {
+      const invalidPayload = {
+        requestId: '123'
+      };
+
+      const result = RequestPermissionPayloadSchema.safeParse(invalidPayload);
+      expect(result.success).toBe(false);
+    });
+  });
+});

--- a/src/types/signer-subscribers.ts
+++ b/src/types/signer-subscribers.ts
@@ -1,0 +1,10 @@
+import {z} from 'zod';
+import {IcrcScopeSchema} from './icrc-responses';
+import {RpcIdSchema} from './rpc';
+
+export const RequestPermissionPayloadSchema = z.object({
+  requestId: RpcIdSchema,
+  scopes: z.array(IcrcScopeSchema)
+});
+
+export type RequestPermissionPayload = z.infer<typeof RequestPermissionPayloadSchema>;


### PR DESCRIPTION
# Motivation

We need the request id and scope for the user to approve permissions.

# Changes

- Rename "events" to subscribers as we are now using events
- Introduce a type, a payload, that is passed to the subscribers for being approved by the user
