### PR TITLE
refactor: move handler errors to own module

### DIFF
--- a/src/handlers/signer-errors.handlers.spec.ts
+++ b/src/handlers/signer-errors.handlers.spec.ts
@@ -1,0 +1,91 @@
+import type {Mock} from 'vitest';
+import {SignerErrorCode} from '../constants/signer.constants';
+import {JSON_RPC_VERSION_2, type RpcId, type RpcResponseWithError} from '../types/rpc';
+import {
+  notifyErrorPermissionNotGranted,
+  notifyErrorRequestNotSupported
+} from './signer-errors.handlers';
+
+describe('Signer-errors.handlers', () => {
+  let requestId: RpcId;
+
+  const testOrigin = 'https://hello.com';
+
+  let originalOpener: typeof window.opener;
+
+  let postMessageMock: Mock;
+
+  beforeEach(() => {
+    originalOpener = window.opener;
+
+    postMessageMock = vi.fn();
+
+    vi.stubGlobal('opener', {postMessage: postMessageMock});
+
+    requestId = crypto.randomUUID();
+  });
+
+  afterEach(() => {
+    window.opener = originalOpener;
+
+    vi.clearAllMocks();
+  });
+
+  describe('notifyErrorNotSupported', () => {
+    it('should post an error message with default message when none is provided', () => {
+      const error = {
+        code: SignerErrorCode.REQUEST_NOT_SUPPORTED,
+        message: 'The request sent by the relying party is not supported by the signer.'
+      };
+
+      notifyErrorRequestNotSupported({id: requestId, origin: testOrigin});
+
+      const expectedMessage: RpcResponseWithError = {
+        jsonrpc: JSON_RPC_VERSION_2,
+        id: requestId,
+        error
+      };
+
+      expect(postMessageMock).toHaveBeenCalledWith(expectedMessage, testOrigin);
+    });
+
+    it('should post an error message with custom message when provided', () => {
+      const message = 'This is a test';
+
+      const error = {
+        code: SignerErrorCode.REQUEST_NOT_SUPPORTED,
+        message
+      };
+
+      notifyErrorRequestNotSupported({id: requestId, origin: testOrigin, message});
+
+      const expectedMessage: RpcResponseWithError = {
+        jsonrpc: JSON_RPC_VERSION_2,
+        id: requestId,
+        error
+      };
+
+      expect(postMessageMock).toHaveBeenCalledWith(expectedMessage, testOrigin);
+    });
+  });
+
+  describe('notifyErrorPermissionNotGranted', () => {
+    it('should post an error message indicating permission not granted', () => {
+      const error = {
+        code: SignerErrorCode.PERMISSION_NOT_GRANTED,
+        message:
+          'The signer has not granted the necessary permissions to process the request from the relying party.'
+      };
+
+      notifyErrorPermissionNotGranted({id: requestId, origin: testOrigin});
+
+      const expectedMessage: RpcResponseWithError = {
+        jsonrpc: JSON_RPC_VERSION_2,
+        id: requestId,
+        error
+      };
+
+      expect(postMessageMock).toHaveBeenCalledWith(expectedMessage, testOrigin);
+    });
+  });
+});

--- a/src/handlers/signer-errors.handlers.ts
+++ b/src/handlers/signer-errors.handlers.ts
@@ -1,0 +1,53 @@
+import {SignerErrorCode} from '../constants/signer.constants';
+import type {Notify} from '../types/signer-handlers';
+import {notifyError} from './signer.handlers';
+
+export const notifyErrorRequestNotSupported = ({
+  message,
+  ...notify
+}: Notify & {message?: string}): void => {
+  notifyError({
+    ...notify,
+    error: {
+      code: SignerErrorCode.REQUEST_NOT_SUPPORTED,
+      message: message ?? 'The request sent by the relying party is not supported by the signer.'
+    }
+  });
+};
+export const notifyErrorActionAborted = (notify: Notify): void => {
+  notifyError({
+    ...notify,
+    error: {
+      code: SignerErrorCode.ACTION_ABORTED,
+      message: 'The signer has canceled the action requested by the relying party.'
+    }
+  });
+};
+export const notifyNetworkError = ({message, ...notify}: Notify & {message: string}): void => {
+  notifyError({
+    ...notify,
+    error: {
+      code: SignerErrorCode.NETWORK_ERROR,
+      message
+    }
+  });
+};
+export const notifyErrorPermissionNotGranted = (notify: Notify): void => {
+  notifyError({
+    ...notify,
+    error: {
+      code: SignerErrorCode.PERMISSION_NOT_GRANTED,
+      message:
+        'The signer has not granted the necessary permissions to process the request from the relying party.'
+    }
+  });
+};
+export const notifyMissingPromptError = (notify: Notify): void => {
+  notifyError({
+    ...notify,
+    error: {
+      code: SignerErrorCode.PERMISSIONS_PROMPT_NOT_REGISTERED,
+      message: 'The signer has not registered a prompt to respond to permission requests.'
+    }
+  });
+};

