### PR TITLE
feat: pass origin to prompts

### DIFF
--- a/src/services/signer.service.ts
+++ b/src/services/signer.service.ts
@@ -1,7 +1,6 @@
 import {Principal} from '@dfinity/principal';
 import {isNullish} from '@dfinity/utils';
 import {Icrc21Canister} from '../api/icrc21-canister.api';
-import type {icrc21_consent_info} from '../declarations/icrc-21';
 import {
   notifyErrorActionAborted,
   notifyErrorRequestNotSupported,
@@ -12,7 +11,11 @@ import {
 import type {IcrcCallCanisterRequestParams} from '../types/icrc-requests';
 import type {Notify} from '../types/signer-handlers';
 import type {SignerOptions} from '../types/signer-options';
-import type {CallCanisterPrompt, ConsentMessageAnswer} from '../types/signer-prompts';
+import type {
+  CallCanisterPrompt,
+  ConsentMessageAnswer,
+  ConsentMessagePromptPayload
+} from '../types/signer-prompts';
 import {mapIcrc21ErrorToString} from '../utils/icrc-21.utils';
 
 export class SignerService {
@@ -73,7 +76,9 @@ export class SignerService {
 
       const {Ok: consentInfo} = response;
 
-      const {result} = await this.promptConsentMessage({consentInfo, prompt});
+      const {origin} = notify;
+
+      const {result} = await this.promptConsentMessage({consentInfo, prompt, origin});
 
       if (result === 'rejected') {
         notifyErrorActionAborted(notify);
@@ -110,11 +115,12 @@ export class SignerService {
 
   private async promptConsentMessage({
     prompt,
-    consentInfo
+    ...payload
   }: {
-    consentInfo: icrc21_consent_info;
     prompt: CallCanisterPrompt;
-  }): Promise<{result: 'approved' | 'rejected'}> {
+  } & Omit<ConsentMessagePromptPayload, 'approve' | 'reject'>): Promise<{
+    result: 'approved' | 'rejected';
+  }> {
     const promise = new Promise<{result: 'approved' | 'rejected'}>((resolve) => {
       const approve: ConsentMessageAnswer = () => {
         resolve({result: 'approved'});
@@ -124,7 +130,7 @@ export class SignerService {
         resolve({result: 'rejected'});
       };
 
-      prompt({approve, reject: userReject, consentInfo});
+      prompt({approve, reject: userReject, ...payload});
     });
 
     return await promise;

--- a/src/signer.spec.ts
+++ b/src/signer.spec.ts
@@ -537,7 +537,8 @@ describe('Signer', () => {
             scope: {...scope},
             state: IcrcPermissionStateSchema.enum.denied
           })),
-          confirmScopes: expect.any(Function)
+          confirmScopes: expect.any(Function),
+          origin: testOrigin
         });
 
         promptSpy.mockClear();
@@ -559,7 +560,8 @@ describe('Signer', () => {
             scope: {...scope},
             state: IcrcPermissionStateSchema.enum.denied
           })),
-          confirmScopes: expect.any(Function)
+          confirmScopes: expect.any(Function),
+          origin: testOrigin
         });
 
         promptSpy.mockClear();
@@ -595,7 +597,8 @@ describe('Signer', () => {
             scope: {...scope},
             state: IcrcPermissionStateSchema.enum.denied
           })),
-          confirmScopes: expect.any(Function)
+          confirmScopes: expect.any(Function),
+          origin: testOrigin
         });
 
         promptSpy.mockClear();
@@ -717,7 +720,8 @@ describe('Signer', () => {
                   state: IcrcPermissionStateSchema.enum.denied
                 }
               ],
-              confirmScopes: expect.any(Function)
+              confirmScopes: expect.any(Function),
+              origin: testOrigin
             });
           });
 

--- a/src/types/post-message.spec.ts
+++ b/src/types/post-message.spec.ts
@@ -1,0 +1,27 @@
+import {OriginSchema} from './post-message';
+
+describe('post-message', () => {
+  it('should validate a correct origin', () => {
+    const validUrl = 'https://test.com';
+    const result = OriginSchema.safeParse(validUrl);
+    expect(result.success).toBe(true);
+  });
+
+  it('should invalidate an incorrect origin', () => {
+    const invalidUrl = 'invalid-origin';
+    const result = OriginSchema.safeParse(invalidUrl);
+    expect(result.success).toBe(false);
+  });
+
+  it('should invalidate an empty origin string', () => {
+    const emptyUrl = '';
+    const result = OriginSchema.safeParse(emptyUrl);
+    expect(result.success).toBe(false);
+  });
+
+  it('should invalidate a non-string origin', () => {
+    const nonStringValue = 12345;
+    const result = OriginSchema.safeParse(nonStringValue);
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/types/post-message.ts
+++ b/src/types/post-message.ts
@@ -1,5 +1,5 @@
 import {z} from 'zod';
 
-const OriginSchema = z.string().url();
+export const OriginSchema = z.string().url();
 
 export type Origin = z.infer<typeof OriginSchema>;

--- a/src/types/signer-prompts.ts
+++ b/src/types/signer-prompts.ts
@@ -7,6 +7,7 @@ import {
 import type {icrc21_consent_info} from '../declarations/icrc-21';
 import {IcrcAccountsSchema} from './icrc-accounts';
 import {IcrcScopesArraySchema} from './icrc-responses';
+import {OriginSchema} from './post-message';
 
 export const PromptMethodSchema = z.enum([
   ICRC25_REQUEST_PERMISSIONS,
@@ -16,13 +17,17 @@ export const PromptMethodSchema = z.enum([
 
 export type PromptMethod = z.infer<typeof PromptMethodSchema>;
 
+const PromptPayloadSchema = z.object({
+  origin: OriginSchema
+});
+
 // Prompt for permissions
 
 const PermissionsConfirmationSchema = z.function().args(IcrcScopesArraySchema).returns(z.void());
 
 export type PermissionsConfirmation = z.infer<typeof PermissionsConfirmationSchema>;
 
-const PermissionsPromptPayloadSchema = z.object({
+const PermissionsPromptPayloadSchema = PromptPayloadSchema.extend({
   requestedScopes: IcrcScopesArraySchema,
   confirmScopes: PermissionsConfirmationSchema
 });
@@ -53,7 +58,7 @@ const AccountsConfirmationSchema = z.function().args(IcrcAccountsSchema).returns
 
 export type AccountsConfirmation = z.infer<typeof AccountsConfirmationSchema>;
 
-const AccountsPromptPayloadSchema = z.object({
+const AccountsPromptPayloadSchema = PromptPayloadSchema.extend({
   confirmAccounts: AccountsConfirmationSchema
 });
 
@@ -78,7 +83,7 @@ const ConsentMessageAnswerSchema = z.function().returns(z.void());
 
 export type ConsentMessageAnswer = z.infer<typeof ConsentMessageAnswerSchema>;
 
-const CallCanisterPromptPayloadSchema = z.object({
+const CallCanisterPromptPayloadSchema = PromptPayloadSchema.extend({
   consentInfo: z.custom<icrc21_consent_info>(),
   approve: ConsentMessageAnswerSchema,
   reject: ConsentMessageAnswerSchema


### PR DESCRIPTION
# Motivation

The signer might want to display the origin to the prompts - for example "origin xyz request permissions abc". That's why we extends the prompts with this information to pass it along.