### PR TITLE
build: add peer dependency candid to library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "node": ">=20"
       },
       "peerDependencies": {
+        "@dfinity/candid": "^2.0.0",
         "@dfinity/principal": "^2.0.0",
         "@dfinity/utils": "^2.4.0-next-2024-08-28",
         "zod": "^3.23.8"

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "node": ">=20"
   },
   "peerDependencies": {
+    "@dfinity/candid": "^2.0.0",
     "@dfinity/principal": "^2.0.0",
     "@dfinity/utils": "^2.4.0-next-2024-08-28",
     "zod": "^3.23.8"


### PR DESCRIPTION
# Motivation

We don't want to have the relying party to have to deal with encoding that's why we add candid to the list of dependencies that way we can obfuscte that conversion and expose an API that require argument and argument's type.
