### PR TITLE
feat: transform message error into rejection

### DIFF
--- a/src/constants/signer.constants.ts
+++ b/src/constants/signer.constants.ts
@@ -9,7 +9,19 @@ export enum SignerErrorCode {
   /**
    * The request sent by the relying party is not supported by the signer.
    */
-  REQUEST_NOT_SUPPORTED = 501
+  REQUEST_NOT_SUPPORTED = 501,
+
+  /**
+   * A generic error.
+   * @see https://github.com/dfinity/wg-identity-authentication/blob/main/topics/icrc_25_signer_interaction_standard.md#errors
+   */
+  GENERIC_ERROR = 1000,
+
+  /**
+   * An error is thrown when the permission to perform a feature is denied.
+   * @see https://github.com/dfinity/wg-identity-authentication/blob/main/topics/icrc_25_signer_interaction_standard.md#errors
+   */
+  PERMISSION_NOT_GRANTED = 3000
 }
 
 export const SIGNER_SUPPORTED_STANDARDS: IcrcSupportedStandards = [

--- a/src/types/rpc.spec.ts
+++ b/src/types/rpc.spec.ts
@@ -4,6 +4,7 @@ import {
   RpcErrorCode,
   RpcNotificationSchema,
   RpcRequestSchema,
+  RpcResponseWithErrorSchema,
   RpcResponseWithResultOrErrorSchema,
   inferRpcRequestWithParamsSchema,
   inferRpcRequestWithoutParamsSchema
@@ -240,7 +241,7 @@ describe('rpc', () => {
     });
   });
 
