### PR TITLE
feat: local storage utils

### DIFF
--- a/src/utils/storage.utils.spec.ts
+++ b/src/utils/storage.utils.spec.ts
@@ -1,0 +1,62 @@
+import {Ed25519KeyIdentity} from '@dfinity/identity';
+import {del, get, set} from './storage.utils';
+
+describe('storage.utils', () => {
+  const newIdentity = Ed25519KeyIdentity.generate();
+  const key = 'testKey';
+  const value = {userId: newIdentity.getPrincipal().toText()};
+
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('should set an item in localStorage', () => {
+    set({key, value});
+
+    expect(localStorage.getItem(key)).toEqual(JSON.stringify(value));
+  });
+
+  it('should get an item from localStorage', () => {
+    localStorage.setItem(key, JSON.stringify(value));
+
+    const result = get({key});
+
+    expect(result).toEqual(value);
+  });
+
+  it('should return undefined if key does not exist', () => {
+    const key = 'unknownKey';
+
+    const result = get({key});
+
+    expect(result).toBeUndefined();
+  });
+
+  it('should delete an item from localStorage', () => {
+    set({key, value});
+
+    const result = get({key});
+
+    expect(result).not.toBeUndefined();
+
+    del({key});
+
+    expect(localStorage.getItem(key)).toBeNull();
+
+    const resultAfterDelete = get({key});
+
+    expect(resultAfterDelete).toBeUndefined();
+  });
+
+  it('should ignore error on get if key is not a JSON object', () => {
+    localStorage.setItem(key, 'something like a string');
+
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    const result = get({key});
+
+    expect(result).toBeUndefined();
+
+    spy.mockClear();
+  });
+});

--- a/src/utils/storage.utils.ts
+++ b/src/utils/storage.utils.ts
@@ -1,0 +1,31 @@
+import {nonNullish} from '@dfinity/utils';
+
+export const set = <T>({key, value}: {key: string; value: T}): void => {
+  try {
+    localStorage.setItem(key, JSON.stringify(value));
+  } catch (err: unknown) {
+    // We use local storage to save the signer's permissions for convenience and to improve the UX.
+    // If this fails, meaning permissions are not saved in storage, the user will always be prompted about the permissions.
+    console.error(err);
+  }
+};
+
+export const del = ({key}: {key: string}): void => {
+  try {
+    localStorage.removeItem(key);
+  } catch (err: unknown) {
+    // See comment in set.error
+    console.error(err);
+  }
+};
+
+export const get = <T>({key}: {key: string}): T | undefined => {
+  try {
+    const value = localStorage.getItem(key);
+    return nonNullish(value) ? JSON.parse(value) : undefined;
+  } catch (err: unknown) {
+    // See comment in set.error
+    console.error(err);
+    return undefined;
+  }
+};


### PR DESCRIPTION
# Motivation

We want to save the permission scopes as session information that can be used to reduce the number of times the signer asks the user for permission grants. Therefore, we need some utilities to interact with local storage.

We have chosen to use local storage instead of IndexedDB because the latter is disabled on Apple devices when Lockdown mode is enabled.
