### PR TITLE
chore: remove scope todo

### DIFF
--- a/src/signer.ts
+++ b/src/signer.ts
@@ -320,7 +320,6 @@ export class Signer {
 
   private async promptPermissions(requestedScopes: IcrcScopesArray): Promise<IcrcScopesArray> {
     const promise = new Promise<IcrcScopesArray>((resolve, reject) => {
-      // TODO: the answer cannot actually contains ask_on_use. That would be cleaner type wise.
       const confirmScopes: PermissionsConfirmation = (scopes) => {
         resolve(scopes);
       };


### PR DESCRIPTION
# Motivation

According to standards, a user is able to select 'ask on use' when prompted to grant permissions. Although this does not make sense to me, given that it's the standard, we should probably not exclude this in the library, even if it would improve the developer experience to do so. Therefore, I am removing the TODO I had left in the code.