-  describe('RpcResponse', () => {
+  describe('RpcResponse with result or error', () => {
     it('should validate a correct RpcResponse with result', () => {
       const validRpcResponse = {
         jsonrpc: JSON_RPC_VERSION_2,
@@ -330,6 +331,89 @@ describe('rpc', () => {
         hello: 'world'
       };
       expect(() => RpcResponseWithResultOrErrorSchema.parse(invalidRpcResponse)).toThrow();
+    });
+  });
+
+  describe('RpcResponse with error', () => {
+    it('should validate a correct RpcResponse with standard error', () => {
+      const validRpcResponseWithError = {
+        jsonrpc: JSON_RPC_VERSION_2,
+        id: 1,
+        error: {
+          code: RpcErrorCode.INTERNAL_ERROR,
+          message: 'An internal error occurred'
+        }
+      };
+      expect(() => RpcResponseWithErrorSchema.parse(validRpcResponseWithError)).not.toThrow();
+    });
+
+    it('should validate a correct RpcResponse with custom error code', () => {
+      const validRpcResponseWithError = {
+        jsonrpc: JSON_RPC_VERSION_2,
+        id: 1,
+        error: {
+          code: 9999,
+          message: 'A custom error occurred'
+        }
+      };
+      expect(() => RpcResponseWithErrorSchema.parse(validRpcResponseWithError)).not.toThrow();
+    });
+
+    it('should throw if RpcResponse with error has no error code', () => {
+      const invalidRpcResponseWithError = {
+        jsonrpc: JSON_RPC_VERSION_2,
+        id: 1,
+        error: {
+          message: 'An error occurred without a code'
+        }
+      };
+      expect(() => RpcResponseWithErrorSchema.parse(invalidRpcResponseWithError)).toThrow();
+    });
+
+    it('should throw if RpcResponse with error has no error message', () => {
+      const invalidRpcResponseWithError = {
+        jsonrpc: JSON_RPC_VERSION_2,
+        id: 1,
+        error: {
+          code: RpcErrorCode.INTERNAL_ERROR
+        }
+      };
+      expect(() => RpcResponseWithErrorSchema.parse(invalidRpcResponseWithError)).toThrow();
+    });
+
+    it('should throw if RpcResponse with error has no id', () => {
+      const invalidRpcResponseWithError = {
+        jsonrpc: JSON_RPC_VERSION_2,
+        error: {
+          code: RpcErrorCode.INTERNAL_ERROR,
+          message: 'An internal error occurred'
+        }
+      };
+      expect(() => RpcResponseWithErrorSchema.parse(invalidRpcResponseWithError)).toThrow();
+    });
+
+    it('should throw if RpcResponse with error has no jsonrpc field', () => {
+      const invalidRpcResponseWithError = {
+        id: 1,
+        error: {
+          code: RpcErrorCode.INTERNAL_ERROR,
+          message: 'An internal error occurred'
+        }
+      };
+      expect(() => RpcResponseWithErrorSchema.parse(invalidRpcResponseWithError)).toThrow();
+    });
+
+    it('should throw if RpcResponse with error has additional fields', () => {
+      const invalidRpcResponseWithError = {
+        jsonrpc: JSON_RPC_VERSION_2,
+        id: 1,
+        error: {
+          code: RpcErrorCode.INTERNAL_ERROR,
+          message: 'An internal error occurred'
+        },
+        additionalField: 'not allowed'
+      };
+      expect(() => RpcResponseWithErrorSchema.parse(invalidRpcResponseWithError)).toThrow();
     });
   });
 });

--- a/src/types/rpc.ts
+++ b/src/types/rpc.ts
@@ -94,8 +94,12 @@ export enum RpcErrorCode {
   SERVER_ERROR = -32000
 }
 
+const RpcResponseErrorCodeSchema = z.union([z.number(), z.nativeEnum(RpcErrorCode)]);
+
+export type RpcResponseErrorCode = z.infer<typeof RpcResponseErrorCodeSchema>;
+
 const RpcResponseErrorSchema = z.object({
-  code: z.union([z.number(), z.nativeEnum(RpcErrorCode)]),
+  code: RpcResponseErrorCodeSchema,
   message: z.string(),
   data: z.optional(z.never())
 });
@@ -108,9 +112,9 @@ const RpcResponseSchema = RpcSchema.extend({
 
 export type RpcResponse = z.infer<typeof RpcResponseSchema>;
 
-const RpcResponseWithErrorSchema = RpcResponseSchema.extend({
+export const RpcResponseWithErrorSchema = RpcResponseSchema.extend({
   error: RpcResponseErrorSchema
-});
+}).strict();
 
 export type RpcResponseWithError = z.infer<typeof RpcResponseWithErrorSchema>;
 

--- a/src/types/wallet-errors.ts
+++ b/src/types/wallet-errors.ts
@@ -1,0 +1,11 @@
+import type {RpcResponseError, RpcResponseErrorCode} from './rpc';
+
+export class WalletResponseError extends Error {
+  code: RpcResponseErrorCode;
+
+  constructor({message, code}: RpcResponseError) {
+    super(message);
+
+    this.code = code;
+  }
+}

--- a/src/wallet.spec.ts
+++ b/src/wallet.spec.ts
@@ -5,6 +5,7 @@ import {
   ICRC29_STATUS,
   ICRC49_CALL_CANISTER
 } from './constants/icrc.constants';
+import {SignerErrorCode} from './constants/signer.constants';
 import {
   WALLET_CONNECT_TIMEOUT_REQUEST_PERMISSIONS,
   WALLET_CONNECT_TIMEOUT_REQUEST_SUPPORTED_STANDARD,
@@ -17,6 +18,7 @@ import {
   IcrcSupportedStandardsResponseSchema
 } from './types/icrc-responses';
 import {JSON_RPC_VERSION_2, RpcResponseWithResultOrErrorSchema} from './types/rpc';
+import {WalletResponseError} from './types/wallet-errors';
 import type {WalletOptions} from './types/wallet-options';
 import {WALLET_WINDOW_CENTER, WALLET_WINDOW_TOP_RIGHT, windowFeatures} from './utils/window.utils';
 import {Wallet} from './wallet';
@@ -376,6 +378,35 @@ describe('Wallet', () => {
             `The response origin ${hackerOrigin} does not match the wallet origin ${mockParameters.url}.`
           );
         });
+
+        it('should throw a wallet response error if the wallet notify an error', async () => {
+          const testId = '12345';
+
+          const promise = wallet.supportedStandards({options: {requestId: testId}});
+
+          const errorMsg = 'This is a test error.';
+
+          const messageEvent = new MessageEvent('message', {
+            origin: mockParameters.url,
+            data: {
+              jsonrpc: JSON_RPC_VERSION_2,
+              id: testId,
+              error: {
+                code: SignerErrorCode.GENERIC_ERROR,
+                message: errorMsg
+              }
+            }
+          });
+
+          window.dispatchEvent(messageEvent);
+
+          const error = {
+            code: SignerErrorCode.GENERIC_ERROR,
+            message: errorMsg
+          };
+
+          await expect(promise).rejects.toThrowError(new WalletResponseError(error));
+        });
       });
 
       describe('Request success', () => {
@@ -546,6 +577,35 @@ describe('Wallet', () => {
           await expect(promise).rejects.toThrow(
             `The response origin ${hackerOrigin} does not match the wallet origin ${mockParameters.url}.`
           );
+        });
+
+        it('should throw a wallet response error if the wallet notify an error', async () => {
+          const testId = '12345';
+
+          const promise = wallet.requestPermissions({options: {requestId: testId}});
+
+          const errorMsg = 'This is a test error.';
+
+          const messageEvent = new MessageEvent('message', {
+            origin: mockParameters.url,
+            data: {
+              jsonrpc: JSON_RPC_VERSION_2,
+              id: testId,
+              error: {
+                code: SignerErrorCode.GENERIC_ERROR,
+                message: errorMsg
+              }
+            }
+          });
+
+          window.dispatchEvent(messageEvent);
+
+          const error = {
+            code: SignerErrorCode.GENERIC_ERROR,
+            message: errorMsg
+          };
+
+          await expect(promise).rejects.toThrowError(new WalletResponseError(error));
         });
       });
 


### PR DESCRIPTION
# Motivation

The relying party call should ends in error if the wallet notify an error.
