### PR TITLE
feat: assert and prompt consent message

### DIFF
--- a/src/mocks/consent-message.mocks.ts
+++ b/src/mocks/consent-message.mocks.ts
@@ -1,0 +1,9 @@
+import type {icrc21_consent_info} from '../declarations/icrc-21';
+
+export const mockConsentInfo: icrc21_consent_info = {
+  consent_message: {GenericDisplayMessage: 'Test Consent Message'},
+  metadata: {
+    language: 'en',
+    utc_offset_minutes: [0]
+  }
+};

--- a/src/services/signer.services.spec.ts
+++ b/src/services/signer.services.spec.ts
@@ -3,7 +3,7 @@ import type {Mock, MockInstance} from 'vitest';
 import * as api from '../api/canister.api';
 import {consentMessage} from '../api/canister.api';
 import {SignerErrorCode} from '../constants/signer.constants';
-import type {icrc21_consent_info} from '../declarations/icrc-21';
+import {mockConsentInfo} from '../mocks/consent-message.mocks';
 import {mockPrincipalText} from '../mocks/icrc-accounts.mocks';
 import type {IcrcCallCanisterRequestParams} from '../types/icrc-requests';
 import {JSON_RPC_VERSION_2, type RpcId, type RpcResponseWithError} from '../types/rpc';
@@ -14,14 +14,6 @@ import {assertAndPromptConsentMessage, notifyErrorPermissionNotGranted} from './
 describe('Signer services', () => {
   let requestId: RpcId;
   let spy: MockInstance;
-
-  const mockConsentInfo: icrc21_consent_info = {
-    consent_message: {GenericDisplayMessage: 'Test Consent Message'},
-    metadata: {
-      language: 'en',
-      utc_offset_minutes: [0]
-    }
-  };
 
   const params: IcrcCallCanisterRequestParams = {
     canisterId: mockPrincipalText,

--- a/src/services/signer.services.ts
+++ b/src/services/signer.services.ts
@@ -42,7 +42,7 @@ export const assertAndPromptConsentMessage = async ({
     });
 
     if ('Err' in response) {
-      // TODO: notify error
+      // TODO: notify error 2000
       return {result: 'error'};
     }
 
@@ -50,7 +50,9 @@ export const assertAndPromptConsentMessage = async ({
 
     return await promptConsentMessage({consentInfo, prompt});
   } catch (err: unknown) {
-    // TODO: notify error
+    // TODO: 2000 for not supported consent message - i.e. method is not implemented
+    // TODO: fine grained error for example out of cycles, stopped etc. should not throw 4000
+    // TODO: notify error 4000
     return {result: 'error'};
   }
 };
@@ -68,6 +70,7 @@ const promptConsentMessage = async ({
     };
 
     const userReject: ConsentMessageAnswer = () => {
+      // TODO: error 3001
       resolve({result: 'rejected'});
     };
 

--- a/src/signer.spec.ts
+++ b/src/signer.spec.ts
@@ -1,6 +1,7 @@
 import {Ed25519KeyIdentity} from '@dfinity/identity';
 import type {MockInstance} from 'vitest';
 import * as actors from './api/actors.api';
+import * as api from './api/canister.api';
 import {
   ICRC25_PERMISSIONS,
   ICRC25_PERMISSION_GRANTED,
@@ -16,6 +17,7 @@ import {
   SignerErrorCode
 } from './constants/signer.constants';
 import * as signerHandlers from './handlers/signer.handlers';
+import {mockConsentInfo} from './mocks/consent-message.mocks';
 import {mockAccounts, mockPrincipalText} from './mocks/icrc-accounts.mocks';
 import {saveSessionScopes} from './sessions/signer.sessions';
 import {Signer} from './signer';
@@ -886,6 +888,126 @@ describe('Signer', () => {
               },
               testOrigin
             );
+          });
+        });
+      });
+
+      describe('Consent message', () => {
+        let spy: MockInstance;
+
+        const requestCallCanisterMsg = {
+          data: requestCallCanisterData,
+          origin: testOrigin
+        };
+
+        beforeEach(() => {
+          spy = vi.spyOn(api, 'consentMessage');
+        });
+
+        describe('Call canister success', () => {
+          beforeEach(() => {
+            spy.mockResolvedValue({
+              Ok: mockConsentInfo
+            });
+          });
+
+          it('should prompt consent message for icrc49_call_canister if permissions were already granted', async () => {
+            const promptSpy = vi.fn();
+
+            signer.register({
+              method: ICRC49_CALL_CANISTER,
+              prompt: promptSpy
+            });
+
+            saveSessionScopes({
+              owner: signerOptions.owner.getPrincipal(),
+              origin: testOrigin,
+              scopes: [
+                {
+                  scope: {method: ICRC49_CALL_CANISTER},
+                  state: IcrcPermissionStateSchema.enum.granted
+                }
+              ]
+            });
+
+            const messageEvent = new MessageEvent('message', requestCallCanisterMsg);
+            window.dispatchEvent(messageEvent);
+
+            await vi.waitFor(() => {
+              expect(promptSpy).toHaveBeenCalledTimes(1);
+            });
+          });
+
+          it('should prompt consent message after prompt for icrc49_call_canister permissions', async () => {
+            let confirmScopes: PermissionsConfirmation | undefined;
+            const promptSpy = vi.fn();
+
+            signer.register({
+              method: ICRC25_REQUEST_PERMISSIONS,
+              prompt: ({confirmScopes: confirm, requestedScopes: _}: PermissionsPromptPayload) => {
+                confirmScopes = confirm;
+              }
+            });
+
+            signer.register({
+              method: ICRC49_CALL_CANISTER,
+              prompt: promptSpy
+            });
+
+            const messageEvent = new MessageEvent('message', requestCallCanisterMsg);
+            window.dispatchEvent(messageEvent);
+
+            await vi.waitFor(() => {
+              expect(confirmScopes).not.toBeUndefined();
+            });
+
+            confirmScopes?.([
+              {
+                scope: {method: ICRC49_CALL_CANISTER},
+                state: IcrcPermissionStateSchema.enum.granted
+              }
+            ]);
+
+            await vi.waitFor(() => {
+              expect(promptSpy).toHaveBeenCalledTimes(1);
+            });
+          });
+        });
+
+        describe('Call canister error', () => {
+          beforeEach(() => {
+            spy.mockResolvedValue({
+              Err: {GenericError: {description: 'Error', error_code: 1n}}
+            });
+          });
+
+          it('should not prompt consent message for icrc49_call_canister if getting message throws an error', async () => {
+            const promptSpy = vi.fn();
+
+            signer.register({
+              method: ICRC49_CALL_CANISTER,
+              prompt: promptSpy
+            });
+
+            saveSessionScopes({
+              owner: signerOptions.owner.getPrincipal(),
+              origin: testOrigin,
+              scopes: [
+                {
+                  scope: {method: ICRC49_CALL_CANISTER},
+                  state: IcrcPermissionStateSchema.enum.granted
+                }
+              ]
+            });
+
+            const messageEvent = new MessageEvent('message', requestCallCanisterMsg);
+            window.dispatchEvent(messageEvent);
+
+            // TODO: wait for notifyError and then test prompt has not be called maybe?
+
+            await vi.waitFor(() => {
+              expect(promptSpy).not.toHaveBeenCalledTimes(1);
+            });
           });
         });
       });


### PR DESCRIPTION
# Motivation

On ICRC-49 call canister, once the permission are approved, the user should also approve or reject a consent message.

This PR add the hook to promt the user about the consent message and, call the targeted canister to load that msg.
