### PR TITLE
feat: copy did types to dist

### DIFF
--- a/demo/src/wallet_frontend/src/lib/ConfirmConsentMessage.svelte
+++ b/demo/src/wallet_frontend/src/lib/ConfirmConsentMessage.svelte
@@ -6,7 +6,7 @@
 		type ConsentMessageAnswer,
 		type ConsentMessagePromptPayload
 	} from '@dfinity/oisy-wallet-signer';
-	import type { icrc21_consent_info } from '@dfinity/oisy-wallet-signer/declarations/icrc-21';
+	import type { icrc21_consent_info } from '@dfinity/oisy-wallet-signer';
 	import Button from '$core/components/Button.svelte';
 
 	type Props = {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   "scripts": {
     "format": "prettier . --write",
     "format:check": "prettier --check .",
-    "ts-declaration": "tsc --emitDeclarationOnly --outDir dist",
+    "ts-declaration": "tsc --emitDeclarationOnly --outDir dist && ./scripts/copy-idl-ts",
     "build": "tsc --noEmit && node rmdir.mjs && node esbuild.mjs && npm run ts-declaration",
     "lint": "eslint --max-warnings 0 \"src/**/*\"",
     "test": "tsc --noEmit -p ./tsconfig.spec.json && vitest",

--- a/scripts/copy-idl-ts
+++ b/scripts/copy-idl-ts
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+DIR=dist/declarations
+
+if [ ! -d "$DIR" ]; then
+  mkdir "$DIR"
+fi
+
+cp src/declarations/*.d.ts "$DIR"


### PR DESCRIPTION
# Motivation

`tsc --emitDeclarationOnly` does not actually copy the `.d.ts` so if we want to expose the auto-generated did types, we actually have to copy them when we build the library.
