### PR TITLE
fix: the result of the static connect function was not properly typed

### DIFF
--- a/src/icp-wallet.ts
+++ b/src/icp-wallet.ts
@@ -11,7 +11,7 @@ export class IcpWallet extends RelyingParty {
    * @returns {Promise<IcpWallet>} A promise that resolves to an object, which can be used to interact with the ICP Wallet when it is connected.
    */
   static async connect(options: RelyingPartyOptions): Promise<IcpWallet> {
-    return await this.connectWallet({
+    return await this.connectSigner({
       options,
       init: (params: {origin: string; popup: Window}) => new IcpWallet(params)
     });

--- a/src/relying-party.spec.ts
+++ b/src/relying-party.spec.ts
@@ -106,7 +106,7 @@ describe('Relying Party', () => {
           const incorrectOrigin = 'test';
 
           await expect(RelyingParty.connect({url: incorrectOrigin})).rejects.toThrow(
-            'Wallet options cannot be parsed:'
+            'Options cannot be parsed:'
           );
         });
       });

--- a/src/relying-party.ts
+++ b/src/relying-party.ts
@@ -67,13 +67,13 @@ export class RelyingParty {
    * @returns {Promise<RelyingParty>} A promise that resolves to an object, which can be used to interact with the signer when it is connected.
    */
   static async connect(options: RelyingPartyOptions): Promise<RelyingParty> {
-    return await this.connectWallet({
+    return await this.connectSigner({
       options,
       init: (params: {origin: string; popup: Window}) => new RelyingParty(params)
     });
   }
 
-  protected static async connectWallet<T extends RelyingParty>({
+  protected static async connectSigner<T extends RelyingParty>({
     options,
     init
   }: {
@@ -83,7 +83,7 @@ export class RelyingParty {
     const {success: optionsSuccess, error} = RelyingPartyOptionsSchema.safeParse(options);
 
     if (!optionsSuccess) {
-      throw new Error(`Wallet options cannot be parsed: ${error?.message ?? ''}`);
+      throw new Error(`Options cannot be parsed: ${error?.message ?? ''}`);
     }
 
     const {url, windowOptions, connectionOptions} = options;


### PR DESCRIPTION
# Motivation

The relying party was inheriting a type RelyingParty while it should receive an IcpWallet.
