### PR TITLE
refactor: extract notify denied permission

### DIFF
--- a/src/handlers/signer.handlers.spec.ts
+++ b/src/handlers/signer.handlers.spec.ts
@@ -12,6 +12,7 @@ import {JSON_RPC_VERSION_2, type RpcId, type RpcResponseWithError} from '../type
 import {
   notifyAccounts,
   notifyError,
+  notifyErrorPermissionNotGranted,
   notifyPermissionScopes,
   notifyReady,
   notifySupportedStandards
@@ -121,6 +122,26 @@ describe('Signer handlers', () => {
         jsonrpc: JSON_RPC_VERSION_2,
         id,
         result: {accounts: mockAccounts}
+      };
+
+      expect(postMessageMock).toHaveBeenCalledWith(expectedMessage, origin);
+    });
+  });
+
+  describe('notifyErrorPermissionNotGranted', () => {
+    it('should post an error message indicating permission not granted', () => {
+      const error = {
+        code: SignerErrorCode.PERMISSION_NOT_GRANTED,
+        message:
+          'The signer has not granted the necessary permissions to process the request from the relying party.'
+      };
+
+      notifyErrorPermissionNotGranted({id, origin});
+
+      const expectedMessage: RpcResponseWithError = {
+        jsonrpc: JSON_RPC_VERSION_2,
+        id,
+        error
       };
 
       expect(postMessageMock).toHaveBeenCalledWith(expectedMessage, origin);

--- a/src/handlers/signer.handlers.ts
+++ b/src/handlers/signer.handlers.ts
@@ -1,4 +1,4 @@
-import {SIGNER_SUPPORTED_STANDARDS} from '../constants/signer.constants';
+import {SIGNER_SUPPORTED_STANDARDS, SignerErrorCode} from '../constants/signer.constants';
 import type {IcrcAccounts} from '../types/icrc-accounts';
 import type {
   IcrcAccountsResponse,
@@ -64,6 +64,17 @@ export const notifyAccounts = ({id, origin, accounts}: NotifyAccounts): void => 
   };
 
   notify({msg, origin});
+};
+
+export const notifyErrorPermissionNotGranted = (notify: Notify): void => {
+  notifyError({
+    ...notify,
+    error: {
+      code: SignerErrorCode.PERMISSION_NOT_GRANTED,
+      message:
+        'The signer has not granted the necessary permissions to process the request from the relying party.'
+    }
+  });
 };
 
 export const notifyError = ({

--- a/src/signer.ts
+++ b/src/signer.ts
@@ -5,6 +5,7 @@ import {SIGNER_DEFAULT_SCOPES, SignerErrorCode} from './constants/signer.constan
 import {
   notifyAccounts,
   notifyError,
+  notifyErrorPermissionNotGranted,
   notifyPermissionScopes,
   notifyReady,
   notifySupportedStandards,
@@ -393,18 +394,6 @@ export class Signer {
         });
       };
 
-      const notifyDeniedAccounts = (): void => {
-        notifyError({
-          id: requestId ?? null,
-          origin,
-          error: {
-            code: SignerErrorCode.PERMISSION_NOT_GRANTED,
-            message:
-              'The signer has not granted the necessary permissions to process the request from the relying party.'
-          }
-        });
-      };
-
       const permission = await this.assertAndPromptPermissions({
         method: ICRC27_ACCOUNTS,
         requestId,
@@ -413,7 +402,10 @@ export class Signer {
 
       switch (permission) {
         case 'denied': {
-          notifyDeniedAccounts();
+          notifyErrorPermissionNotGranted({
+            id: requestId ?? null,
+            origin
+          });
           break;
         }
         case 'granted': {


### PR DESCRIPTION
# Motivation

Extract notify denied permission in a standalone function which can be reused. Useful as we are going to need it for "call canister" as well.
