### PR TITLE
feat: export signer prompts types

### DIFF
--- a/demo/src/wallet_frontend/src/lib/ConfirmAccounts.svelte
+++ b/demo/src/wallet_frontend/src/lib/ConfirmAccounts.svelte
@@ -3,10 +3,7 @@
 	import type { Signer } from '@dfinity/oisy-wallet-signer/signer';
 	import { isNullish, nonNullish } from '@dfinity/utils';
 	import { ICRC27_ACCOUNTS } from '@dfinity/oisy-wallet-signer';
-	import type {
-		AccountsConfirmation,
-		AccountsPromptPayload
-	} from '@dfinity/oisy-wallet-signer/types/signer-prompts';
+	import type { AccountsConfirmation, AccountsPromptPayload } from '@dfinity/oisy-wallet-signer';
 	import { authStore } from '$core/stores/auth.store';
 
 	type Props = {

--- a/demo/src/wallet_frontend/src/lib/ConfirmConsentMessage.svelte
+++ b/demo/src/wallet_frontend/src/lib/ConfirmConsentMessage.svelte
@@ -5,7 +5,7 @@
 	import {
 		type ConsentMessageAnswer,
 		type ConsentMessagePromptPayload
-	} from '@dfinity/oisy-wallet-signer/types/signer-prompts';
+	} from '@dfinity/oisy-wallet-signer';
 	import type { icrc21_consent_info } from '@dfinity/oisy-wallet-signer/declarations/icrc-21';
 	import Button from '$core/components/Button.svelte';
 

--- a/demo/src/wallet_frontend/src/lib/ConfirmPermissions.svelte
+++ b/demo/src/wallet_frontend/src/lib/ConfirmPermissions.svelte
@@ -7,7 +7,7 @@
 	import type {
 		PermissionsConfirmation,
 		PermissionsPromptPayload
-	} from '@dfinity/oisy-wallet-signer/types/signer-prompts';
+	} from '@dfinity/oisy-wallet-signer';
 
 	type Props = {
 		signer: Signer | undefined;

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ export type * from './types/relying-party-options';
 export type * from './types/relying-party-requests';
 export type * from './types/rpc';
 export type * from './types/signer-options';
+export type * from './types/signer-prompts';
 
 export * from './constants/icrc.constants';
 export * from './constants/window.constants';


### PR DESCRIPTION
# Motivation

I noticed the prompts types were not exposed.