### PR TITLE
feat: just return the scopes as array

### DIFF
--- a/demo/src/relying_party_frontend/src/lib/components/RequestPermissions.svelte
+++ b/demo/src/relying_party_frontend/src/lib/components/RequestPermissions.svelte
@@ -15,8 +15,7 @@
 	let scopes: IcrcScope[] | undefined = $state(undefined);
 
 	const onclick = async () => {
-		const result = await wallet?.requestPermissions();
-		scopes = result?.scopes;
+		scopes = await wallet?.requestPermissions();
 	};
 </script>
 

--- a/src/wallet.spec.ts
+++ b/src/wallet.spec.ts
@@ -682,7 +682,7 @@ describe('Wallet', () => {
 
           const result = await promise;
 
-          expect(result).toEqual({scopes});
+          expect(result).toEqual(scopes);
         });
       });
     });

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -15,7 +15,7 @@ import {
   IcrcReadyResponseSchema,
   IcrcScopesResponseSchema,
   IcrcSupportedStandardsResponseSchema,
-  type IcrcScopes,
+  type IcrcScopesArray,
   type IcrcSupportedStandards
 } from './types/icrc-responses';
 import {
@@ -335,14 +335,14 @@ export class Wallet {
     scopes
   }: {
     options?: WalletRequestOptions;
-  } & Partial<IcrcAnyRequestedScopes> = {}): Promise<IcrcScopes> => {
+  } & Partial<IcrcAnyRequestedScopes> = {}): Promise<IcrcScopesArray> => {
     const handleMessage = async ({
       data,
       id
     }: {
       data: WalletMessageEventData;
       id: RpcId;
-    }): Promise<{handled: boolean; result?: IcrcScopes}> => {
+    }): Promise<{handled: boolean; result?: IcrcScopesArray}> => {
       const {success: isRequestPermissions, data: requestPermissionsData} =
         IcrcScopesResponseSchema.safeParse(data);
 
@@ -355,7 +355,7 @@ export class Wallet {
           result: {scopes}
         } = requestPermissionsData;
 
-        return {handled: true, result: {scopes}};
+        return {handled: true, result: scopes};
       }
 
       return {handled: false};
@@ -370,7 +370,7 @@ export class Wallet {
       });
     };
 
-    return await this.request<IcrcScopes>({
+    return await this.request<IcrcScopesArray>({
       options: {
         timeoutInMilliseconds: timeoutInMilliseconds ?? WALLET_CONNECT_TIMEOUT_REQUEST_PERMISSIONS,
         ...rest


### PR DESCRIPTION
# Motivation

While the specification of the response for the permissions returns a `result` that contains an object `scopes`, in the implementation, there is no real reason at the moment to return such a object. Therefore we can simplify the API by returning solely the list of permissions array.