### PR TITLE
refactor: move window types around and rename interfaces

### DIFF
--- a/src/constants/relying-party.constants.ts
+++ b/src/constants/relying-party.constants.ts
@@ -1,5 +1,6 @@
 import type {IcrcRequestedScopes} from '../types/icrc-requests';
 import {IcrcScopedMethodSchema} from '../types/icrc-standards';
+import type {WindowOptions} from '../types/relying-party-options';
 
 const RELYING_PARTY_TIMEOUT_IN_MILLISECONDS_WITH_USER_INTERACTION = 60 * 2 * 1000;
 const RELYING_PARTY_TIMEOUT_IN_MILLISECONDS_WITHOUT_USER_INTERACTION = 5000;
@@ -19,4 +20,21 @@ export const RELYING_PARTY_TIMEOUT_CALL_CANISTER =
 
 export const RELYING_PARTY_DEFAULT_SCOPES: IcrcRequestedScopes = {
   scopes: Object.values(IcrcScopedMethodSchema.Values).map((method) => ({method}))
+};
+
+export const RELYING_PARTY_SIGNER_WINDOW_FEATURES =
+  'toolbar=no, location=no, directories=no, status=no, menubar=no, scrollbars=yes, resizable=no, copyhistory=no';
+
+export const RELYING_PARTY_SIGNER_WINDOW_TOP_RIGHT: WindowOptions = {
+  position: 'top-right',
+  width: 350,
+  height: 600,
+  features: RELYING_PARTY_SIGNER_WINDOW_FEATURES
+};
+
+export const RELYING_PARTY_SIGNER_WINDOW_CENTER: WindowOptions = {
+  position: 'center',
+  width: 576,
+  height: 625,
+  features: RELYING_PARTY_SIGNER_WINDOW_FEATURES
 };

