### PR TITLE
feat: shorten IcrcWallet prefix type

### DIFF
--- a/e2e/page-objects/party.page.ts
+++ b/e2e/page-objects/party.page.ts
@@ -1,6 +1,6 @@
 import {InternetIdentityPage} from '@dfinity/internet-identity-playwright';
 import {expect} from '@playwright/test';
-import {IcrcWalletPermissionState, IcrcWalletScopedMethod} from '../../src';
+import {IcrcPermissionState, IcrcScopedMethod} from '../../src';
 import {waitForFadeAnimation} from '../utils/test.utils';
 import {IdentityPage, IdentityPageParams} from './identity.page';
 import {WalletPage} from './wallet.page';
@@ -81,7 +81,7 @@ export class PartyPage extends IdentityPage {
   }
 
   async assertPermissions(
-    expectedPermissions: Record<IcrcWalletScopedMethod, IcrcWalletPermissionState>
+    expectedPermissions: Record<IcrcScopedMethod, IcrcPermissionState>
   ): Promise<void> {
     await expect(this.page.getByTestId('permissions')).toBeVisible();
 

--- a/src/constants/signer.constants.ts
+++ b/src/constants/signer.constants.ts
@@ -1,5 +1,5 @@
 import type {IcrcScopesArray, IcrcSupportedStandards} from '../types/icrc-responses';
-import {IcrcWalletScopedMethodSchema, IcrcWalletStandardSchema} from '../types/icrc-standards';
+import {IcrcScopedMethodSchema, IcrcStandardSchema} from '../types/icrc-standards';
 import {ICRC25_PERMISSION_ASK_ON_USE} from './icrc.constants';
 
 export enum SignerErrorCode {
@@ -34,14 +34,14 @@ export enum SignerErrorCode {
 }
 
 export const SIGNER_SUPPORTED_STANDARDS: IcrcSupportedStandards = Object.values(
-  IcrcWalletStandardSchema.Values
+  IcrcStandardSchema.Values
 ).map((name) => ({
   name,
   url: `https://github.com/dfinity/ICRC/blob/main/ICRCs/${name}/${name}.md`
 }));
 
 export const SIGNER_DEFAULT_SCOPES: IcrcScopesArray = Object.values(
-  IcrcWalletScopedMethodSchema.Values
+  IcrcScopedMethodSchema.Values
 ).map((method) => ({scope: {method}, state: ICRC25_PERMISSION_ASK_ON_USE}));
 
 export const SIGNER_PERMISSION_VALIDITY_PERIOD_IN_MILLISECONDS = 7 * 24 * 60 * 60 * 1000; // 7 days

--- a/src/constants/wallet.constants.ts
+++ b/src/constants/wallet.constants.ts
@@ -1,5 +1,5 @@
 import type {IcrcRequestedScopes} from '../types/icrc-requests';
-import {IcrcWalletScopedMethodSchema} from '../types/icrc-standards';
+import {IcrcScopedMethodSchema} from '../types/icrc-standards';
 
 const WALLET_TIMEOUT_IN_MILLISECONDS_WITH_USER_INTERACTION = 60 * 2 * 1000;
 const WALLET_TIMEOUT_IN_MILLISECONDS_WITHOUT_USER_INTERACTION = 5000;
@@ -14,5 +14,5 @@ export const WALLET_TIMEOUT_PERMISSIONS = WALLET_TIMEOUT_IN_MILLISECONDS_WITHOUT
 export const WALLET_TIMEOUT_ACCOUNTS = WALLET_TIMEOUT_IN_MILLISECONDS_WITH_USER_INTERACTION;
 
 export const {scopes: WALLET_DEFAULT_SCOPES}: IcrcRequestedScopes = {
-  scopes: Object.values(IcrcWalletScopedMethodSchema.Values).map((method) => ({method}))
+  scopes: Object.values(IcrcScopedMethodSchema.Values).map((method) => ({method}))
 };

--- a/src/sessions/signer.sessions.spec.ts
+++ b/src/sessions/signer.sessions.spec.ts
@@ -10,7 +10,7 @@ import {
 } from '../constants/icrc.constants';
 import {SIGNER_PERMISSION_VALIDITY_PERIOD_IN_MILLISECONDS} from '../constants/signer.constants';
 import type {IcrcScope, IcrcScopesArray} from '../types/icrc-responses';
-import type {IcrcWalletScopedMethod} from '../types/icrc-standards';
+import type {IcrcScopedMethod} from '../types/icrc-standards';
 import type {SessionPermissions} from '../types/signer-sessions';
 import * as storageUtils from '../utils/storage.utils';
 import {del, get} from '../utils/storage.utils';
@@ -240,7 +240,7 @@ describe('Signer sessions', () => {
       const state = sessionScopeState({
         owner,
         origin,
-        method: 'this_does_not_exist' as IcrcWalletScopedMethod
+        method: 'this_does_not_exist' as IcrcScopedMethod
       });
 
       expect(state).toBe(ICRC25_PERMISSION_ASK_ON_USE);

--- a/src/sessions/signer.sessions.ts
+++ b/src/sessions/signer.sessions.ts
@@ -3,7 +3,7 @@ import {isNullish} from '@dfinity/utils';
 import {ICRC25_PERMISSION_ASK_ON_USE} from '../constants/icrc.constants';
 import {SIGNER_PERMISSION_VALIDITY_PERIOD_IN_MILLISECONDS} from '../constants/signer.constants';
 import type {IcrcScopesArray} from '../types/icrc-responses';
-import type {IcrcWalletPermissionState, IcrcWalletScopedMethod} from '../types/icrc-standards';
+import type {IcrcPermissionState, IcrcScopedMethod} from '../types/icrc-standards';
 import type {SessionIcrcScope, SessionPermissions} from '../types/signer-sessions';
 import {get, set} from '../utils/storage.utils';
 
@@ -86,7 +86,7 @@ export const readSessionValidScopes = (params: SessionIdentifier): IcrcScopesArr
 export const sessionScopeState = ({
   method,
   ...rest
-}: SessionIdentifier & {method: IcrcWalletScopedMethod}): IcrcWalletPermissionState => {
+}: SessionIdentifier & {method: IcrcScopedMethod}): IcrcPermissionState => {
   const scopes = readSessionValidScopes(rest);
 
   return (

--- a/src/signer.spec.ts
+++ b/src/signer.spec.ts
@@ -20,7 +20,7 @@ import {saveSessionScopes} from './sessions/signer.sessions';
 import {Signer} from './signer';
 import type {IcrcAccountsRequest, IcrcRequestAnyPermissionsRequest} from './types/icrc-requests';
 import type {IcrcScopesArray} from './types/icrc-responses';
-import {IcrcWalletPermissionStateSchema} from './types/icrc-standards';
+import {IcrcPermissionStateSchema} from './types/icrc-standards';
 import {JSON_RPC_VERSION_2} from './types/rpc';
 import type {SignerMessageEventData} from './types/signer';
 import type {SignerOptions} from './types/signer-options';
@@ -508,7 +508,7 @@ describe('Signer', () => {
         expect(promptSpy).toHaveBeenNthCalledWith(1, {
           requestedScopes: requestPermissionsData.params.scopes.map((scope) => ({
             scope: {...scope},
-            state: IcrcWalletPermissionStateSchema.enum.denied
+            state: IcrcPermissionStateSchema.enum.denied
           })),
           confirmScopes: expect.any(Function)
         });
@@ -544,7 +544,7 @@ describe('Signer', () => {
         expect(promptSpy).toHaveBeenNthCalledWith(1, {
           requestedScopes: requestPermissionsData.params.scopes.map((scope) => ({
             scope: {...scope},
-            state: IcrcWalletPermissionStateSchema.enum.denied
+            state: IcrcPermissionStateSchema.enum.denied
           })),
           confirmScopes: expect.any(Function)
         });
@@ -603,7 +603,7 @@ describe('Signer', () => {
           scopes: [
             {
               scope: {method: ICRC27_ACCOUNTS},
-              state: IcrcWalletPermissionStateSchema.enum.denied
+              state: IcrcPermissionStateSchema.enum.denied
             }
           ]
         });
@@ -646,7 +646,7 @@ describe('Signer', () => {
           scopes: [
             {
               scope: {method: ICRC27_ACCOUNTS},
-              state: IcrcWalletPermissionStateSchema.enum.granted
+              state: IcrcPermissionStateSchema.enum.granted
             }
           ]
         });
@@ -691,7 +691,7 @@ describe('Signer', () => {
             requestedScopes: [
               {
                 scope: {method: ICRC27_ACCOUNTS},
-                state: IcrcWalletPermissionStateSchema.enum.denied
+                state: IcrcPermissionStateSchema.enum.denied
               }
             ],
             confirmScopes: expect.any(Function)
@@ -721,7 +721,7 @@ describe('Signer', () => {
         confirmScopes?.([
           {
             scope: {method: ICRC27_ACCOUNTS},
-            state: IcrcWalletPermissionStateSchema.enum.granted
+            state: IcrcPermissionStateSchema.enum.granted
           }
         ]);
 
@@ -735,7 +735,7 @@ describe('Signer', () => {
           expect(storedScopes?.scopes).toEqual([
             {
               scope: {method: ICRC27_ACCOUNTS},
-              state: IcrcWalletPermissionStateSchema.enum.granted,
+              state: IcrcPermissionStateSchema.enum.granted,
               createdAt: expect.any(Number),
               updatedAt: expect.any(Number)
             }
@@ -771,7 +771,7 @@ describe('Signer', () => {
         confirmScopes?.([
           {
             scope: {method: ICRC27_ACCOUNTS},
-            state: IcrcWalletPermissionStateSchema.enum.granted
+            state: IcrcPermissionStateSchema.enum.granted
           }
         ]);
 
@@ -816,7 +816,7 @@ describe('Signer', () => {
         confirmScopes?.([
           {
             scope: {method: ICRC27_ACCOUNTS},
-            state: IcrcWalletPermissionStateSchema.enum.denied
+            state: IcrcPermissionStateSchema.enum.denied
           }
         ]);
 

--- a/src/signer.ts
+++ b/src/signer.ts
@@ -26,9 +26,9 @@ import {
 } from './types/icrc-requests';
 import type {IcrcScope, IcrcScopesArray} from './types/icrc-responses';
 import {
-  IcrcWalletPermissionStateSchema,
-  IcrcWalletScopedMethodSchema,
-  type IcrcWalletApproveMethod
+  IcrcPermissionStateSchema,
+  IcrcScopedMethodSchema,
+  type IcrcApproveMethod
 } from './types/icrc-standards';
 import {RpcRequestSchema, type RpcId} from './types/rpc';
 import type {SignerMessageEvent} from './types/signer';
@@ -163,7 +163,7 @@ export class Signer {
     method,
     prompt
   }: {
-    method: IcrcWalletApproveMethod;
+    method: IcrcApproveMethod;
     prompt: PermissionsPrompt | AccountsPrompt;
   }): void => {
     // TODO: is there a way to avoid casting?
@@ -285,14 +285,13 @@ export class Signer {
       // TODO: Can the newer version of TypeScript infer "as IcrcScope"?
       const supportedRequestedScopes = requestedScopes
         .filter(
-          ({method: requestedMethod}) =>
-            IcrcWalletScopedMethodSchema.safeParse(requestedMethod).success
+          ({method: requestedMethod}) => IcrcScopedMethodSchema.safeParse(requestedMethod).success
         )
         .map(
           ({method}) =>
             ({
               scope: {method},
-              state: IcrcWalletPermissionStateSchema.enum.denied
+              state: IcrcPermissionStateSchema.enum.denied
             }) as const as IcrcScope
         );
 

--- a/src/types/icrc-requests.ts
+++ b/src/types/icrc-requests.ts
@@ -6,7 +6,7 @@ import {
   ICRC27_ACCOUNTS,
   ICRC29_STATUS
 } from '../constants/icrc.constants';
-import {IcrcWalletScopedMethodSchema} from './icrc-standards';
+import {IcrcScopedMethodSchema} from './icrc-standards';
 import {inferRpcRequestWithParamsSchema, inferRpcRequestWithoutParamsSchema} from './rpc';
 
 // icrc25_request_permissions
@@ -15,7 +15,7 @@ const IcrcRequestedScopesSchema = z.object({
   scopes: z
     .array(
       z.object({
-        method: IcrcWalletScopedMethodSchema
+        method: IcrcScopedMethodSchema
       })
     )
     .min(1)

--- a/src/types/icrc-responses.ts
+++ b/src/types/icrc-responses.ts
@@ -1,20 +1,20 @@
 import {z} from 'zod';
 import {IcrcAccountsSchema} from './icrc-accounts';
 import {
-  IcrcWalletPermissionStateSchema,
-  IcrcWalletScopedMethodSchema,
-  IcrcWalletStandardSchema
+  IcrcPermissionStateSchema,
+  IcrcScopedMethodSchema,
+  IcrcStandardSchema
 } from './icrc-standards';
 import {inferRpcResponseSchema} from './rpc';
 
 const IcrcScopeMethodSchema = z.object({
-  method: IcrcWalletScopedMethodSchema
+  method: IcrcScopedMethodSchema
 });
 
 export const IcrcScopeSchema = z
   .object({
     scope: IcrcScopeMethodSchema,
-    state: IcrcWalletPermissionStateSchema
+    state: IcrcPermissionStateSchema
   })
   .strict();
 
@@ -58,10 +58,10 @@ const UrlSchema = z
 
       const [_, icrc] = match;
 
-      return Object.keys(IcrcWalletStandardSchema.Values).includes(icrc);
+      return Object.keys(IcrcStandardSchema.Values).includes(icrc);
     },
     {
-      message: 'The URL does not match any of the IcrcWalletStandard values.'
+      message: 'The URL does not match any of the IcrcStandard values.'
     }
   );
 
@@ -69,7 +69,7 @@ export const IcrcSupportedStandardsSchema = z
   .array(
     z
       .object({
-        name: IcrcWalletStandardSchema,
+        name: IcrcStandardSchema,
         url: UrlSchema
       })
       .strict()

--- a/src/types/icrc-standards.spec.ts
+++ b/src/types/icrc-standards.spec.ts
@@ -9,10 +9,10 @@ import {
   ICRC29_STATUS
 } from '../constants/icrc.constants';
 import {
-  IcrcWalletApproveMethodSchema,
-  IcrcWalletMethodSchema,
-  IcrcWalletScopedMethodSchema,
-  IcrcWalletStandardSchema
+  IcrcApproveMethodSchema,
+  IcrcMethodSchema,
+  IcrcScopedMethodSchema,
+  IcrcStandardSchema
 } from './icrc-standards';
 
 describe('ICRC standards', () => {
@@ -39,15 +39,12 @@ describe('ICRC standards', () => {
     }
   ];
 
-  it.each(methodEnums)(
-    'should validate $title with IcrcWalletMethodSchema',
-    async ({validEnum}) => {
-      expect(IcrcWalletMethodSchema.safeParse(validEnum).success).toBe(true);
-    }
-  );
+  it.each(methodEnums)('should validate $title with IcrcMethodSchema', async ({validEnum}) => {
+    expect(IcrcMethodSchema.safeParse(validEnum).success).toBe(true);
+  });
 
-  it('should not validate IcrcWalletMethodSchema unkown value', () => {
-    expect(IcrcWalletMethodSchema.safeParse('INVALID_METHOD').success).toBe(false);
+  it('should not validate IcrcMethodSchema unkown value', () => {
+    expect(IcrcMethodSchema.safeParse('INVALID_METHOD').success).toBe(false);
   });
 
   const approveEnums = [
@@ -77,16 +74,16 @@ describe('ICRC standards', () => {
   ];
 
   it.each(approveEnums)(
-    'should validate $title with IcrcWalletApproveMethodSchema',
+    'should validate $title with IcrcApproveMethodSchema',
     async ({validEnum}) => {
-      expect(IcrcWalletApproveMethodSchema.safeParse(validEnum).success).toBe(true);
+      expect(IcrcApproveMethodSchema.safeParse(validEnum).success).toBe(true);
     }
   );
 
   it.each(invalidApproveEnums)(
-    'should not validate $title with IcrcWalletApproveMethodSchema',
+    'should not validate $title with IcrcApproveMethodSchema',
     async ({validEnum}) => {
-      expect(IcrcWalletApproveMethodSchema.safeParse(validEnum).success).toBe(false);
+      expect(IcrcApproveMethodSchema.safeParse(validEnum).success).toBe(false);
     }
   );
 
@@ -116,17 +113,14 @@ describe('ICRC standards', () => {
     }
   ];
 
-  it.each(scopeEnums)(
-    'should validate $title with IcrcWalletScopedMethodSchema',
-    async ({validEnum}) => {
-      expect(IcrcWalletScopedMethodSchema.safeParse(validEnum).success).toBe(true);
-    }
-  );
+  it.each(scopeEnums)('should validate $title with IcrcScopedMethodSchema', async ({validEnum}) => {
+    expect(IcrcScopedMethodSchema.safeParse(validEnum).success).toBe(true);
+  });
 
   it.each(invalidScopeEnums)(
-    'should not validate $title with IcrcWalletScopedMethodSchema',
+    'should not validate $title with IcrcScopedMethodSchema',
     async ({validEnum}) => {
-      expect(IcrcWalletScopedMethodSchema.safeParse(validEnum).success).toBe(false);
+      expect(IcrcScopedMethodSchema.safeParse(validEnum).success).toBe(false);
     }
   );
 
@@ -145,14 +139,11 @@ describe('ICRC standards', () => {
     }
   ];
 
-  it.each(standardEnums)(
-    'should validate $title with IcrcWalletStandardSchema',
-    async ({validEnum}) => {
-      expect(IcrcWalletStandardSchema.safeParse(validEnum).success).toBe(true);
-    }
-  );
+  it.each(standardEnums)('should validate $title with IcrcStandardSchema', async ({validEnum}) => {
+    expect(IcrcStandardSchema.safeParse(validEnum).success).toBe(true);
+  });
 
-  it('should not validate IcrcWalletStandardSchema unknown enum values', () => {
-    expect(IcrcWalletStandardSchema.safeParse('INVALID_STANDARD').success).toBe(false);
+  it('should not validate IcrcStandardSchema unknown enum values', () => {
+    expect(IcrcStandardSchema.safeParse('INVALID_STANDARD').success).toBe(false);
   });
 });

--- a/src/types/icrc-standards.ts
+++ b/src/types/icrc-standards.ts
@@ -15,7 +15,7 @@ import {
   ICRC49_CALL_CANISTER
 } from '../constants/icrc.constants';
 
-export const IcrcWalletMethodSchema = z.enum([
+export const IcrcMethodSchema = z.enum([
   ICRC25_REQUEST_PERMISSIONS,
   ICRC25_PERMISSIONS,
   ICRC25_SUPPORTED_STANDARDS,
@@ -24,27 +24,27 @@ export const IcrcWalletMethodSchema = z.enum([
   ICRC49_CALL_CANISTER
 ]);
 
-export const IcrcWalletApproveMethodSchema = z.enum([
+export const IcrcApproveMethodSchema = z.enum([
   ICRC25_REQUEST_PERMISSIONS,
   ICRC27_ACCOUNTS,
   ICRC49_CALL_CANISTER
 ]);
 
-export type IcrcWalletApproveMethod = z.infer<typeof IcrcWalletApproveMethodSchema>;
+export type IcrcApproveMethod = z.infer<typeof IcrcApproveMethodSchema>;
 
-export const IcrcWalletScopedMethodSchema = IcrcWalletMethodSchema.extract([
+export const IcrcScopedMethodSchema = IcrcMethodSchema.extract([
   ICRC27_ACCOUNTS,
   ICRC49_CALL_CANISTER
 ]);
 
-export type IcrcWalletScopedMethod = z.infer<typeof IcrcWalletScopedMethodSchema>;
+export type IcrcScopedMethod = z.infer<typeof IcrcScopedMethodSchema>;
 
-export const IcrcWalletPermissionStateSchema = z.enum([
+export const IcrcPermissionStateSchema = z.enum([
   ICRC25_PERMISSION_GRANTED,
   ICRC25_PERMISSION_DENIED,
   ICRC25_PERMISSION_ASK_ON_USE
 ]);
 
-export type IcrcWalletPermissionState = z.infer<typeof IcrcWalletPermissionStateSchema>;
+export type IcrcPermissionState = z.infer<typeof IcrcPermissionStateSchema>;
 
-export const IcrcWalletStandardSchema = z.enum([ICRC25, ICRC27, ICRC29, ICRC49]);
+export const IcrcStandardSchema = z.enum([ICRC25, ICRC27, ICRC29, ICRC49]);


### PR DESCRIPTION
# Motivation

No particular reason to called things "IcrcWallet" so we can shorten "Icrc". A bit less verbose.
