### PR TITLE
feat: ICRC-49 call canister response type

### DIFF
--- a/src/types/icrc-responses.spec.ts
+++ b/src/types/icrc-responses.spec.ts
@@ -7,6 +7,7 @@ import {
 } from '../constants/icrc.constants';
 import {
   IcrcAccountsResponseSchema,
+  IcrcCallCanisterResultResponseSchema,
   IcrcReadyResponseSchema,
   IcrcScopeSchema,
   IcrcScopesResponseSchema,
@@ -642,6 +643,95 @@ describe('icrc-responses', () => {
       };
 
       expect(() => IcrcAccountsResponseSchema.parse(invalidResponse)).toThrow();
+    });
+  });
+
+  describe('icrc49_call_canister', () => {
+    const validResponse = {
+      jsonrpc: JSON_RPC_VERSION_2,
+      id: 1,
+      result: {
+        contentMap: new Uint8Array([1, 2, 3, 4]),
+        certificate: new Uint8Array([5, 6, 7, 8])
+      }
+    };
+
+    it('should validate a correct response', () => {
+      expect(() => IcrcCallCanisterResultResponseSchema.parse(validResponse)).not.toThrow();
+    });
+
+    it('should throw if response has invalid contentMap (not Uint8Array)', () => {
+      const invalidResponse = {
+        ...validResponse,
+        result: {
+          ...validResponse.result,
+          contentMap: 'invalid-content' // Not a Uint8Array
+        }
+      };
+      expect(() => IcrcCallCanisterResultResponseSchema.parse(invalidResponse)).toThrow();
+    });
+
+    it('should throw if response has invalid certificate (not Uint8Array)', () => {
+      const invalidResponse = {
+        ...validResponse,
+        result: {
+          ...validResponse.result,
+          certificate: 'invalid-certificate' // Not a Uint8Array
+        }
+      };
+      expect(() => IcrcCallCanisterResultResponseSchema.parse(invalidResponse)).toThrow();
+    });
+
+    it('should throw if response has missing contentMap', () => {
+      const {contentMap: _, ...rest} = validResponse.result;
+
+      const invalidResponse = {
+        ...validResponse,
+        result: rest
+      };
+      expect(() => IcrcCallCanisterResultResponseSchema.parse(invalidResponse)).toThrow();
+    });
+
+    it('should throw if response has missing certificate', () => {
+      const {certificate: _, ...rest} = validResponse.result;
+
+      const invalidResponse = {
+        ...validResponse,
+        result: rest
+      };
+      expect(() => IcrcCallCanisterResultResponseSchema.parse(invalidResponse)).toThrow();
+    });
+
+    it('should throw if response has extra fields in result', () => {
+      const invalidResponse = {
+        ...validResponse,
+        result: {
+          ...validResponse.result,
+          extraField: 'unexpected'
+        }
+      };
+      expect(() => IcrcCallCanisterResultResponseSchema.parse(invalidResponse)).toThrow();
+    });
+
+    it('should throw if response has no result field', () => {
+      const {result: _, ...rest} = validResponse;
+
+      const invalidResponse = rest;
+      expect(() => IcrcCallCanisterResultResponseSchema.parse(invalidResponse)).toThrow();
+    });
+
+    it('should throw if response has no id', () => {
+      const {id: _, ...rest} = validResponse;
+
+      const invalidResponse = rest;
+      expect(() => IcrcCallCanisterResultResponseSchema.parse(invalidResponse)).toThrow();
+    });
+
+    it('should throw if response has no jsonrpc field', () => {
+      const {jsonrpc: _, ...rest} = validResponse;
+
+      const invalidResponse = rest;
+      expect(() => IcrcCallCanisterResultResponseSchema.parse(invalidResponse)).toThrow();
     });
   });
 });

--- a/src/types/icrc-responses.ts
+++ b/src/types/icrc-responses.ts
@@ -1,4 +1,5 @@
 import {z} from 'zod';
+import {IcrcBlob} from './blob';
 import {IcrcAccountsSchema} from './icrc-accounts';
 import {
   IcrcPermissionStateSchema,
@@ -103,3 +104,19 @@ export const IcrcAccountsResponseSchema = inferRpcResponseSchema(
 );
 
 export type IcrcAccountsResponse = z.infer<typeof IcrcAccountsResponseSchema>;
+
+// icrc49_call_canister
+// https://github.com/dfinity/wg-identity-authentication/blob/main/topics/icrc_49_call_canister.md
+
+const IcrcCallCanisterResultSchema = z.object({
+  contentMap: IcrcBlob,
+  certificate: IcrcBlob
+});
+
+export type IcrcCallCanisterResult = z.infer<typeof IcrcCallCanisterResultSchema>;
+
+export const IcrcCallCanisterResultResponseSchema = inferRpcResponseSchema(
+  IcrcCallCanisterResultSchema.strict()
+);
+
+export type IcrcCallCanisterResultResponse = z.infer<typeof IcrcCallCanisterResultResponseSchema>;


### PR DESCRIPTION
# Motivation

It might change along the way of the implementation but we need a type for ICRC-49 canister call response.
