### PR TITLE
feat: we want to notify a network error on consent message call error

### DIFF
--- a/src/constants/signer.constants.ts
+++ b/src/constants/signer.constants.ts
@@ -36,7 +36,13 @@ export enum SignerErrorCode {
    * An error is thrown when the user cancel or deny an action.
    * @see https://github.com/dfinity/wg-identity-authentication/blob/main/topics/icrc_25_signer_interaction_standard.md#errors-3
    */
-  ACTION_ABORTED = 3001
+  ACTION_ABORTED = 3001,
+
+  /**
+   * An unexpected "network" error happened. Like not being able to call the IC.
+   * @see https://github.com/dfinity/wg-identity-authentication/blob/main/topics/icrc_25_signer_interaction_standard.md#errors-3
+   */
+  NETWORK_ERROR = 4000
 }
 
 export const SIGNER_SUPPORTED_STANDARDS: IcrcSupportedStandards = Object.values(

--- a/src/services/signer.services.spec.ts
+++ b/src/services/signer.services.spec.ts
@@ -146,7 +146,7 @@ describe('Signer services', () => {
       });
     });
 
-    describe('Call consent message error', () => {
+    describe('Call consent message responds with an error', () => {
       const error = {GenericError: {description: 'Error', error_code: 1n}};
 
       beforeEach(() => {
@@ -180,6 +180,82 @@ describe('Signer services', () => {
         const errorNotify = {
           code: SignerErrorCode.REQUEST_NOT_SUPPORTED,
           message: mapIcrc21ErrorToString(error)
+        };
+
+        const expectedMessage: RpcResponseWithError = {
+          jsonrpc: JSON_RPC_VERSION_2,
+          id: requestId,
+          error: errorNotify
+        };
+
+        expect(postMessageMock).toHaveBeenCalledWith(expectedMessage, origin);
+      });
+    });
+
+    describe('Call consent message throws an error', () => {
+      it('should return error when consentMessage throws an error', async () => {
+        spy.mockImplementation(() => {
+          // eslint-disable-next-line @typescript-eslint/no-throw-literal
+          throw 'Test';
+        });
+
+        const mockSpy = vi.fn();
+
+        const result = await assertAndPromptConsentMessage({
+          notify,
+          params,
+          prompt: mockSpy,
+          options: signerOptions
+        });
+
+        expect(result).toEqual({result: 'error'});
+        expect(mockSpy).not.toHaveBeenCalled();
+      });
+
+      it('should call notifyNetworkError with an unknown error message when consentMessage throws some error', async () => {
+        spy.mockImplementation(() => {
+          // eslint-disable-next-line @typescript-eslint/no-throw-literal
+          throw 'Test';
+        });
+
+        await assertAndPromptConsentMessage({
+          notify,
+          params,
+          prompt: vi.fn(),
+          options: signerOptions
+        });
+
+        const errorNotify = {
+          code: SignerErrorCode.NETWORK_ERROR,
+          message: 'An unknown error occurred'
+        };
+
+        const expectedMessage: RpcResponseWithError = {
+          jsonrpc: JSON_RPC_VERSION_2,
+          id: requestId,
+          error: errorNotify
+        };
+
+        expect(postMessageMock).toHaveBeenCalledWith(expectedMessage, origin);
+      });
+
+      it('should call notifyNetworkError with an the error message when consentMessage throws an error', async () => {
+        const errorMessage = 'This is a test';
+
+        spy.mockImplementation(() => {
+          throw new Error(errorMessage);
+        });
+
+        await assertAndPromptConsentMessage({
+          notify,
+          params,
+          prompt: vi.fn(),
+          options: signerOptions
+        });
+
+        const errorNotify = {
+          code: SignerErrorCode.NETWORK_ERROR,
+          message: errorMessage
         };
 
         const expectedMessage: RpcResponseWithError = {

--- a/src/services/signer.services.ts
+++ b/src/services/signer.services.ts
@@ -71,7 +71,11 @@ export const assertAndPromptConsentMessage = async ({
     // TODO: 2000 for not supported consent message - i.e. method is not implemented.
     // TODO: Likewise for example if canister is out of cycles or stopped etc. it should not throw 4000.
 
-    // TODO: notify error 4000
+    notifyNetworkError({
+      ...notify,
+      message: err instanceof Error ? err.message : 'An unknown error occurred'
+    });
+
     return {result: 'error'};
   }
 };
@@ -117,6 +121,16 @@ const notifyErrorActionAborted = (notify: Notify): void => {
     error: {
       code: SignerErrorCode.ACTION_ABORTED,
       message: 'The signer has canceled the action requested by the relying party.'
+    }
+  });
+};
+
+const notifyNetworkError = ({message, ...notify}: Notify & {message: string}): void => {
+  notifyError({
+    ...notify,
+    error: {
+      code: SignerErrorCode.NETWORK_ERROR,
+      message
     }
   });
 };


### PR DESCRIPTION
# Motivation

If there is an unepexted error when the signer read the consent message it should throws a 4000 error.