### PR TITLE
feat: extract principal module

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ export type * from './types/icrc-accounts';
 export type * from './types/icrc-requests';
 export type * from './types/icrc-responses';
 export type * from './types/icrc-standards';
+export type * from './types/principal';
 export type * from './types/rpc';
 export type * from './types/signer-options';
 export type * from './types/wallet-options';

--- a/src/types/icrc-accounts.spec.ts
+++ b/src/types/icrc-accounts.spec.ts
@@ -1,6 +1,6 @@
 import {Principal} from '@dfinity/principal';
 import {mockPrincipalText} from '../constants/icrc-accounts.mocks';
-import {IcrcAccountSchema, IcrcAccountsSchema, PrincipalTextSchema} from './icrc-accounts';
+import {IcrcAccountSchema, IcrcAccountsSchema} from './icrc-accounts';
 
 describe('ICRC accounts', () => {
   describe('IcrcAccount', () => {
@@ -143,39 +143,6 @@ describe('ICRC accounts', () => {
       const invalidAccounts = [{owner: mockPrincipalText, subaccount: 'invalid-subaccount'}];
       const result = IcrcAccountsSchema.safeParse(invalidAccounts);
       expect(result.success).toBe(false);
-    });
-  });
-
-  describe('PrincipalText', () => {
-    it('should pass validation with a valid Principal string', () => {
-      const result = PrincipalTextSchema.safeParse(mockPrincipalText);
-      expect(result.success).toBe(true);
-    });
-
-    it('should fail validation with an invalid Principal string', () => {
-      const invalidPrincipal = 'invalid-principal';
-      const result = PrincipalTextSchema.safeParse(invalidPrincipal);
-      expect(result.success).toBe(false);
-      if (!result.success) {
-        expect(result.error.errors[0].message).toBe(
-          'Invalid textual representation of a Principal.'
-        );
-      }
-    });
-
-    it('should pass validation with an anonymous Principal', () => {
-      const validPrincipal = Principal.anonymous().toText();
-      const result = PrincipalTextSchema.safeParse(validPrincipal);
-      expect(result.success).toBe(true);
-    });
-
-    it('should fail validation with a non-string input', () => {
-      const invalidPrincipal = 12345;
-      const result = PrincipalTextSchema.safeParse(invalidPrincipal);
-      expect(result.success).toBe(false);
-      if (!result.success) {
-        expect(result.error.errors[0].message).toBe('Expected string, received number');
-      }
     });
   });
 });

--- a/src/types/icrc-accounts.ts
+++ b/src/types/icrc-accounts.ts
@@ -1,6 +1,6 @@
-import {Principal} from '@dfinity/principal';
 import {arrayOfNumberToUint8Array} from '@dfinity/utils';
 import {z} from 'zod';
+import {PrincipalTextSchema} from './principal';
 
 const IcrcSubaccountSchema = z
   .union([z.instanceof(Uint8Array), z.array(z.number())])
@@ -11,20 +11,6 @@ const IcrcSubaccountSchema = z
       message: 'Subaccount must be exactly 32 bytes long.'
     }
   );
-
-export const PrincipalTextSchema = z.string().refine(
-  (principal) => {
-    try {
-      Principal.fromText(principal);
-      return true;
-    } catch (err: unknown) {
-      return false;
-    }
-  },
-  {
-    message: 'Invalid textual representation of a Principal.'
-  }
-);
 
 export const IcrcAccountSchema = z
   .object({

--- a/src/types/principal.spec.ts
+++ b/src/types/principal.spec.ts
@@ -1,0 +1,34 @@
+import {Principal} from '@dfinity/principal';
+import {mockPrincipalText} from '../constants/icrc-accounts.mocks';
+import {PrincipalTextSchema} from './principal';
+
+describe('PrincipalText', () => {
+  it('should pass validation with a valid Principal string', () => {
+    const result = PrincipalTextSchema.safeParse(mockPrincipalText);
+    expect(result.success).toBe(true);
+  });
+
+  it('should fail validation with an invalid Principal string', () => {
+    const invalidPrincipal = 'invalid-principal';
+    const result = PrincipalTextSchema.safeParse(invalidPrincipal);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.errors[0].message).toBe('Invalid textual representation of a Principal.');
+    }
+  });
+
+  it('should pass validation with an anonymous Principal', () => {
+    const validPrincipal = Principal.anonymous().toText();
+    const result = PrincipalTextSchema.safeParse(validPrincipal);
+    expect(result.success).toBe(true);
+  });
+
+  it('should fail validation with a non-string input', () => {
+    const invalidPrincipal = 12345;
+    const result = PrincipalTextSchema.safeParse(invalidPrincipal);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.errors[0].message).toBe('Expected string, received number');
+    }
+  });
+});

--- a/src/types/principal.ts
+++ b/src/types/principal.ts
@@ -1,0 +1,18 @@
+import {Principal} from '@dfinity/principal';
+import {z} from 'zod';
+
+export const PrincipalTextSchema = z.string().refine(
+  (principal) => {
+    try {
+      Principal.fromText(principal);
+      return true;
+    } catch (err: unknown) {
+      return false;
+    }
+  },
+  {
+    message: 'Invalid textual representation of a Principal.'
+  }
+);
+
+export type PrincipalText = z.infer<typeof PrincipalTextSchema>;


### PR DESCRIPTION
# Motivation

Given that `PrincipalText` is not tight anymore to accounts, it make sense to extract it in its own module definition.
