### PR TITLE
feat: expose icp-wallet and relying-party

### DIFF
--- a/demo/src/relying_party_frontend/src/lib/components/Accounts.svelte
+++ b/demo/src/relying_party_frontend/src/lib/components/Accounts.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { Wallet } from '@dfinity/oisy-wallet-signer/wallet';
+	import type { IcpWallet } from '@dfinity/oisy-wallet-signer/icp-wallet';
 	import { nonNullish } from '@dfinity/utils';
 	import { fade } from 'svelte/transition';
 	import Button from '$core/components/Button.svelte';
@@ -7,7 +7,7 @@
 	import { accountsStore } from '$lib/stores/accounts.store';
 
 	type Props = {
-		wallet: Wallet | undefined;
+		wallet: IcpWallet | undefined;
 	};
 
 	let { wallet }: Props = $props();

--- a/demo/src/relying_party_frontend/src/lib/components/CallCanister.svelte
+++ b/demo/src/relying_party_frontend/src/lib/components/CallCanister.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { Wallet } from '@dfinity/oisy-wallet-signer/wallet';
+	import type { IcpWallet } from '@dfinity/oisy-wallet-signer/icp-wallet';
 	import { isNullish, nonNullish } from '@dfinity/utils';
 	import { fade } from 'svelte/transition';
 	import Button from '$core/components/Button.svelte';
@@ -11,7 +11,7 @@
 	import { authStore } from '$core/stores/auth.store';
 
 	type Props = {
-		wallet: Wallet | undefined;
+		wallet: IcpWallet | undefined;
 	};
 
 	let { wallet }: Props = $props();

--- a/demo/src/relying_party_frontend/src/lib/components/Permissions.svelte
+++ b/demo/src/relying_party_frontend/src/lib/components/Permissions.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { Wallet } from '@dfinity/oisy-wallet-signer/wallet';
+	import type { IcpWallet } from '@dfinity/oisy-wallet-signer/icp-wallet';
 	import { isNullish, nonNullish } from '@dfinity/utils';
 	import type { IcrcScopesArray } from '@dfinity/oisy-wallet-signer';
 	import { fade } from 'svelte/transition';
@@ -7,7 +7,7 @@
 	import PermissionsScopes from '$lib/components/PermissionsScopes.svelte';
 
 	type Props = {
-		wallet: Wallet | undefined;
+		wallet: IcpWallet | undefined;
 	};
 
 	let { wallet }: Props = $props();

--- a/demo/src/relying_party_frontend/src/lib/components/RequestPermissions.svelte
+++ b/demo/src/relying_party_frontend/src/lib/components/RequestPermissions.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { Wallet } from '@dfinity/oisy-wallet-signer/wallet';
+	import type { IcpWallet } from '@dfinity/oisy-wallet-signer/icp-wallet';
 	import { nonNullish } from '@dfinity/utils';
 	import { fade } from 'svelte/transition';
 	import Button from '$core/components/Button.svelte';
@@ -9,7 +9,7 @@
 	import { emit } from '$core/utils/events.utils';
 
 	type Props = {
-		wallet: Wallet | undefined;
+		wallet: IcpWallet | undefined;
 	};
 
 	let { wallet }: Props = $props();

--- a/demo/src/relying_party_frontend/src/lib/components/SupportedStandards.svelte
+++ b/demo/src/relying_party_frontend/src/lib/components/SupportedStandards.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
-	import type { Wallet } from '@dfinity/oisy-wallet-signer/wallet';
+	import type { IcpWallet } from '@dfinity/oisy-wallet-signer/icp-wallet';
 	import { isNullish, nonNullish } from '@dfinity/utils';
 	import type { IcrcSupportedStandards } from '@dfinity/oisy-wallet-signer';
 	import Value from '$core/components/Value.svelte';
 	import { fade } from 'svelte/transition';
 
 	type Props = {
-		wallet: Wallet | undefined;
+		wallet: IcpWallet | undefined;
 	};
 
 	let { wallet }: Props = $props();

--- a/demo/src/relying_party_frontend/src/routes/+page.svelte
+++ b/demo/src/relying_party_frontend/src/routes/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { fade } from 'svelte/transition';
-	import { Wallet } from '@dfinity/oisy-wallet-signer/wallet';
+	import { IcpWallet } from '@dfinity/oisy-wallet-signer/icp-wallet';
 	import { isNullish } from '@dfinity/utils';
 	import Button from '$core/components/Button.svelte';
 	import UserId from '$core/components/UserId.svelte';
@@ -11,10 +11,10 @@
 	import Accounts from '$lib/components/Accounts.svelte';
 	import CallCanister from '$lib/components/CallCanister.svelte';
 
-	let wallet = $state<Wallet | undefined>(undefined);
+	let wallet = $state<IcpWallet | undefined>(undefined);
 
 	const onclick = async () => {
-		wallet = await Wallet.connect({
+		wallet = await IcpWallet.connect({
 			url: 'http://localhost:5174'
 		});
 	};

--- a/package.json
+++ b/package.json
@@ -34,10 +34,15 @@
       "import": "./dist/index.js",
       "require": "./dist/index.mjs"
     },
-    "./wallet": {
-      "types": "./dist/wallet.d.ts",
-      "import": "./dist/wallet.js",
-      "require": "./dist/wallet.mjs"
+    "./relying-party": {
+      "types": "./dist/relying-party.d.ts",
+      "import": "./dist/relying-party.js",
+      "require": "./dist/relying-party.mjs"
+    },
+    "./icp-wallet": {
+      "types": "./dist/icp-wallet.d.ts",
+      "import": "./dist/icp-wallet.js",
+      "require": "./dist/icp-wallet.mjs"
     },
     "./signer": {
       "types": "./dist/signer.d.ts",

--- a/src/icp-wallet.ts
+++ b/src/icp-wallet.ts
@@ -1,0 +1,3 @@
+import {RelyingParty} from './relying-party';
+
+export class IcpWallet extends RelyingParty {}

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -1,4 +1,0 @@
-import {RelyingParty} from './relying-party';
-
-// TODO: placeholder. Will be split into IcpWallet and IcrcWallet
-export class Wallet extends RelyingParty {}


### PR DESCRIPTION
# Motivation

To follow ic-js pattern, we want to expose two different opiniated clients, `IcrcWallet` and `IcpWallet`. Those will contains method that takes care of converting params and candid encoding.

This PR rename wallet to IcpWallet and also expose the "generic" relying party client.
