### PR TITLE
fix: accounts prompt payload

### DIFF
--- a/src/signer.spec.ts
+++ b/src/signer.spec.ts
@@ -656,7 +656,7 @@ describe('Signer', () => {
 
         signer.register({
           method: ICRC25_REQUEST_PERMISSIONS,
-          prompt: ({confirmScopes: confirm, requestedScopes: _}) => {
+          prompt: ({confirmScopes: confirm, requestedScopes: _}: PermissionsPromptPayload) => {
             confirmScopes = confirm;
           }
         });
@@ -776,7 +776,7 @@ describe('Signer', () => {
 
         signer.register({
           method: ICRC25_REQUEST_PERMISSIONS,
-          prompt: (p) => (payload = p)
+          prompt: (p: PermissionsPromptPayload) => (payload = p)
         });
 
         const messageEventPermissionsRequests = new MessageEvent('message', requestPermissionsMsg);

--- a/src/signer.ts
+++ b/src/signer.ts
@@ -162,15 +162,16 @@ export class Signer {
     method: IcrcWalletApproveMethod;
     prompt: PermissionsPrompt | AccountsPrompt;
   }): void => {
+    // TODO: is there a way to avoid casting?
     switch (method) {
       case ICRC25_REQUEST_PERMISSIONS: {
         PermissionsPromptSchema.parse(prompt);
-        this.#permissionsPrompt = prompt;
+        this.#permissionsPrompt = prompt as PermissionsPrompt;
         return;
       }
       case ICRC27_ACCOUNTS: {
         AccountsPromptSchema.parse(prompt);
-        this.#accountsPrompt = prompt;
+        this.#accountsPrompt = prompt as AccountsPrompt;
         return;
       }
     }

--- a/src/types/signer-prompts.ts
+++ b/src/types/signer-prompts.ts
@@ -49,7 +49,7 @@ export type AccountsPromptPayload = z.infer<typeof AccountsPromptPayloadSchema>;
  */
 export const AccountsPromptSchema = z
   .function()
-  .args(PermissionsPromptPayloadSchema)
+  .args(AccountsPromptPayloadSchema)
   .returns(z.void());
 
 export type AccountsPrompt = z.infer<typeof AccountsPromptSchema>;


### PR DESCRIPTION
# Motivation

The payload of the accounts prompt was incorrect due to an original copy/paste which was not revisited.
