### PR TITLE
feat: do not focus wallet on signer standards

### DIFF
--- a/src/handlers/wallet.handlers.spec.ts
+++ b/src/handlers/wallet.handlers.spec.ts
@@ -139,10 +139,10 @@ describe('Wallet handlers', () => {
       );
     });
 
-    it('should bring the popup in front with focus', () => {
+    it('should not bring the popup in front with focus', () => {
       requestSupportedStandards({id: testId, popup, origin: testOrigin});
 
-      expect(focusMock).toHaveBeenCalledTimes(1);
+      expect(focusMock).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
# Motivation

Requesting the signer standards does not need user interaction therefore we do not need to focus the wallet.
