### PR TITLE
feat: relying party generic arg

### DIFF
--- a/demo/src/relying_party_frontend/src/lib/components/CallCanister.svelte
+++ b/demo/src/relying_party_frontend/src/lib/components/CallCanister.svelte
@@ -54,7 +54,7 @@
 			amount: Icrc1Tokens
 		});
 
-		const arg: TransferArg = {
+		const value: TransferArg = {
 			to: {
 				owner: $authStore.identity.getPrincipal(),
 				subaccount: []
@@ -86,13 +86,14 @@
 		// 	}
 		// }
 
+		const arg = new Uint8Array(IDL.encode([TransferArg], [value]));
+
 		result = await wallet?.call({
 			params: {
 				sender: account.owner,
 				method: 'icrc1_transfer',
 				canisterId: 'ryjl3-tyaaa-aaaaa-aaaba-cai',
-				arg,
-				argType: TransferArg
+				arg
 			}
 		});
 	};

--- a/src/relying-party.spec.ts
+++ b/src/relying-party.spec.ts
@@ -1,4 +1,3 @@
-import {IDL} from '@dfinity/candid';
 import {
   ICRC25_PERMISSIONS,
   ICRC25_REQUEST_PERMISSIONS,
@@ -19,7 +18,7 @@ import {SignerErrorCode} from './constants/signer.constants';
 import * as relyingPartyHandlers from './handlers/relying-party.handlers';
 import {mockAccounts, mockPrincipalText} from './mocks/icrc-accounts.mocks';
 import {RelyingParty} from './relying-party';
-import type {IcrcAnyRequestedScopes} from './types/icrc-requests';
+import type {IcrcAnyRequestedScopes, IcrcCallCanisterRequestParams} from './types/icrc-requests';
 import {
   IcrcAccountsResponseSchema,
   IcrcCallCanisterResultResponseSchema,
@@ -29,7 +28,6 @@ import {
 } from './types/icrc-responses';
 import {RelyingPartyResponseError} from './types/relying-party-errors';
 import type {RelyingPartyOptions} from './types/relying-party-options';
-import type {RelyingPartyCallParams} from './types/relying-party-request';
 import {JSON_RPC_VERSION_2, RpcResponseWithResultOrErrorSchema} from './types/rpc';
 import {WALLET_WINDOW_CENTER, WALLET_WINDOW_TOP_RIGHT, windowFeatures} from './utils/window.utils';
 
@@ -1067,18 +1065,11 @@ describe('Relying Party', () => {
     describe('Call', () => {
       let relyingParty: RelyingParty;
 
-      interface MyTest {
-        hello: string;
-      }
-
-      const params: RelyingPartyCallParams<MyTest> = {
+      const params: IcrcCallCanisterRequestParams = {
         canisterId: mockPrincipalText,
         sender: mockPrincipalText,
         method: 'some_method',
-        arg: {hello: 'world'},
-        argType: IDL.Record({
-          hello: IDL.Text
-        })
+        arg: new Uint8Array([1, 2, 3, 4, 5, 6, 7])
       };
 
       const result: IcrcCallCanisterResult = {
@@ -1248,16 +1239,11 @@ describe('Relying Party', () => {
           expect(spy).toHaveBeenCalledTimes(1);
           expect(spyPostMessage).toHaveBeenCalledTimes(1);
 
-          const {arg, argType, ...rest} = params;
-
           expect(spyPostMessage).toHaveBeenCalledWith(
             expect.objectContaining({
               jsonrpc: JSON_RPC_VERSION_2,
               method: ICRC49_CALL_CANISTER,
-              params: {
-                ...rest,
-                arg: new Uint8Array(IDL.encode([argType], [arg]))
-              }
+              params
             }),
             mockParameters.url
           );

--- a/src/relying-party.ts
+++ b/src/relying-party.ts
@@ -1,4 +1,3 @@
-import {IDL} from '@dfinity/candid';
 import {assertNonNullish, nonNullish, notEmptyString} from '@dfinity/utils';
 import {
   RELYING_PARTY_CONNECT_TIMEOUT_IN_MILLISECONDS,
@@ -18,7 +17,7 @@ import {
   retryRequestStatus
 } from './handlers/relying-party.handlers';
 import type {IcrcAccounts} from './types/icrc-accounts';
-import type {IcrcAnyRequestedScopes} from './types/icrc-requests';
+import type {IcrcAnyRequestedScopes, IcrcCallCanisterRequestParams} from './types/icrc-requests';
 import {
   IcrcAccountsResponseSchema,
   IcrcCallCanisterResultResponseSchema,
@@ -34,7 +33,6 @@ import {RelyingPartyResponseError} from './types/relying-party-errors';
 import {RelyingPartyOptionsSchema, type RelyingPartyOptions} from './types/relying-party-options';
 import {
   RelyingPartyRequestOptionsSchema,
-  type RelyingPartyCallParams,
   type RelyingPartyRequestOptions,
   type RelyingPartyRequestOptionsWithTimeout
 } from './types/relying-party-request';
@@ -493,17 +491,17 @@ export class RelyingParty {
    * @async
    * @template T - The type of the argument being passed to the canister call.
    * @param {Object} args - The arguments for the call.
-   * @param {RelyingPartyCallParams<T>} args.params - The parameters required to call the canister, including the canister ID, method name, and a generic argument of type `T`.
+   * @param {IcrcCallCanisterRequestParams} args.params - The parameters required to call the canister, including the canister ID, method name, and the encoded argument payload.
    * @param {RelyingPartyRequestOptions} [args.options] - The options for the signer request, which may include parameters such as timeout settings and other request-specific configurations.
    * @returns {Promise<IcrcCallCanisterResult>} A promise that resolves to the result of the canister call.
    * @see [ICRC49 Call Canister](https://github.com/dfinity/wg-identity-authentication/blob/main/topics/icrc_49_call_canister.md)
    */
-  call = async <T>({
+  call = async ({
     options: {timeoutInMilliseconds, ...rest} = {},
     params
   }: {
     options?: RelyingPartyRequestOptions;
-    params: RelyingPartyCallParams<T>;
+    params: IcrcCallCanisterRequestParams;
   }): Promise<IcrcCallCanisterResult> => {
     const handleMessage = async ({
       data,
@@ -524,18 +522,11 @@ export class RelyingParty {
     };
 
     const postRequest = (id: RpcId): void => {
-      const {arg: userArg, argType, ...rest} = params;
-
-      const arg = new Uint8Array(IDL.encode([argType], [userArg]));
-
       requestCallCanister({
         popup: this.#popup,
         origin: this.#origin,
         id,
-        params: {
-          ...rest,
-          arg
-        }
+        params
       });
     };
 

--- a/src/types/relying-party-request.spec.ts
+++ b/src/types/relying-party-request.spec.ts
@@ -1,10 +1,4 @@
-import {IDL} from '@dfinity/candid';
-import {mockPrincipalText} from '../mocks/icrc-accounts.mocks';
-import {
-  RelyingPartyRequestOptionsSchema,
-  extendIcrcCallCanisterRequestParamsSchema,
-  type RelyingPartyCallParams
-} from './relying-party-request';
+import {RelyingPartyRequestOptionsSchema} from './relying-party-request';
 
 describe('RelyingPartyRequest', () => {
   describe('Options', () => {
@@ -30,105 +24,6 @@ describe('RelyingPartyRequest', () => {
       };
 
       const result = RelyingPartyRequestOptionsSchema.safeParse(invalidData);
-      expect(result.success).toBe(false);
-    });
-  });
-
-  describe('Call', () => {
-    interface MyTest {
-      hello: string;
-    }
-
-    const argType = IDL.Record({
-      hello: IDL.Text
-    });
-
-    const schema = extendIcrcCallCanisterRequestParamsSchema<MyTest>();
-
-    it('should validate correct parameters', () => {
-      const validParams: RelyingPartyCallParams<{hello: string}> = {
-        canisterId: mockPrincipalText,
-        sender: mockPrincipalText,
-        method: 'some_method',
-        arg: {hello: 'world'},
-        argType
-      };
-
-      const result = schema.safeParse(validParams);
-      expect(result.success).toBe(true);
-    });
-
-    // TODO: not sure how to solve this with zod that's why this test succeed.
-    it('should validate incorrect "arg" type', () => {
-      const invalidParams = {
-        canisterId: mockPrincipalText,
-        sender: mockPrincipalText,
-        method: 'some_method',
-        arg: 'invalid_arg',
-        argType
-      };
-
-      const result = schema.safeParse(invalidParams);
-      expect(result.success).toBe(true);
-    });
-
-    it('should fail validation with missing "argType"', () => {
-      const invalidParams = {
-        canisterId: mockPrincipalText,
-        sender: mockPrincipalText,
-        method: 'some_method',
-        arg: {hello: 'world'}
-      };
-
-      const result = schema.safeParse(invalidParams);
-      expect(result.success).toBe(false);
-    });
-
-    it('should fail validation with missing "arg"', () => {
-      const invalidParams = {
-        canisterId: mockPrincipalText,
-        sender: mockPrincipalText,
-        method: 'some_method',
-        argType
-      };
-
-      const result = schema.safeParse(invalidParams);
-      expect(result.success).toBe(false);
-    });
-
-    it('should fail validation with missing "canisterId"', () => {
-      const invalidParams = {
-        sender: mockPrincipalText,
-        method: 'some_method',
-        arg: {hello: 'world'},
-        argType
-      };
-
-      const result = schema.safeParse(invalidParams);
-      expect(result.success).toBe(false);
-    });
-
-    it('should fail validation with missing "sender"', () => {
-      const invalidParams = {
-        canisterId: mockPrincipalText,
-        method: 'some_method',
-        arg: {hello: 'world'},
-        argType
-      };
-
-      const result = schema.safeParse(invalidParams);
-      expect(result.success).toBe(false);
-    });
-
-    it('should fail validation with missing "method"', () => {
-      const invalidParams = {
-        canisterId: mockPrincipalText,
-        sender: mockPrincipalText,
-        arg: {hello: 'world'},
-        argType
-      };
-
-      const result = schema.safeParse(invalidParams);
       expect(result.success).toBe(false);
     });
   });

--- a/src/types/relying-party-request.ts
+++ b/src/types/relying-party-request.ts
@@ -1,7 +1,4 @@
-import {Type} from '@dfinity/candid/lib/cjs/idl';
-import {nonNullish} from '@dfinity/utils';
 import {z} from 'zod';
-import {IcrcCallCanisterRequestParamsSchema} from './icrc-requests';
 import {RpcIdSchema} from './rpc';
 
 export const RelyingPartyRequestOptionsTimeoutSchema = z.object({
@@ -33,36 +30,4 @@ export const RelyingPartyRequestOptionsWithTimeoutSchema = RelyingPartyRequestOp
 
 export type RelyingPartyRequestOptionsWithTimeout = z.infer<
   typeof RelyingPartyRequestOptionsWithTimeoutSchema
->;
-
-/**
- * Creates an extended schema for ICRC call canister request parameters.
- *
- * This function generates a schema that extends the base `IcrcCallCanisterRequestParamsSchema`
- * by replacing the `arg` field with a custom type `T` and adding an `argType` field that must be
- * an instance of the `Type` class from `@dfinity/candid`.
- *
- * @template T - The type of the `arg` field.
- * @returns {z.ZodObject} - A Zod schema object that includes the base fields and the custom `arg` and `argType`.
- */
-/* eslint-disable @typescript-eslint/explicit-function-return-type */
-export const extendIcrcCallCanisterRequestParamsSchema = <T>() =>
-  IcrcCallCanisterRequestParamsSchema.omit({arg: true}).extend({
-    arg: z.custom<T>().refine(nonNullish, {
-      message: 'arg is required'
-    }),
-    argType: z.instanceof(Type) as z.ZodType<Type>
-  });
-
-/**
- * Represents the type of parameters used in a relying party call, based on the
- * extended ICRC call canister request schema.
- *
- * This type is inferred from the return type of `extendIcrcCallCanisterRequestParamsSchema<T>`,
- * meaning it includes all fields of `IcrcCallCanisterRequestParamsSchema` with a generic `arg` type.
- *
- * @template T - The type of the `arg` field in the schema.
- */
-export type RelyingPartyCallParams<T> = z.infer<
-  ReturnType<typeof extendIcrcCallCanisterRequestParamsSchema<T>>
 >;


### PR DESCRIPTION
# Motivation

We gonna implement opiniated relying party therefor the relying party itself can be generic and accept `arg` as definied by the spec without taking care of processing the Candid encoding.