### PR TITLE
feat: notify error on accounts if permissions are denied

### DIFF
--- a/src/signer.ts
+++ b/src/signer.ts
@@ -372,7 +372,15 @@ export class Signer {
       // TODO: this will be refactored as other requests will require the same checks and execution flow.
       switch (sessionScopeState({owner: this.#owner, origin, method: ICRC27_ACCOUNTS})) {
         case 'denied': {
-          // TODO: Is permission denied => notify error
+          notifyError({
+            id: requestId ?? null,
+            origin,
+            error: {
+              code: SignerErrorCode.PERMISSION_NOT_GRANTED,
+              message:
+                'The signer has not granted the necessary permissions to process the request from the relying party.'
+            }
+          });
           break;
         }
         case 'granted': {


### PR DESCRIPTION
# Motivation

If the permissions were denied, the signer should notify the relying party with an error.