### PR TITLE
feat: derive signer standard list constant

### DIFF
--- a/src/constants/signer.constants.ts
+++ b/src/constants/signer.constants.ts
@@ -1,3 +1,4 @@
+import {IcrcWalletStandardSchema} from '../types/icrc';
 import type {IcrcSupportedStandards} from '../types/icrc-responses';
 
 export enum SignerErrorCode {
@@ -24,13 +25,9 @@ export enum SignerErrorCode {
   PERMISSION_NOT_GRANTED = 3000
 }
 
-export const SIGNER_SUPPORTED_STANDARDS: IcrcSupportedStandards = [
-  {
-    name: 'ICRC-25',
-    url: 'https://github.com/dfinity/ICRC/blob/main/ICRCs/ICRC-25/ICRC-25.md'
-  },
-  {
-    name: 'ICRC-27',
-    url: 'https://github.com/dfinity/ICRC/blob/main/ICRCs/ICRC-27/ICRC-27.md'
-  }
-];
+export const SIGNER_SUPPORTED_STANDARDS: IcrcSupportedStandards = Object.values(
+  IcrcWalletStandardSchema.Values
+).map((name) => ({
+  name,
+  url: `https://github.com/dfinity/ICRC/blob/main/ICRCs/${name}/${name}.md`
+}));


### PR DESCRIPTION
# Motivation

The list of standards was not up-to-date anymore. That's because I had a custom constant. Deriving it from zod allow use to have this always up-to-date with the type.
