### PR TITLE
feat: filter permissions scopes

### DIFF
--- a/src/sessions/signer.sessions.ts
+++ b/src/sessions/signer.sessions.ts
@@ -62,22 +62,20 @@ export const savePermissions = ({
   set({key: permissionKey, value: updatedPermissions});
 };
 
-export const readValidPermissions = (params: SessionParams): SessionPermissions | undefined => {
+export const readValidPermissions = (params: SessionParams): IcrcScopesArray | undefined => {
   const permissions = get<SessionPermissions>({key: key(params)});
 
   if (isNullish(permissions)) {
     return undefined;
   }
 
-  // TODO: the permissions should be filtered with their respective updatedAt timestamp not the overall timestamp.
-
   // TODO: We can improve the UX by "tracking" when the user is using a feature of the signer.
   // For example:
   // 1. Checking if the signer was last used within the past seven days.
   // 2. Comparing the creation date was granted within the last 30 days.
-  if (permissions.createdAt < Date.now() - SIGNER_PERMISSION_VALIDITY_PERIOD_IN_MILLISECONDS) {
-    return undefined;
-  }
-
-  return permissions;
+  return permissions.scopes
+    .filter(
+      ({updatedAt}) => updatedAt >= Date.now() - SIGNER_PERMISSION_VALIDITY_PERIOD_IN_MILLISECONDS
+    )
+    .map(({updatedAt: _, createdAt: __, ...rest}) => ({...rest}));
 };

--- a/src/signer.ts
+++ b/src/signer.ts
@@ -211,10 +211,7 @@ export class Signer {
       notifyPermissionScopes({
         id,
         origin,
-        scopes:
-          // TODO: move map to service
-          permissions?.scopes.map(({updatedAt: _, createdAt: __, ...rest}) => ({...rest})) ??
-          SIGNER_DEFAULT_SCOPES
+        scopes: permissions ?? SIGNER_DEFAULT_SCOPES
       });
       return {handled: true};
     }


### PR DESCRIPTION
# Motivation

When the signer search for permissions, it should filter the valid scopes according their own dates given that it was requested to track permissions separatly.
