### PR TITLE
refactor: extract prompt type to module

### DIFF
--- a/src/signer.ts
+++ b/src/signer.ts
@@ -27,6 +27,7 @@ import {
   sessionScopeState
 } from './sessions/signer.sessions';
 import type {IcrcAccounts} from './types/icrc-accounts';
+import type {IcrcApproveMethod} from './types/icrc-prompts';
 import {
   IcrcAccountsRequestSchema,
   IcrcCallCanisterRequestSchema,
@@ -39,7 +40,6 @@ import type {IcrcScope, IcrcScopesArray} from './types/icrc-responses';
 import {
   IcrcPermissionStateSchema,
   IcrcScopedMethodSchema,
-  type IcrcApproveMethod,
   type IcrcPermissionState,
   type IcrcScopedMethod
 } from './types/icrc-standards';

--- a/src/types/icrc-prompts.spec.ts
+++ b/src/types/icrc-prompts.spec.ts
@@ -1,0 +1,50 @@
+import {
+  ICRC25_PERMISSIONS,
+  ICRC25_REQUEST_PERMISSIONS,
+  ICRC25_SUPPORTED_STANDARDS,
+  ICRC27_ACCOUNTS,
+  ICRC29_STATUS
+} from '../constants/icrc.constants';
+import {IcrcApproveMethodSchema} from './icrc-prompts';
+
+describe('ICRC prompts', () => {
+  const approveEnums = [
+    {
+      title: 'ICRC25_REQUEST_PERMISSIONS',
+      validEnum: ICRC25_REQUEST_PERMISSIONS
+    },
+    {
+      title: 'ICRC27_ACCOUNTS',
+      validEnum: ICRC27_ACCOUNTS
+    }
+  ];
+
+  const invalidApproveEnums = [
+    {
+      title: 'ICRC25_PERMISSIONS',
+      validEnum: ICRC25_PERMISSIONS
+    },
+    {
+      title: 'ICRC25_SUPPORTED_STANDARDS',
+      validEnum: ICRC25_SUPPORTED_STANDARDS
+    },
+    {
+      title: 'ICRC29_STATUS',
+      validEnum: ICRC29_STATUS
+    }
+  ];
+
+  it.each(approveEnums)(
+    'should validate $title with IcrcApproveMethodSchema',
+    async ({validEnum}) => {
+      expect(IcrcApproveMethodSchema.safeParse(validEnum).success).toBe(true);
+    }
+  );
+
+  it.each(invalidApproveEnums)(
+    'should not validate $title with IcrcApproveMethodSchema',
+    async ({validEnum}) => {
+      expect(IcrcApproveMethodSchema.safeParse(validEnum).success).toBe(false);
+    }
+  );
+});

--- a/src/types/icrc-prompts.ts
+++ b/src/types/icrc-prompts.ts
@@ -1,0 +1,14 @@
+import {z} from 'zod';
+import {
+  ICRC25_REQUEST_PERMISSIONS,
+  ICRC27_ACCOUNTS,
+  ICRC49_CALL_CANISTER
+} from '../constants/icrc.constants';
+
+export const IcrcApproveMethodSchema = z.enum([
+  ICRC25_REQUEST_PERMISSIONS,
+  ICRC27_ACCOUNTS,
+  ICRC49_CALL_CANISTER
+]);
+
+export type IcrcApproveMethod = z.infer<typeof IcrcApproveMethodSchema>;

--- a/src/types/icrc-standards.spec.ts
+++ b/src/types/icrc-standards.spec.ts
@@ -8,12 +8,7 @@ import {
   ICRC29,
   ICRC29_STATUS
 } from '../constants/icrc.constants';
-import {
-  IcrcApproveMethodSchema,
-  IcrcMethodSchema,
-  IcrcScopedMethodSchema,
-  IcrcStandardSchema
-} from './icrc-standards';
+import {IcrcMethodSchema, IcrcScopedMethodSchema, IcrcStandardSchema} from './icrc-standards';
 
 describe('ICRC standards', () => {
   const methodEnums = [
@@ -46,46 +41,6 @@ describe('ICRC standards', () => {
   it('should not validate IcrcMethodSchema unkown value', () => {
     expect(IcrcMethodSchema.safeParse('INVALID_METHOD').success).toBe(false);
   });
-
-  const approveEnums = [
-    {
-      title: 'ICRC25_REQUEST_PERMISSIONS',
-      validEnum: ICRC25_REQUEST_PERMISSIONS
-    },
-    {
-      title: 'ICRC27_ACCOUNTS',
-      validEnum: ICRC27_ACCOUNTS
-    }
-  ];
-
-  const invalidApproveEnums = [
-    {
-      title: 'ICRC25_PERMISSIONS',
-      validEnum: ICRC25_PERMISSIONS
-    },
-    {
-      title: 'ICRC25_SUPPORTED_STANDARDS',
-      validEnum: ICRC25_SUPPORTED_STANDARDS
-    },
-    {
-      title: 'ICRC29_STATUS',
-      validEnum: ICRC29_STATUS
-    }
-  ];
-
-  it.each(approveEnums)(
-    'should validate $title with IcrcApproveMethodSchema',
-    async ({validEnum}) => {
-      expect(IcrcApproveMethodSchema.safeParse(validEnum).success).toBe(true);
-    }
-  );
-
-  it.each(invalidApproveEnums)(
-    'should not validate $title with IcrcApproveMethodSchema',
-    async ({validEnum}) => {
-      expect(IcrcApproveMethodSchema.safeParse(validEnum).success).toBe(false);
-    }
-  );
 
   const scopeEnums = [
     {

--- a/src/types/icrc-standards.ts
+++ b/src/types/icrc-standards.ts
@@ -24,14 +24,6 @@ export const IcrcMethodSchema = z.enum([
   ICRC49_CALL_CANISTER
 ]);
 
-export const IcrcApproveMethodSchema = z.enum([
-  ICRC25_REQUEST_PERMISSIONS,
-  ICRC27_ACCOUNTS,
-  ICRC49_CALL_CANISTER
-]);
-
-export type IcrcApproveMethod = z.infer<typeof IcrcApproveMethodSchema>;
-
 export const IcrcScopedMethodSchema = IcrcMethodSchema.extract([
   ICRC27_ACCOUNTS,
   ICRC49_CALL_CANISTER


### PR DESCRIPTION
# Motivation

Extract type for prompt to own module as it's not really part of the standard.
