### PR TITLE
feat: service to assert, fetch and prompt for consent message

### DIFF
--- a/src/services/signer.services.spec.ts
+++ b/src/services/signer.services.spec.ts
@@ -1,13 +1,149 @@
-import {beforeEach, type Mock} from 'vitest';
+import {Ed25519KeyIdentity} from '@dfinity/identity';
+import type {Mock, MockInstance} from 'vitest';
+import * as api from '../api/canister.api';
+import {consentMessage} from '../api/canister.api';
+import {mockPrincipalText} from '../constants/icrc-accounts.mocks';
 import {SignerErrorCode} from '../constants/signer.constants';
+import type {icrc21_consent_info} from '../declarations/icrc-21';
+import type {IcrcCallCanisterRequestParams} from '../types/icrc-requests';
 import {JSON_RPC_VERSION_2, type RpcId, type RpcResponseWithError} from '../types/rpc';
-import {notifyErrorPermissionNotGranted} from './signer.services';
+import type {SignerOptions} from '../types/signer-options';
+import type {ConsentMessagePromptPayload} from '../types/signer-prompts';
+import {assertAndPromptConsentMessage, notifyErrorPermissionNotGranted} from './signer.services';
 
 describe('Signer services', () => {
   let requestId: RpcId;
+  let spy: MockInstance;
+
+  const mockConsentInfo: icrc21_consent_info = {
+    consent_message: {GenericDisplayMessage: 'Test Consent Message'},
+    metadata: {
+      language: 'en',
+      utc_offset_minutes: [0]
+    }
+  };
+
+  const params: IcrcCallCanisterRequestParams = {
+    canisterId: mockPrincipalText,
+    sender: mockPrincipalText,
+    method: 'some_method',
+    arg: new Uint8Array([1, 2, 3, 4])
+  };
+
+  const signerOptions: SignerOptions = {
+    owner: Ed25519KeyIdentity.generate(),
+    host: 'http://localhost:5987'
+  };
 
   beforeEach(() => {
     requestId = crypto.randomUUID();
+    spy = vi.spyOn(api, 'consentMessage');
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('assertAndPromptConsentMessage', () => {
+    it('should return approved when user approves the consent message', async () => {
+      spy.mockResolvedValue({
+        Ok: mockConsentInfo
+      });
+
+      const prompt = ({approve}: ConsentMessagePromptPayload): void => {
+        approve();
+      };
+
+      const result = await assertAndPromptConsentMessage({
+        requestId,
+        params,
+        prompt,
+        ...signerOptions
+      });
+
+      expect(result).toEqual({result: 'approved'});
+
+      expect(consentMessage).toHaveBeenCalledWith({
+        ...signerOptions,
+        canisterId: params.canisterId,
+        request: {
+          method: params.method,
+          arg: params.arg,
+          user_preferences: {
+            metadata: {language: 'en', utc_offset_minutes: []},
+            device_spec: []
+          }
+        }
+      });
+    });
+
+    it('should return rejected when user rejects the consent message', async () => {
+      spy.mockResolvedValue({
+        Ok: mockConsentInfo
+      });
+
+      const prompt = ({reject}: ConsentMessagePromptPayload): void => {
+        reject();
+      };
+
+      const result = await assertAndPromptConsentMessage({
+        requestId,
+        params,
+        prompt,
+        ...signerOptions
+      });
+
+      expect(result).toEqual({result: 'rejected'});
+    });
+
+    it('should return error when consentMessage returns error', async () => {
+      spy.mockResolvedValue({
+        Err: {GenericError: {description: 'Error', error_code: 1n}}
+      });
+
+      const prompt = vi.fn();
+
+      const result = await assertAndPromptConsentMessage({
+        requestId,
+        params,
+        prompt,
+        ...signerOptions
+      });
+
+      expect(result).toEqual({result: 'error'});
+      expect(prompt).not.toHaveBeenCalled();
+    });
+
+    it.skip('should throw MissingPromptError if prompt is undefined', async () => {
+      // TODO: missing prompt error test
+      // try {
+      //   await assertAndPromptConsentMessage({
+      //     requestId,
+      //     params,
+      //     prompt: undefined,
+      //     ...signerOptions
+      //   });
+      // } catch (error) {
+      //   expect(error).toBeInstanceOf(MissingPromptError);
+      // }
+    });
+
+    it('should return error if consentMessage throws', async () => {
+      spy.mockRejectedValue(new Error('Test Error'));
+
+      const prompt = vi.fn();
+
+      const result = await assertAndPromptConsentMessage({
+        requestId,
+        params,
+        prompt,
+        ...signerOptions
+      });
+
+      expect(result).toEqual({result: 'error'});
+
+      expect(prompt).not.toHaveBeenCalled();
+    });
   });
 
   describe('notifyErrorPermissionNotGranted', () => {

--- a/src/services/signer.services.ts
+++ b/src/services/signer.services.ts
@@ -1,6 +1,87 @@
+import {isNullish} from '@dfinity/utils';
+import {consentMessage} from '../api/canister.api';
 import {SignerErrorCode} from '../constants/signer.constants';
+import type {icrc21_consent_info} from '../declarations/icrc-21';
 import {notifyError} from '../handlers/signer.handlers';
+import type {IcrcCallCanisterRequestParams} from '../types/icrc-requests';
+import type {RpcId} from '../types/rpc';
+import {MissingPromptError} from '../types/signer-errors';
 import type {Notify} from '../types/signer-handlers';
+import type {SignerOptions} from '../types/signer-options';
+import type {ConsentMessageAnswer, ConsentMessagePrompt} from '../types/signer-prompts';
+
+export const assertAndPromptConsentMessage = async ({
+  requestId: _,
+  params: {canisterId, method, arg},
+  prompt,
+  ...rest
+}: {
+  params: IcrcCallCanisterRequestParams;
+  requestId: RpcId;
+  prompt: ConsentMessagePrompt | undefined;
+} & SignerOptions): Promise<{result: 'approved' | 'rejected' | 'error'}> => {
+  // TODO: asserting that the sender = owner of the accounts = principal derived by II in the signer
+  // i.e. sender === this.#owner
+
+  try {
+    const response = await consentMessage({
+      ...rest,
+      canisterId,
+      request: {
+        method,
+        arg,
+        // TODO: consumer should be able to define user_preferences
+        user_preferences: {
+          metadata: {
+            language: 'en',
+            utc_offset_minutes: []
+          },
+          device_spec: []
+        }
+      }
+    });
+
+    if ('Err' in response) {
+      // TODO: notify error
+      return {result: 'error'};
+    }
+
+    const {Ok: consentInfo} = response;
+
+    return await promptConsentMessage({consentInfo, prompt});
+  } catch (err: unknown) {
+    // TODO: notify error
+    return {result: 'error'};
+  }
+};
+
+const promptConsentMessage = async ({
+  prompt,
+  consentInfo
+}: {
+  consentInfo: icrc21_consent_info;
+  prompt: ConsentMessagePrompt | undefined;
+}): Promise<{result: 'approved' | 'rejected'}> => {
+  const promise = new Promise<{result: 'approved' | 'rejected'}>((resolve, reject) => {
+    const approve: ConsentMessageAnswer = () => {
+      resolve({result: 'approved'});
+    };
+
+    const userReject: ConsentMessageAnswer = () => {
+      resolve({result: 'rejected'});
+    };
+
+    // The consumer currently has no way to unregister the prompt, so we know that it is defined. However, to be future-proof, it's better to ensure it is defined.
+    if (isNullish(prompt)) {
+      reject(new MissingPromptError());
+      return;
+    }
+
+    prompt({approve, reject: userReject, consentInfo});
+  });
+
+  return await promise;
+};
 
 export const notifyErrorPermissionNotGranted = (notify: Notify): void => {
   notifyError({


### PR DESCRIPTION
# Motivation

When a relying party request a call to a canister the signer should prompt the user with a consent message.
