### PR TITLE
test: accounts after permissions

### DIFF
--- a/e2e/accounts.spec.ts
+++ b/e2e/accounts.spec.ts
@@ -7,15 +7,12 @@ testWithII('should requests permissions and list accounts', async () => {
   const partyPage = getPartyPage();
 
   await partyPage.approvePermissionsAccounts();
-
-  // TODO list accounts
 });
 
 testWithII('should not requests permissions and list accounts', async () => {
   const partyPage = getPartyPage();
 
-  // TODO: uncomment when list accounts on first test
-  // await partyPage.resetAccounts();
+  await partyPage.resetAccounts();
 
   await partyPage.accounts();
 });

--- a/e2e/page-objects/party.page.ts
+++ b/e2e/page-objects/party.page.ts
@@ -114,7 +114,7 @@ export class PartyPage extends IdentityPage {
 
     await this.#walletPage?.approveAccountsPermissions();
 
-    // TODO: response not yet implemented
+    await this.assertAccounts();
   }
 
   async resetAccounts(): Promise<void> {
@@ -130,6 +130,10 @@ export class PartyPage extends IdentityPage {
 
     await this.page.getByTestId('accounts-button').click();
 
+    await this.assertAccounts();
+  }
+
+  private async assertAccounts(): Promise<void> {
     await expect(this.page.getByTestId('accounts')).toBeVisible();
 
     const ul = this.page.getByTestId('accounts-list');


### PR DESCRIPTION
# Motivation

In the demo and E2E happy path tests, we want to asserts that the accounts are also listed if the user is prompted to grant the permissions.