--- a/src/services/signer.services.spec.ts
+++ b/src/services/signer.services.spec.ts
@@ -11,11 +11,7 @@ import type {Notify} from '../types/signer-handlers';
 import type {SignerOptions} from '../types/signer-options';
 import type {ConsentMessagePromptPayload} from '../types/signer-prompts';
 import {mapIcrc21ErrorToString} from '../utils/icrc-21.utils';
-import {
-  assertAndPromptConsentMessage,
-  notifyErrorPermissionNotGranted,
-  notifyErrorRequestNotSupported
-} from './signer.services';
+import {assertAndPromptConsentMessage} from './signer.services';
 
 describe('Signer services', () => {
   let requestId: RpcId;
@@ -35,8 +31,6 @@ describe('Signer services', () => {
     owner: Ed25519KeyIdentity.generate(),
     host: 'http://localhost:5987'
   };
-
-  const origin = 'https://hello.com';
 
   let originalOpener: typeof window.opener;
 
@@ -142,7 +136,7 @@ describe('Signer services', () => {
           error: errorNotify
         };
 
-        expect(postMessageMock).toHaveBeenCalledWith(expectedMessage, origin);
+        expect(postMessageMock).toHaveBeenCalledWith(expectedMessage, testOrigin);
       });
     });
 
@@ -188,7 +182,7 @@ describe('Signer services', () => {
           error: errorNotify
         };
 
-        expect(postMessageMock).toHaveBeenCalledWith(expectedMessage, origin);
+        expect(postMessageMock).toHaveBeenCalledWith(expectedMessage, testOrigin);
       });
     });
 
@@ -236,7 +230,7 @@ describe('Signer services', () => {
           error: errorNotify
         };
 
-        expect(postMessageMock).toHaveBeenCalledWith(expectedMessage, origin);
+        expect(postMessageMock).toHaveBeenCalledWith(expectedMessage, testOrigin);
       });
 
       it('should call notifyNetworkError with an the error message when consentMessage throws an error', async () => {
@@ -264,7 +258,7 @@ describe('Signer services', () => {
           error: errorNotify
         };
 
-        expect(postMessageMock).toHaveBeenCalledWith(expectedMessage, origin);
+        expect(postMessageMock).toHaveBeenCalledWith(expectedMessage, testOrigin);
       });
     });
 
