### PR TITLE
feat: dfinity identity and principal dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,6 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "@dfinity/identity": "^1.4.0",
         "@dfinity/principal": "^1.4.0",
         "@dfinity/utils": "^2.3.1",
         "zod": "^3.23.8"

--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
     "node": ">=20"
   },
   "peerDependencies": {
-    "@dfinity/identity": "^1.4.0",
     "@dfinity/principal": "^1.4.0",
     "@dfinity/utils": "^2.3.1",
     "zod": "^3.23.8"


### PR DESCRIPTION
# Motivation

The library requires `@dfinity/principal` as a peer dependency because the signer requires a `Principal`, an owner (see #81).
We also need `@dfinity/identity` as a dev dependency to generate principals for test purposes. 
