### PR TITLE
refactor: extract notify request not supported

### DIFF
--- a/src/services/signer.services.spec.ts
+++ b/src/services/signer.services.spec.ts
@@ -9,7 +9,11 @@ import type {IcrcCallCanisterRequestParams} from '../types/icrc-requests';
 import {JSON_RPC_VERSION_2, type RpcId, type RpcResponseWithError} from '../types/rpc';
 import type {SignerOptions} from '../types/signer-options';
 import type {ConsentMessagePromptPayload} from '../types/signer-prompts';
-import {assertAndPromptConsentMessage, notifyErrorPermissionNotGranted} from './signer.services';
+import {
+  assertAndPromptConsentMessage,
+  notifyErrorRequestNotSupported,
+  notifyErrorPermissionNotGranted
+} from './signer.services';
 
 describe('Signer services', () => {
   let requestId: RpcId;
@@ -138,43 +142,66 @@ describe('Signer services', () => {
     });
   });
 
-  describe('notifyErrorPermissionNotGranted', () => {
-    const origin = 'https://hello.com';
+  describe('Notifiers', () => {
+    describe('notifyErrorPermissionNotGranted', () => {
+      const origin = 'https://hello.com';
 
-    let originalOpener: typeof window.opener;
+      let originalOpener: typeof window.opener;
 
-    let postMessageMock: Mock;
+      let postMessageMock: Mock;
 
-    beforeEach(() => {
-      originalOpener = window.opener;
+      beforeEach(() => {
+        originalOpener = window.opener;
 
-      postMessageMock = vi.fn();
+        postMessageMock = vi.fn();
 
-      vi.stubGlobal('opener', {postMessage: postMessageMock});
-    });
+        vi.stubGlobal('opener', {postMessage: postMessageMock});
+      });
 
-    afterEach(() => {
-      window.opener = originalOpener;
+      afterEach(() => {
+        window.opener = originalOpener;
 
-      vi.restoreAllMocks();
-    });
+        vi.restoreAllMocks();
+      });
 
-    it('should post an error message indicating permission not granted', () => {
-      const error = {
-        code: SignerErrorCode.PERMISSION_NOT_GRANTED,
-        message:
-          'The signer has not granted the necessary permissions to process the request from the relying party.'
-      };
+      describe('notifyErrorNotSupported', () => {
+        it('should post an error message indicating request is not supported', () => {
+          const error = {
+            code: SignerErrorCode.REQUEST_NOT_SUPPORTED,
+            message: 'The request sent by the relying party is not supported by the signer.'
+          };
 
-      notifyErrorPermissionNotGranted({id: requestId, origin});
+          notifyErrorRequestNotSupported({id: requestId, origin});
 
-      const expectedMessage: RpcResponseWithError = {
-        jsonrpc: JSON_RPC_VERSION_2,
-        id: requestId,
-        error
-      };
+          const expectedMessage: RpcResponseWithError = {
+            jsonrpc: JSON_RPC_VERSION_2,
+            id: requestId,
+            error
+          };
 
-      expect(postMessageMock).toHaveBeenCalledWith(expectedMessage, origin);
+          expect(postMessageMock).toHaveBeenCalledWith(expectedMessage, origin);
+        });
+      });
+
+      describe('notifyErrorPermissionNotGranted', () => {
+        it('should post an error message indicating permission not granted', () => {
+          const error = {
+            code: SignerErrorCode.PERMISSION_NOT_GRANTED,
+            message:
+              'The signer has not granted the necessary permissions to process the request from the relying party.'
+          };
+
+          notifyErrorPermissionNotGranted({id: requestId, origin});
+
+          const expectedMessage: RpcResponseWithError = {
+            jsonrpc: JSON_RPC_VERSION_2,
+            id: requestId,
+            error
+          };
+
+          expect(postMessageMock).toHaveBeenCalledWith(expectedMessage, origin);
+        });
+      });
     });
   });
 });

--- a/src/services/signer.services.ts
+++ b/src/services/signer.services.ts
@@ -86,6 +86,16 @@ const promptConsentMessage = async ({
   return await promise;
 };
 
+export const notifyErrorRequestNotSupported = (notify: Notify): void => {
+  notifyError({
+    ...notify,
+    error: {
+      code: SignerErrorCode.REQUEST_NOT_SUPPORTED,
+      message: 'The request sent by the relying party is not supported by the signer.'
+    }
+  });
+};
+
 export const notifyErrorPermissionNotGranted = (notify: Notify): void => {
   notifyError({
     ...notify,

--- a/src/signer.ts
+++ b/src/signer.ts
@@ -17,6 +17,7 @@ import {
 } from './handlers/signer.handlers';
 import {
   assertAndPromptConsentMessage,
+  notifyErrorRequestNotSupported,
   notifyErrorPermissionNotGranted
 } from './services/signer.services';
 import {
@@ -143,13 +144,9 @@ export class Signer {
       return;
     }
 
-    notifyError({
+    notifyErrorRequestNotSupported({
       id: requestData?.id ?? null,
-      origin,
-      error: {
-        code: SignerErrorCode.REQUEST_NOT_SUPPORTED,
-        message: 'The request sent by the relying party is not supported by the signer.'
-      }
+      origin
     });
   };
 


### PR DESCRIPTION
# Motivation

We will reuse the same error in the service therefore let's extract it to avoid code duplication.
