### PR TITLE
feat: signer sessions for permissions

### DIFF
--- a/src/sessions/signer.sessions.spec.ts
+++ b/src/sessions/signer.sessions.spec.ts
@@ -1,0 +1,49 @@
+import {Ed25519KeyIdentity} from '@dfinity/identity';
+import {afterEach, beforeEach, type MockInstance} from 'vitest';
+import {ICRC25_PERMISSION_GRANTED, ICRC27_ACCOUNTS} from '../constants/icrc.constants';
+import type {IcrcScopesArray} from '../types/icrc-responses';
+import * as storageUtils from '../utils/storage.utils';
+import {savePermissions} from './signer.sessions';
+
+describe('Signer sessions', () => {
+  describe('savePermissions', () => {
+    const owner = Ed25519KeyIdentity.generate().getPrincipal();
+
+    const scopes: IcrcScopesArray = [
+      {
+        scope: {
+          method: ICRC27_ACCOUNTS
+        },
+        state: ICRC25_PERMISSION_GRANTED
+      }
+    ];
+
+    const origin = 'https://example.com';
+
+    let setSpy: MockInstance;
+
+    beforeEach(() => {
+      setSpy = vi.spyOn(storageUtils, 'set');
+    });
+
+    afterEach(() => {
+      vi.clearAllMocks();
+    });
+
+    it('should save the permissions to local storage', () => {
+      savePermissions({
+        owner,
+        origin,
+        scopes
+      });
+
+      const expectedKey = `oisy_signer_${origin}_${owner.toText()}`;
+      const expectedValue = {
+        scopes,
+        created_at: expect.any(Number)
+      };
+
+      expect(setSpy).toHaveBeenCalledWith({key: expectedKey, value: expectedValue});
+    });
+  });
+});

--- a/src/sessions/signer.sessions.ts
+++ b/src/sessions/signer.sessions.ts
@@ -1,0 +1,25 @@
+import type {Principal} from '@dfinity/principal';
+import type {IcrcScopesArray} from '../types/icrc-responses';
+import type {SessionPermissions} from '../types/signer-sessions';
+import {set} from '../utils/storage.utils';
+
+const KEY_PREFIX = 'oisy_signer';
+
+export const savePermissions = ({
+  owner,
+  origin,
+  scopes
+}: {
+  owner: Principal;
+  origin: string;
+  scopes: IcrcScopesArray;
+}): void => {
+  const key = `${KEY_PREFIX}_${origin}_${owner.toText()}`;
+
+  const value: SessionPermissions = {
+    scopes,
+    created_at: Date.now()
+  };
+
+  set({key, value});
+};

--- a/src/types/signer-sessions.spec.ts
+++ b/src/types/signer-sessions.spec.ts
@@ -1,0 +1,49 @@
+import {ICRC25_PERMISSION_GRANTED, ICRC27_ACCOUNTS} from '../constants/icrc.constants';
+import type {IcrcScopesArray} from './icrc-responses';
+import {SessionPermissionsSchema} from './signer-sessions';
+
+describe('Signer-sessions', () => {
+  const scopes: IcrcScopesArray = [
+    {
+      scope: {
+        method: ICRC27_ACCOUNTS
+      },
+      state: ICRC25_PERMISSION_GRANTED
+    }
+  ];
+
+  it('should validate a correct SessionPermissions object', () => {
+    const validData = {
+      scopes,
+      created_at: Date.now()
+    };
+
+    const parsedData = SessionPermissionsSchema.parse(validData);
+    expect(parsedData).toEqual(validData);
+  });
+
+  it('should fail validation if created_at is not a number', () => {
+    const invalidData = {
+      scopes,
+      created_at: 'not-a-number'
+    };
+
+    expect(() => SessionPermissionsSchema.parse(invalidData)).toThrow();
+  });
+
+  it('should fail validation if created_at is missing', () => {
+    const invalidData = {
+      scopes
+    };
+
+    expect(() => SessionPermissionsSchema.parse(invalidData)).toThrow();
+  });
+
+  it('should fail validation if scopes is missing', () => {
+    const invalidData = {
+      created_at: Date.now()
+    };
+
+    expect(() => SessionPermissionsSchema.parse(invalidData)).toThrow();
+  });
+});

--- a/src/types/signer-sessions.ts
+++ b/src/types/signer-sessions.ts
@@ -1,0 +1,9 @@
+import {z} from 'zod';
+import {IcrcScopesArraySchema} from './icrc-responses';
+
+export const SessionPermissionsSchema = z.object({
+  scopes: IcrcScopesArraySchema,
+  created_at: z.number()
+});
+
+export type SessionPermissions = z.infer<typeof SessionPermissionsSchema>;


### PR DESCRIPTION
# Motivation

We want to save the permissions approved or denied by the signer within local storage to reduce the number of times we ask users for permissions, thereby improving the UI/UX. This wrapper allows saving the permissions with the expected types.
