### PR TITLE
chore: start party and wallet with Playwright

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -3,11 +3,18 @@ import {defineConfig, devices} from '@playwright/test';
 const DEV = (process.env.NODE_ENV ?? 'production') === 'development';
 
 export default defineConfig({
-  webServer: {
-    command: 'npm run dev:party --prefix demo',
-    reuseExistingServer: true,
-    port: 5173
-  },
+  webServer: [
+    {
+      command: 'npm run dev:party --prefix demo',
+      reuseExistingServer: true,
+      port: 5173
+    },
+    {
+      command: 'npm run dev:wallet --prefix demo',
+      reuseExistingServer: true,
+      port: 5174
+    }
+  ],
   testDir: 'e2e',
   testMatch: ['**/*.e2e.ts', '**/*.spec.ts'],
   timeout: 60000,


### PR DESCRIPTION
# Motivation

Cool stuffs, Playwright can start multiple servers. We can leverage this feature to start both the relying party and wallet demo dApps in our e2e tests.
