### PR TITLE
refactor: extract permissions request reusable function

### DIFF
--- a/src/types/wallet-request.ts
+++ b/src/types/wallet-request.ts
@@ -1,20 +1,31 @@
 import {z} from 'zod';
 import {RpcIdSchema} from './rpc';
 
-export const WalletRequestOptionsSchema = z.object({
-  /**
-   * A custom identifier for the request, used to correlate responses with their corresponding requests.
-   *
-   * The wallet is expected to include this ID in its response, ensuring that the response can be accurately matched to the original request.
-   *
-   * If not provided, the library will generate a unique identifier automatically.
-   */
-  requestId: RpcIdSchema.optional(),
-
+export const WalletRequestOptionsTimeoutSchema = z.object({
   /**
    * Specifies the maximum duration in milliseconds for attempting to request an interaction with the wallet.
    * If the wallet does not answer within this duration, the process will time out.
    */
-  timeoutInMilliseconds: z.number().optional()
+  timeoutInMilliseconds: z.number()
 });
+
+export const WalletRequestOptionsSchema = z
+  .object({
+    /**
+     * A custom identifier for the request, used to correlate responses with their corresponding requests.
+     *
+     * The wallet is expected to include this ID in its response, ensuring that the response can be accurately matched to the original request.
+     *
+     * If not provided, the library will generate a unique identifier automatically.
+     */
+    requestId: RpcIdSchema.optional()
+  })
+  .merge(WalletRequestOptionsTimeoutSchema.partial());
+
 export type WalletRequestOptions = z.infer<typeof WalletRequestOptionsSchema>;
+
+export const WalletRequestOptionsWithTimeoutSchema = WalletRequestOptionsSchema.omit({
+  timeoutInMilliseconds: true
+}).merge(WalletRequestOptionsTimeoutSchema);
+
+export type WalletRequestOptionsWithTimeout = z.infer<typeof WalletRequestOptionsWithTimeoutSchema>;

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -26,7 +26,11 @@ import {
 import type {WalletMessageEvent, WalletMessageEventData} from './types/wallet';
 import {WalletResponseError} from './types/wallet-errors';
 import {WalletOptionsSchema, type WalletOptions} from './types/wallet-options';
-import {WalletRequestOptionsSchema, type WalletRequestOptions} from './types/wallet-request';
+import {
+  WalletRequestOptionsSchema,
+  type WalletRequestOptions,
+  type WalletRequestOptionsWithTimeout
+} from './types/wallet-request';
 import type {ReadyOrError} from './utils/timeout.utils';
 import {WALLET_WINDOW_TOP_RIGHT, windowFeatures} from './utils/window.utils';
 
@@ -331,7 +335,7 @@ export class Wallet {
    * @see [ICRC25 Request Permissions](https://github.com/dfinity/wg-identity-authentication/blob/main/topics/icrc_25_signer_interaction_standard.md#icrc25_request_permissions)
    */
   requestPermissions = async ({
-    options,
+    options: {timeoutInMilliseconds, ...rest} = {},
     scopes
   }: {
     options?: WalletRequestOptions;
@@ -346,16 +350,19 @@ export class Wallet {
     };
 
     return await this.requestPermissionsScopes({
-      options,
+      options: {
+        timeoutInMilliseconds: timeoutInMilliseconds ?? WALLET_CONNECT_TIMEOUT_REQUEST_PERMISSIONS,
+        ...rest
+      },
       postRequest
     });
   };
 
   private readonly requestPermissionsScopes = async ({
-    options: {timeoutInMilliseconds, ...rest} = {},
+    options,
     postRequest
   }: {
-    options?: WalletRequestOptions;
+    options: WalletRequestOptionsWithTimeout;
     postRequest: (id: RpcId) => void;
   }): Promise<IcrcScopesArray> => {
     const handleMessage = async ({
@@ -384,10 +391,7 @@ export class Wallet {
     };
 
     return await this.request<IcrcScopesArray>({
-      options: {
-        timeoutInMilliseconds: timeoutInMilliseconds ?? WALLET_CONNECT_TIMEOUT_REQUEST_PERMISSIONS,
-        ...rest
-      },
+      options,
       postRequest,
       handleMessage
     });


### PR DESCRIPTION
# Motivation

Querying and requesting permissions can reuse the same `request` function within the wallet client given that both generate the same return types. They do require different timeout though.