### PR TITLE
feat: sort scopes in signer

### DIFF
--- a/demo/src/wallet_frontend/src/lib/ConfirmPermissions.svelte
+++ b/demo/src/wallet_frontend/src/lib/ConfirmPermissions.svelte
@@ -18,11 +18,6 @@
 	let scopes = $state<IcrcScope[] | undefined>(undefined);
 	let confirm = $state<PermissionsConfirmation | undefined>(undefined);
 
-	const sortScope = (
-		{ scope: { method: methodA } }: IcrcScope,
-		{ scope: { method: methodB } }: IcrcScope
-	): number => methodA.localeCompare(methodB);
-
 	const resetPrompt = () => {
 		confirm = undefined;
 		scopes = undefined;
@@ -60,7 +55,7 @@
 				...scope,
 				state: scope.state === 'denied' ? 'granted' : 'denied'
 			} as IcrcScope
-		].sort(sortScope);
+		];
 	};
 
 	let countApproved = $derived((scopes ?? []).filter(({ state }) => state === 'granted').length);

--- a/src/signer.ts
+++ b/src/signer.ts
@@ -318,6 +318,10 @@ export class Signer {
               scope: {method},
               state: IcrcPermissionStateSchema.enum.denied
             }) as const as IcrcScope
+        )
+        .sort(
+          ({scope: {method: methodA}}: IcrcScope, {scope: {method: methodB}}: IcrcScope): number =>
+            methodA.localeCompare(methodB)
         );
 
       // TODO: Maybe validating that the list of requested scopes contains at least one scope would be cool?


### PR DESCRIPTION
# Motivation

It's probably useful for any signer to get the list of permissions sorted. Using the icrc standard as key is maybe not the best but, at least that way it's consistent.
