### PR TITLE
feat: handle accounts requests, prompts permissions and save those

### DIFF
--- a/src/types/signer.ts
+++ b/src/types/signer.ts
@@ -1,5 +1,6 @@
 import {z} from 'zod';
 import {
+  IcrcAccountsRequestSchema,
   IcrcPermissionsRequestSchema,
   IcrcRequestAnyPermissionsRequestSchema,
   IcrcStatusRequestSchema,
@@ -11,7 +12,8 @@ const SignerMessageEventDataSchema = z
     IcrcStatusRequestSchema,
     IcrcRequestAnyPermissionsRequestSchema,
     IcrcPermissionsRequestSchema,
-    IcrcSupportedStandardsRequestSchema
+    IcrcSupportedStandardsRequestSchema,
+    IcrcAccountsRequestSchema
   ])
   .optional();
 


### PR DESCRIPTION
# Motivation

When a relying party ask for accounts, the signer should be able to process the request. If no permissions were ever set, the signer should first ask the user of the signer if the user want to deny, approve or grant the accounts permissions. The answer should be saved in the session permissions.