@@ -287,7 +281,7 @@ describe('Signer services', () => {
         error: errorNotify
       };
 
-      expect(postMessageMock).toHaveBeenCalledWith(expectedMessage, origin);
+      expect(postMessageMock).toHaveBeenCalledWith(expectedMessage, testOrigin);
     });
 
     it('should return error if consentMessage throws', async () => {
@@ -305,66 +299,6 @@ describe('Signer services', () => {
       expect(result).toEqual({result: 'error'});
 
       expect(prompt).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('notifyErrorPermissionNotGranted', () => {
-    describe('notifyErrorNotSupported', () => {
-      it('should post an error message with default message when none is provided', () => {
-        const error = {
-          code: SignerErrorCode.REQUEST_NOT_SUPPORTED,
-          message: 'The request sent by the relying party is not supported by the signer.'
-        };
-
-        notifyErrorRequestNotSupported({id: requestId, origin});
-
-        const expectedMessage: RpcResponseWithError = {
-          jsonrpc: JSON_RPC_VERSION_2,
-          id: requestId,
-          error
-        };
-
-        expect(postMessageMock).toHaveBeenCalledWith(expectedMessage, origin);
-      });
-
-      it('should post an error message with custom message when provided', () => {
-        const message = 'This is a test';
-
-        const error = {
-          code: SignerErrorCode.REQUEST_NOT_SUPPORTED,
-          message
-        };
-
-        notifyErrorRequestNotSupported({id: requestId, origin, message});
-
-        const expectedMessage: RpcResponseWithError = {
-          jsonrpc: JSON_RPC_VERSION_2,
-          id: requestId,
-          error
-        };
-
-        expect(postMessageMock).toHaveBeenCalledWith(expectedMessage, origin);
-      });
-    });
-
-    describe('notifyErrorPermissionNotGranted', () => {
-      it('should post an error message indicating permission not granted', () => {
-        const error = {
-          code: SignerErrorCode.PERMISSION_NOT_GRANTED,
-          message:
-            'The signer has not granted the necessary permissions to process the request from the relying party.'
-        };
-
-        notifyErrorPermissionNotGranted({id: requestId, origin});
-
-        const expectedMessage: RpcResponseWithError = {
-          jsonrpc: JSON_RPC_VERSION_2,
-          id: requestId,
-          error
-        };
-
-        expect(postMessageMock).toHaveBeenCalledWith(expectedMessage, origin);
-      });
     });
   });
 });

--- a/src/services/signer.services.ts
+++ b/src/services/signer.services.ts
@@ -1,8 +1,12 @@
 import {isNullish} from '@dfinity/utils';
 import {consentMessage} from '../api/canister.api';
-import {SignerErrorCode} from '../constants/signer.constants';
 import type {icrc21_consent_info} from '../declarations/icrc-21';
-import {notifyError} from '../handlers/signer.handlers';
+import {
+  notifyErrorActionAborted,
+  notifyErrorRequestNotSupported,
+  notifyMissingPromptError,
+  notifyNetworkError
+} from '../handlers/signer-errors.handlers';
 import type {IcrcCallCanisterRequestParams} from '../types/icrc-requests';
 import type {Notify} from '../types/signer-handlers';
 import type {SignerOptions} from '../types/signer-options';
@@ -100,58 +104,4 @@ const promptConsentMessage = async ({
   });
 
   return await promise;
-};
-
-export const notifyErrorRequestNotSupported = ({
-  message,
-  ...notify
-}: Notify & {message?: string}): void => {
-  notifyError({
-    ...notify,
-    error: {
-      code: SignerErrorCode.REQUEST_NOT_SUPPORTED,
-      message: message ?? 'The request sent by the relying party is not supported by the signer.'
-    }
-  });
-};
-
-const notifyErrorActionAborted = (notify: Notify): void => {
-  notifyError({
-    ...notify,
-    error: {
-      code: SignerErrorCode.ACTION_ABORTED,
-      message: 'The signer has canceled the action requested by the relying party.'
-    }
-  });
-};
-
-const notifyNetworkError = ({message, ...notify}: Notify & {message: string}): void => {
-  notifyError({
-    ...notify,
-    error: {
-      code: SignerErrorCode.NETWORK_ERROR,
-      message
-    }
-  });
-};
-
-export const notifyErrorPermissionNotGranted = (notify: Notify): void => {
-  notifyError({
-    ...notify,
-    error: {
-      code: SignerErrorCode.PERMISSION_NOT_GRANTED,
-      message:
-        'The signer has not granted the necessary permissions to process the request from the relying party.'
-    }
-  });
-};
-
-export const notifyMissingPromptError = (notify: Notify): void => {
-  notifyError({
-    ...notify,
-    error: {
-      code: SignerErrorCode.PERMISSIONS_PROMPT_NOT_REGISTERED,
-      message: 'The signer has not registered a prompt to respond to permission requests.'
-    }
-  });
 };

--- a/src/signer.ts
+++ b/src/signer.ts
@@ -7,6 +7,11 @@ import {
 } from './constants/icrc.constants';
 import {SIGNER_DEFAULT_SCOPES, SignerErrorCode} from './constants/signer.constants';
 import {
+  notifyErrorPermissionNotGranted,
+  notifyErrorRequestNotSupported,
+  notifyMissingPromptError
+} from './handlers/signer-errors.handlers';
+import {
   notifyAccounts,
   notifyError,
   notifyPermissionScopes,
@@ -15,12 +20,7 @@ import {
   type NotifyAccounts,
   type NotifyPermissions
 } from './handlers/signer.handlers';
-import {
-  assertAndPromptConsentMessage,
-  notifyErrorPermissionNotGranted,
-  notifyErrorRequestNotSupported,
-  notifyMissingPromptError
-} from './services/signer.services';
+import {assertAndPromptConsentMessage} from './services/signer.services';
 import {
   readSessionValidScopes,
   saveSessionScopes,


### PR DESCRIPTION
# Motivation

It's cleaner to not have the error notifier at the service layer.
