### PR TITLE
feat: use port 4943

### DIFF
--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   juno-satellite:
     image: junobuild/satellite:latest
     ports:
-      - 5987:5987
+      - 4943:5987
     volumes:
       - juno_satellite:/juno/.juno
       - ./juno.dev.config.js:/juno/juno.dev.config.js

--- a/demo/src/core/stores/auth.store.ts
+++ b/demo/src/core/stores/auth.store.ts
@@ -59,8 +59,8 @@ const initAuthStore = (): AuthStore => {
 				const identityProvider =
 					nonNullish(container) && nonNullish(iiId)
 						? /apple/i.test(navigator?.vendor)
-							? `http://localhost:5987?canisterId=${iiId}`
-							: `http://${iiId}.localhost:5987`
+							? `http://localhost:4943?canisterId=${iiId}`
+							: `http://${iiId}.localhost:4943`
 						: `https://identity.${domain ?? 'ic0.app'}`;
 
 				await authClient?.login({

--- a/demo/src/wallet_frontend/src/routes/+page.svelte
+++ b/demo/src/wallet_frontend/src/routes/+page.svelte
@@ -23,7 +23,7 @@
 
 		signer = Signer.init({
 			owner: $authStore.identity,
-			host: 'http://localhost:5987'
+			host: 'http://localhost:4943'
 		});
 
 		return () => {

--- a/e2e/page-objects/party.page.ts
+++ b/e2e/page-objects/party.page.ts
@@ -27,7 +27,7 @@ export class PartyPage extends IdentityPage {
   }
 
   async waitReady(): Promise<void> {
-    const REPLICA_URL = 'http://127.0.0.1:5987';
+    const REPLICA_URL = 'http://127.0.0.1:4943';
     const INTERNET_IDENTITY_ID = 'rdmx6-jaaaa-aaaaa-aaadq-cai';
 
     await this.#partyIIPage.waitReady({url: REPLICA_URL, canisterId: INTERNET_IDENTITY_ID});

--- a/src/api/icrc21-canister.api.spec.ts
+++ b/src/api/icrc21-canister.api.spec.ts
@@ -40,7 +40,7 @@ vi.mock('@dfinity/utils', async (importOriginal) => {
 describe('icrc-21.canister.api', () => {
   const signerOptions: SignerOptions = {
     owner: Ed25519KeyIdentity.generate(),
-    host: 'http://localhost:5987'
+    host: 'http://localhost:4943'
   };
 
   let canister: Icrc21Canister;

--- a/src/services/signer.services.spec.ts
+++ b/src/services/signer.services.spec.ts
@@ -31,7 +31,7 @@ describe('Signer services', () => {
 
   const signerOptions: SignerOptions = {
     owner,
-    host: 'http://localhost:5987'
+    host: 'http://localhost:4943'
   };
 
   let originalOpener: typeof window.opener;

--- a/src/signer.spec.ts
+++ b/src/signer.spec.ts
@@ -50,7 +50,7 @@ describe('Signer', () => {
 
   const signerOptions: SignerOptions = {
     owner,
-    host: 'http://localhost:5987'
+    host: 'http://localhost:4943'
   };
 
   it('should init a signer', () => {


### PR DESCRIPTION
# Motivation

By using port `4943` for demo and E2E purposes, we can start the `dev:party` against the implementation in Oisy Wallet which is developed locally on `4943`.