--- a/src/relying-party.spec.ts
+++ b/src/relying-party.spec.ts
@@ -8,6 +8,8 @@ import {
 } from './constants/icrc.constants';
 import {
   RELYING_PARTY_DEFAULT_SCOPES,
+  RELYING_PARTY_SIGNER_WINDOW_CENTER,
+  RELYING_PARTY_SIGNER_WINDOW_TOP_RIGHT,
   RELYING_PARTY_TIMEOUT_ACCOUNTS,
   RELYING_PARTY_TIMEOUT_CALL_CANISTER,
   RELYING_PARTY_TIMEOUT_PERMISSIONS,
@@ -29,7 +31,7 @@ import {
 import {RelyingPartyResponseError} from './types/relying-party-errors';
 import type {RelyingPartyOptions} from './types/relying-party-options';
 import {JSON_RPC_VERSION_2, RpcResponseWithResultOrErrorSchema} from './types/rpc';
-import {WALLET_WINDOW_CENTER, WALLET_WINDOW_TOP_RIGHT, windowFeatures} from './utils/window.utils';
+import {windowFeatures} from './utils/window.utils';
 
 describe('Relying Party', () => {
   const mockParameters: RelyingPartyOptions = {url: 'https://test.com'};
@@ -116,15 +118,15 @@ describe('Relying Party', () => {
           {
             title: 'default options',
             params: mockParameters,
-            expectedOptions: windowFeatures(WALLET_WINDOW_TOP_RIGHT)
+            expectedOptions: windowFeatures(RELYING_PARTY_SIGNER_WINDOW_TOP_RIGHT)
           },
           {
             title: 'centered window',
             params: {
               ...mockParameters,
-              windowOptions: WALLET_WINDOW_CENTER
+              windowOptions: RELYING_PARTY_SIGNER_WINDOW_CENTER
             },
-            expectedOptions: windowFeatures(WALLET_WINDOW_CENTER)
+            expectedOptions: windowFeatures(RELYING_PARTY_SIGNER_WINDOW_CENTER)
           },
           {
             title: 'custom window',

--- a/src/relying-party.ts
+++ b/src/relying-party.ts
@@ -2,6 +2,7 @@ import {assertNonNullish, nonNullish, notEmptyString} from '@dfinity/utils';
 import {
   RELYING_PARTY_CONNECT_TIMEOUT_IN_MILLISECONDS,
   RELYING_PARTY_DEFAULT_SCOPES,
+  RELYING_PARTY_SIGNER_WINDOW_TOP_RIGHT,
   RELYING_PARTY_TIMEOUT_ACCOUNTS,
   RELYING_PARTY_TIMEOUT_CALL_CANISTER,
   RELYING_PARTY_TIMEOUT_PERMISSIONS,
@@ -42,7 +43,7 @@ import {
   type RpcId
 } from './types/rpc';
 import type {ReadyOrError} from './utils/timeout.utils';
-import {WALLET_WINDOW_TOP_RIGHT, windowFeatures} from './utils/window.utils';
+import {windowFeatures} from './utils/window.utils';
 
 export class RelyingParty {
   readonly #origin: string;
@@ -91,7 +92,7 @@ export class RelyingParty {
     const popupFeatures =
       typeof windowOptions === 'string'
         ? windowOptions
-        : windowFeatures(windowOptions ?? WALLET_WINDOW_TOP_RIGHT);
+        : windowFeatures(windowOptions ?? RELYING_PARTY_SIGNER_WINDOW_TOP_RIGHT);
 
     const popup = window.open(url, 'relyingPartyWindow', popupFeatures);
 

--- a/src/types/relying-party-options.ts
+++ b/src/types/relying-party-options.ts
@@ -1,15 +1,15 @@
 import {z} from 'zod';
 
-const RelyingPartyConnectionOptionsSchema = z.object({
+const ConnectionOptionsSchema = z.object({
   /**
-   * Specifies the interval in milliseconds at which the relying party is checked (polled) to determine if it is ready.
+   * Specifies the interval in milliseconds at which the signer is checked (polled) to determine if it is ready.
    *
    * @default 500 - The default polling interval is set to 500 milliseconds.
    */
   pollingIntervalInMilliseconds: z.number().optional(),
 
   /**
-   * Specifies the maximum duration in milliseconds for attempting to establish a connection to the relying party.
+   * Specifies the maximum duration in milliseconds for attempting to establish a connection to the signer.
    * If the connection is not established within this duration, the process will time out.
    *
    * @default 120_000 - The default timeout is set to 120,000 milliseconds (2 minutes).
@@ -17,46 +17,48 @@ const RelyingPartyConnectionOptionsSchema = z.object({
   timeoutInMilliseconds: z.number().optional()
 });
 
-const RelyingPartyWindowOptionsSchema = z.object({
+export type ConnectionOptions = z.infer<typeof ConnectionOptionsSchema>;
+
+const WindowOptionsSchema = z.object({
   /**
-   * Specifies the position of the relying party window.
+   * Specifies the position of the signer window.
    */
   position: z.enum(['top-right', 'center']),
 
   /**
-   * Specifies the width of the relying party window.
+   * Specifies the width of the signer window.
    */
   width: z.number(),
 
   /**
-   * Specifies the height of the relying party window.
+   * Specifies the height of the signer window.
    */
   height: z.number(),
 
   /**
-   * Optional features for the relying party Window object.
+   * Optional features for the signer Window object.
    */
   features: z.string().optional()
 });
 
+export type WindowOptions = z.infer<typeof WindowOptionsSchema>;
+
 export const RelyingPartyOptionsSchema = z.object({
   /**
-   * The URL of the relying party.
+   * The URL of the signer.
    */
   url: z.string().url(),
 
   /**
-   * Optional window options to display the relying party, which can be an object of type RelyingPartyWindowOptions or a string.
+   * Optional window options to display the signer, which can be an object of type WindowOptions or a string.
    * If a string is passed, those are applied as-is to the window that is opened (see https://developer.mozilla.org/en-US/docs/Web/API/Window/open#windowfeatures for more information).
    */
-  windowOptions: z.union([RelyingPartyWindowOptionsSchema, z.string()]).optional(),
+  windowOptions: z.union([WindowOptionsSchema, z.string()]).optional(),
 
   /**
-   * The connection options for establishing the connection with the relying party.
+   * The connection options for establishing the connection with the signer.
    */
-  connectionOptions: RelyingPartyConnectionOptionsSchema.optional()
+  connectionOptions: ConnectionOptionsSchema.optional()
 });
 
-export type RelyingPartyConnectionOptions = z.infer<typeof RelyingPartyConnectionOptionsSchema>;
-export type RelyingPartyWindowOptions = z.infer<typeof RelyingPartyWindowOptionsSchema>;
 export type RelyingPartyOptions = z.infer<typeof RelyingPartyOptionsSchema>;

--- a/src/utils/window.utils.ts
+++ b/src/utils/window.utils.ts
@@ -1,31 +1,9 @@
 import {isNullish} from '@dfinity/utils';
+import {RELYING_PARTY_SIGNER_WINDOW_FEATURES} from '../constants/relying-party.constants';
+import type {WindowOptions} from '../types/relying-party-options';
 import {isBrowser} from './env.utils';
 
-export interface WalletWindowOptions {
-  position: 'top-right' | 'center';
-  width: number;
-  height: number;
-  features?: string;
-}
-
-const WALLET_WINDOW_FEATURES =
-  'toolbar=no, location=no, directories=no, status=no, menubar=no, scrollbars=yes, resizable=no, copyhistory=no';
-
-export const WALLET_WINDOW_TOP_RIGHT: WalletWindowOptions = {
-  position: 'top-right',
-  width: 350,
-  height: 600,
-  features: WALLET_WINDOW_FEATURES
-};
-
-export const WALLET_WINDOW_CENTER: WalletWindowOptions = {
-  position: 'center',
-  width: 576,
-  height: 625,
-  features: WALLET_WINDOW_FEATURES
-};
-
-export const windowFeatures = ({position, ...rest}: WalletWindowOptions): string | undefined => {
+export const windowFeatures = ({position, ...rest}: WindowOptions): string | undefined => {
   const fn = position === 'center' ? windowCenter : windowTopRight;
   return fn(rest);
 };
@@ -33,8 +11,8 @@ export const windowFeatures = ({position, ...rest}: WalletWindowOptions): string
 const windowCenter = ({
   width,
   height,
-  features = WALLET_WINDOW_FEATURES
-}: Omit<WalletWindowOptions, 'position'>): string | undefined => {
+  features = RELYING_PARTY_SIGNER_WINDOW_FEATURES
+}: Omit<WindowOptions, 'position'>): string | undefined => {
   if (!isBrowser()) {
     return undefined;
   }
@@ -56,8 +34,8 @@ const windowCenter = ({
 const windowTopRight = ({
   width,
   height,
-  features = WALLET_WINDOW_FEATURES
-}: Omit<WalletWindowOptions, 'position'>): string | undefined => {
+  features = RELYING_PARTY_SIGNER_WINDOW_FEATURES
+}: Omit<WindowOptions, 'position'>): string | undefined => {
   if (!isBrowser()) {
     return undefined;
   }


### PR DESCRIPTION
# Motivation

Few things were implemented since those types and constants were introduced. This PR is a clean-up or alignement.