### PR TITLE
chore: failure E2E test screenshots

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -25,12 +25,20 @@ jobs:
           juno dev start --headless &
           cd ..
           npm run e2e:ci
-      - uses: actions/upload-artifact@v4
-        if: ${{ !cancelled() }}
+      - name: Upload Playwright report on failure
+        uses: actions/upload-artifact@v4
+        if: ${{ failure() }}
         with:
           name: playwright-report
           path: playwright-report/
-          retention-days: 30
+          retention-days: 3
+      - name: Upload Playwright results on failure
+        uses: actions/upload-artifact@v4
+        if: ${{ failure() }}
+        with:
+          name: test-results
+          path: test-results/
+          retention-days: 3
 
   may-merge:
     needs: ['e2e']

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -21,7 +21,8 @@ export default defineConfig({
   use: {
     testIdAttribute: 'data-tid',
     trace: 'on',
-    ...(DEV && {headless: false})
+    ...(DEV && {headless: false}),
+    screenshot: 'only-on-failure'
   },
   projects: [
     {


### PR DESCRIPTION
# Motivation

Make E2E tests failure screenshots available for download. It can be handy to debug issues with the tests in the CI.
