### PR TITLE
feat: replace agent option with mode

### DIFF
--- a/src/signer.spec.ts
+++ b/src/signer.spec.ts
@@ -1,4 +1,3 @@
-import {HttpAgent} from '@dfinity/agent';
 import {Ed25519KeyIdentity} from '@dfinity/identity';
 import type {MockInstance} from 'vitest';
 import {mockAccounts, mockPrincipalText} from './constants/icrc-accounts.mocks';
@@ -41,20 +40,12 @@ import {
 import type {SessionPermissions} from './types/signer-sessions';
 import {del, get} from './utils/storage.utils';
 
-vi.mock('@dfinity/agent', async (importOriginal) => {
-  return {
-    // eslint-disable-next-line @typescript-eslint/consistent-type-imports
-    ...(await importOriginal<typeof import('@dfinity/agent')>()),
-    createSync: vi.fn()
-  };
-});
-
 describe('Signer', () => {
   const identity = Ed25519KeyIdentity.generate();
 
   const signerOptions: SignerOptions = {
     owner: identity,
-    agent: HttpAgent.createSync()
+    mode: 'development'
   };
 
   it('should init a signer', () => {

--- a/src/types/signer-options.ts
+++ b/src/types/signer-options.ts
@@ -1,4 +1,4 @@
-import {HttpAgent, ProxyAgent, type Agent, type Identity} from '@dfinity/agent';
+import {type Identity} from '@dfinity/agent';
 import {isNullish} from '@dfinity/utils';
 import {z} from 'zod';
 
@@ -28,6 +28,10 @@ const IdentityNotAnonymousSchema = IdentitySchema.refine(
 
 export type IdentityNotAnonymous = z.infer<typeof IdentityNotAnonymousSchema>;
 
+export const SignerModeSchema = z.enum(['production', 'development']);
+
+export type SignerMode = z.infer<typeof SignerModeSchema>;
+
 export const SignerOptionsSchema = z.object({
   /**
    * The owner who interacts with the signer.
@@ -37,17 +41,12 @@ export const SignerOptionsSchema = z.object({
    */
   owner: IdentityNotAnonymousSchema,
 
-  // TODO: instead of an agent, should the consumer only pas a "DEV" mode?
-  // The library can take care of creating the Anonymous agent for consent message, at least for now.
-
   /**
-   * An agent that the signer can use to fetch the consent message during a canister call.
-   *
-   * This should be an instance of either `HttpAgent` or `ProxyAgent`.
+   * The mode in which the signer is running.
+   * Can be either "production" or "development". In "development" mode, a local agent that tries to fetch the root key locally will be used.
+   * Defaults to "production".
    */
-  agent: z.custom<Agent>((agent) => agent instanceof ProxyAgent || agent instanceof HttpAgent, {
-    message: 'Invalid agent instance.'
-  })
+  mode: SignerModeSchema.default('production')
 });
 
 export type SignerOptions = z.infer<typeof SignerOptionsSchema>;


### PR DESCRIPTION
# Motivation

We are going to use the owner identity for call purposes (see #162) therefore we do not need an optional agent as we aim to create one within the lib. However we need an information to get to know if we need to fetch the local root key for the agent or not.