### PR TITLE
refactor: extract type scopes array

### DIFF
--- a/src/types/icrc-responses.ts
+++ b/src/types/icrc-responses.ts
@@ -19,9 +19,13 @@ export const IcrcScopeSchema = z
 
 export type IcrcScope = z.infer<typeof IcrcScopeSchema>;
 
+export const IcrcScopesArraySchema = z.array(IcrcScopeSchema);
+
+export type IcrcScopesArray = z.infer<typeof IcrcScopesArraySchema>;
+
 export const IcrcScopesSchema = z
   .object({
-    scopes: z.array(IcrcScopeSchema)
+    scopes: IcrcScopesArraySchema
   })
   .strict();
 

--- a/src/types/signer-subscribers.ts
+++ b/src/types/signer-subscribers.ts
@@ -1,10 +1,10 @@
 import {z} from 'zod';
-import {IcrcScopeSchema} from './icrc-responses';
+import {IcrcScopesArraySchema} from './icrc-responses';
 import {RpcIdSchema} from './rpc';
 
 export const RequestPermissionPayloadSchema = z.object({
   requestId: RpcIdSchema,
-  scopes: z.array(IcrcScopeSchema)
+  scopes: IcrcScopesArraySchema
 });
 
 export type RequestPermissionPayload = z.infer<typeof RequestPermissionPayloadSchema>;


### PR DESCRIPTION
# Motivation

It's handy to have a type array for the scopes.
