### PR TITLE
feat: create agent

### DIFF
--- a/src/api/actors.api.spec.ts
+++ b/src/api/actors.api.spec.ts
@@ -1,7 +1,11 @@
-import {Actor, HttpAgent} from '@dfinity/agent';
+import {Actor} from '@dfinity/agent';
+import {Ed25519KeyIdentity} from '@dfinity/identity';
+import {createAgent} from '@dfinity/utils';
+import {beforeEach} from 'vitest';
 import {mockCanisterId} from '../constants/icrc-accounts.mocks';
 import {idlFactory} from '../declarations/icrc-21.idl';
-import {getIcrc21Actor} from './actors.api';
+import type {SignerOptions} from '../types/signer-options';
+import {getIcrc21Actor, resetActors} from './actors.api';
 
 vi.mock('@dfinity/agent', async (importOriginal) => {
   // eslint-disable-next-line @typescript-eslint/consistent-type-imports
@@ -19,16 +23,58 @@ vi.mock('@dfinity/agent', async (importOriginal) => {
   };
 });
 
-describe('getIcrc21Actor', () => {
-  const agent = HttpAgent.createSync();
+vi.mock('@dfinity/utils', async (importOriginal) => {
+  const mockAgent = {test: 456};
 
-  it('should create a new actor when none exists', async () => {
-    const result = await getIcrc21Actor({agent, canisterId: mockCanisterId});
+  return {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-imports
+    ...(await importOriginal<typeof import('@dfinity/utils')>()),
+    createAgent: vi.fn().mockResolvedValue(mockAgent)
+  };
+});
+
+describe('getIcrc21Actor', () => {
+  const signerOptions: SignerOptions = {
+    owner: Ed25519KeyIdentity.generate(),
+    host: 'http://localhost:5987'
+  };
+
+  beforeEach(() => {
+    resetActors();
+    vi.clearAllMocks();
+  });
+
+  it('should create a new actor when none exists for local development', async () => {
+    const result = await getIcrc21Actor({canisterId: mockCanisterId, ...signerOptions});
+
+    expect(createAgent).toHaveBeenNthCalledWith(1, {
+      host: signerOptions.host,
+      identity: signerOptions.owner,
+      fetchRootKey: true
+    });
 
     // TODO: spyOn nor function does work with vitest and Actor.createActor. Not against a better idea than disabling eslint for next line.
     // eslint-disable-next-line @typescript-eslint/unbound-method
     expect(Actor.createActor).toHaveBeenCalledWith(idlFactory, {
-      agent,
+      agent: {test: 456},
+      canisterId: mockCanisterId
+    });
+
+    expect(result).toStrictEqual({test: 123});
+  });
+
+  it('should create a new actor when none exists for mainnet', async () => {
+    const result = await getIcrc21Actor({canisterId: mockCanisterId, owner: signerOptions.owner});
+
+    expect(createAgent).toHaveBeenNthCalledWith(1, {
+      host: 'https://icp-api.io',
+      identity: signerOptions.owner
+    });
+
+    // TODO: spyOn nor function does work with vitest and Actor.createActor. Not against a better idea than disabling eslint for next line.
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(Actor.createActor).toHaveBeenCalledWith(idlFactory, {
+      agent: {test: 456},
       canisterId: mockCanisterId
     });
 
@@ -36,10 +82,24 @@ describe('getIcrc21Actor', () => {
   });
 
   it('should return an existing actor if it is already created', async () => {
-    const actor = await getIcrc21Actor({agent, canisterId: mockCanisterId});
+    const actor = await getIcrc21Actor({canisterId: mockCanisterId, ...signerOptions});
 
-    const actorAgain = await getIcrc21Actor({agent, canisterId: mockCanisterId});
+    const actorAgain = await getIcrc21Actor({canisterId: mockCanisterId, ...signerOptions});
 
     expect(actorAgain).toBe(actor);
+  });
+
+  it('should clear the cached actors after resetActors is called', async () => {
+    await getIcrc21Actor({canisterId: mockCanisterId, ...signerOptions});
+
+    expect(createAgent).toHaveBeenCalledTimes(1);
+
+    resetActors();
+
+    const newActor = await getIcrc21Actor({canisterId: mockCanisterId, ...signerOptions});
+
+    expect(createAgent).toHaveBeenCalledTimes(2);
+
+    expect(newActor).toStrictEqual({test: 123});
   });
 });

--- a/src/api/canister.api.ts
+++ b/src/api/canister.api.ts
@@ -1,19 +1,18 @@
-import type {Identity} from '@dfinity/agent';
 import type {Principal} from '@dfinity/principal';
 import type {
   icrc21_consent_message_request,
   icrc21_consent_message_response
 } from '../declarations/icrc-21';
+import type {SignerOptions} from '../types/signer-options';
 import {getIcrc21Actor} from './actors.api';
 
 export const consentMessage = async ({
   request,
   ...actorParams
 }: {
-  identity: Identity;
   canisterId: string | Principal;
   request: icrc21_consent_message_request;
-}): Promise<icrc21_consent_message_response> => {
+} & SignerOptions): Promise<icrc21_consent_message_response> => {
   const {icrc21_canister_call_consent_message: canisterCallConsentMessage} =
     await getIcrc21Actor(actorParams);
   return await canisterCallConsentMessage(request);

--- a/src/signer.spec.ts
+++ b/src/signer.spec.ts
@@ -1,5 +1,6 @@
 import {Ed25519KeyIdentity} from '@dfinity/identity';
 import type {MockInstance} from 'vitest';
+import * as actors from './api/actors.api';
 import {mockAccounts, mockPrincipalText} from './constants/icrc-accounts.mocks';
 import {
   ICRC25_PERMISSIONS,
@@ -62,13 +63,30 @@ describe('Signer', () => {
     signer.disconnect();
   });
 
-  it('should remove event listener for message on connect', () => {
+  it('should remove event listener for message on disconnect', () => {
     const removeEventListenerSpy = vi.spyOn(window, 'removeEventListener');
 
     const signer = Signer.init(signerOptions);
     signer.disconnect();
 
     expect(removeEventListenerSpy).toHaveBeenCalledWith('message', expect.any(Function));
+  });
+
+  it('should clean actors on disconnect', () => {
+    const removeEventListenerSpy = vi.spyOn(window, 'removeEventListener');
+
+    const signer = Signer.init(signerOptions);
+    signer.disconnect();
+
+    expect(removeEventListenerSpy).toHaveBeenCalledWith('message', expect.any(Function));
+  });
+
+  it('should clean actors on disconnect', () => {
+    const spy = vi.spyOn(actors, 'resetActors');
+
+    const signer = Signer.init(signerOptions);
+    signer.disconnect();
+    expect(spy).toHaveBeenNthCalledWith(1);
   });
 
   describe('onMessage', () => {

--- a/src/signer.ts
+++ b/src/signer.ts
@@ -1,4 +1,5 @@
 import {assertNonNullish, isNullish, nonNullish} from '@dfinity/utils';
+import {resetActors} from './api/actors.api';
 import {
   ICRC25_REQUEST_PERMISSIONS,
   ICRC27_ACCOUNTS,
@@ -50,7 +51,6 @@ import {
   type PermissionsConfirmation,
   type PermissionsPrompt
 } from './types/signer-prompts';
-import {resetActors} from "./api/actors.api";
 
 class MissingPromptError extends Error {}
 


### PR DESCRIPTION
# Motivation

We want to create the actors with the identity of the consumer of the signer library within the library. We also want to clean the cache when the lib is disconnected.
