### PR TITLE
feat: add an agent to signer options

### DIFF
--- a/demo/src/wallet_frontend/src/routes/+page.svelte
+++ b/demo/src/wallet_frontend/src/routes/+page.svelte
@@ -4,7 +4,7 @@
 	import UserId from '$core/components/UserId.svelte';
 	import ConfirmPermissions from '$lib/ConfirmPermissions.svelte';
 	import { authStore } from '$core/stores/auth.store';
-	import { isNullish } from '@dfinity/utils';
+	import { defaultAgent, isNullish } from '@dfinity/utils';
 	import ConfirmAccounts from '$lib/ConfirmAccounts.svelte';
 
 	let signer: Signer | undefined = $state(undefined);
@@ -21,7 +21,8 @@
 		}
 
 		signer = Signer.init({
-			owner: $authStore.identity.getPrincipal()
+			owner: $authStore.identity.getPrincipal(),
+			agent: defaultAgent()
 		});
 
 		return () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "node": ">=20"
       },
       "peerDependencies": {
+        "@dfinity/agent": "^2.0.0",
         "@dfinity/candid": "^2.0.0",
         "@dfinity/principal": "^2.0.0",
         "@dfinity/utils": "^2.5.0",

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "node": ">=20"
   },
   "peerDependencies": {
+    "@dfinity/agent": "^2.0.0",
     "@dfinity/candid": "^2.0.0",
     "@dfinity/principal": "^2.0.0",
     "@dfinity/utils": "^2.5.0",

--- a/src/signer.spec.ts
+++ b/src/signer.spec.ts
@@ -1,3 +1,4 @@
+import {HttpAgent} from '@dfinity/agent';
 import {Ed25519KeyIdentity} from '@dfinity/identity';
 import type {MockInstance} from 'vitest';
 import {mockAccounts, mockPrincipalText} from './constants/icrc-accounts.mocks';
@@ -39,9 +40,18 @@ import {
 import type {SessionPermissions} from './types/signer-sessions';
 import {del, get} from './utils/storage.utils';
 
+vi.mock('@dfinity/agent', async (importOriginal) => {
+  return {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-imports
+    ...(await importOriginal<typeof import('@dfinity/agent')>()),
+    createSync: vi.fn()
+  };
+});
+
 describe('Signer', () => {
   const signerOptions: SignerOptions = {
-    owner: Ed25519KeyIdentity.generate().getPrincipal()
+    owner: Ed25519KeyIdentity.generate().getPrincipal(),
+    agent: HttpAgent.createSync()
   };
 
   it('should init a signer', () => {

--- a/src/signer.ts
+++ b/src/signer.ts
@@ -1,3 +1,4 @@
+import type {Agent} from '@dfinity/agent';
 import type {Principal} from '@dfinity/principal';
 import {assertNonNullish, isNullish, nonNullish} from '@dfinity/utils';
 import {
@@ -54,14 +55,16 @@ class MissingPromptError extends Error {}
 
 export class Signer {
   readonly #owner: Principal;
+  readonly #agent: Agent;
 
   #walletOrigin: string | undefined | null;
 
   #permissionsPrompt: PermissionsPrompt | undefined;
   #accountsPrompt: AccountsPrompt | undefined;
 
-  private constructor({owner}: SignerOptions) {
+  private constructor({owner, agent}: SignerOptions) {
     this.#owner = owner;
+    this.#agent = agent;
 
     window.addEventListener('message', this.onMessageListener);
   }

--- a/src/types/signer-options.spec.ts
+++ b/src/types/signer-options.spec.ts
@@ -1,37 +1,92 @@
-import {AnonymousIdentity} from '@dfinity/agent';
+import {AnonymousIdentity, HttpAgent, ProxyAgent} from '@dfinity/agent';
 import {Ed25519KeyIdentity} from '@dfinity/identity';
+import {describe} from 'vitest';
 import {SignerOptionsSchema} from './signer-options';
 
+vi.mock('@dfinity/agent', async (importOriginal) => {
+  return {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-imports
+    ...(await importOriginal<typeof import('@dfinity/agent')>()),
+    createSync: vi.fn()
+  };
+});
+
 describe('SignerOptions', () => {
-  it('should validate a valid owner', () => {
-    const identity = Ed25519KeyIdentity.generate();
+  describe('Owner', () => {
+    const agent = HttpAgent.createSync();
 
-    const validSignerOptions = {
-      owner: identity.getPrincipal()
-    };
+    it('should validate a valid owner', () => {
+      const identity = Ed25519KeyIdentity.generate();
 
-    expect(() => SignerOptionsSchema.parse(validSignerOptions)).not.toThrow();
+      const validSignerOptions = {
+        owner: identity.getPrincipal(),
+        agent
+      };
+
+      expect(() => SignerOptionsSchema.parse(validSignerOptions)).not.toThrow();
+    });
+
+    it('should throw an error for invalid principal', () => {
+      const invalidPrincipal = {id: 'not-a-principal'};
+
+      const invalidSignerOptions = {
+        owner: invalidPrincipal,
+        agent
+      };
+
+      expect(() => SignerOptionsSchema.parse(invalidSignerOptions)).toThrow(
+        'The value provided is not a valid Principal.'
+      );
+    });
+
+    it('should throw an error for an anonymous Principal', () => {
+      const invalidSignerOptions = {
+        owner: new AnonymousIdentity().getPrincipal(),
+        agent
+      };
+
+      expect(() => SignerOptionsSchema.parse(invalidSignerOptions)).toThrow(
+        'The Principal is anonymous and cannot be used.'
+      );
+    });
   });
 
-  it('should throw an error for invalid principal', () => {
-    const invalidPrincipal = {id: 'not-a-principal'};
+  describe('Agent', () => {
+    const owner = Ed25519KeyIdentity.generate().getPrincipal();
 
-    const invalidSignerOptions = {
-      owner: invalidPrincipal
-    };
+    it('should validate a valid HttpAgent', () => {
+      const agent = HttpAgent.createSync();
 
-    expect(() => SignerOptionsSchema.parse(invalidSignerOptions)).toThrow(
-      'The value provided is not a valid Principal.'
-    );
-  });
+      const validSignerOptions = {
+        owner,
+        agent
+      };
 
-  it('should throw an error for an anonymous Principal', () => {
-    const invalidSignerOptions = {
-      owner: new AnonymousIdentity().getPrincipal()
-    };
+      expect(() => SignerOptionsSchema.parse(validSignerOptions)).not.toThrow();
+    });
 
-    expect(() => SignerOptionsSchema.parse(invalidSignerOptions)).toThrow(
-      'The Principal is anonymous and cannot be used.'
-    );
+    it('should validate a valid ProxyAgent', () => {
+      const agent = new ProxyAgent(() => undefined);
+
+      const validSignerOptions = {
+        owner,
+        agent
+      };
+
+      expect(() => SignerOptionsSchema.parse(validSignerOptions)).not.toThrow();
+    });
+
+    it('should throw an error for an invalid agent', () => {
+      const invalidAgent = {};
+
+      const invalidSignerOptions = {
+        owner,
+        agent: invalidAgent
+      };
+
+      expect(() => SignerOptionsSchema.parse(invalidSignerOptions)).toThrow(
+        'Invalid agent instance.'
+      );
+    });
   });
 });

--- a/src/types/signer-options.ts
+++ b/src/types/signer-options.ts
@@ -1,3 +1,4 @@
+import {HttpAgent, ProxyAgent, type Agent} from '@dfinity/agent';
 import {Principal} from '@dfinity/principal';
 import {z} from 'zod';
 
@@ -41,7 +42,16 @@ export const SignerOptionsSchema = z.object({
    * When the signer is initialized, the owner should be signed in to the consumer dApp.
    * Upon signing out, it is up to the consumer to disconnect the signer.
    */
-  owner: PrincipalNotAnonymousSchema
+  owner: PrincipalNotAnonymousSchema,
+
+  /**
+   * An agent that the signer can use to fetch the consent message during a canister call.
+   *
+   * This should be an instance of either `HttpAgent` or `ProxyAgent`.
+   */
+  agent: z.custom<Agent>((agent) => agent instanceof ProxyAgent || agent instanceof HttpAgent, {
+    message: 'Invalid agent instance.'
+  })
 });
 
 export type SignerOptions = z.infer<typeof SignerOptionsSchema>;


### PR DESCRIPTION
# Motivation

We do not want to create an agent in the signer library but let the consumer (the wallet) pass the agent. At least for this first iteration. The agent should for example now if dev mode or production and not sure that I'm a fan of adding some related checks in the library at this point therefore using a parameter.
