### PR TITLE
feat: consistency in prompt approval naming

### DIFF
--- a/demo/src/wallet_frontend/src/lib/ConfirmAccounts.svelte
+++ b/demo/src/wallet_frontend/src/lib/ConfirmAccounts.svelte
@@ -3,7 +3,7 @@
 	import type { Signer } from '@dfinity/oisy-wallet-signer/signer';
 	import { isNullish, nonNullish } from '@dfinity/utils';
 	import { ICRC27_ACCOUNTS } from '@dfinity/oisy-wallet-signer';
-	import type { AccountsConfirmation, AccountsPromptPayload } from '@dfinity/oisy-wallet-signer';
+	import type { AccountsApproval, AccountsPromptPayload } from '@dfinity/oisy-wallet-signer';
 	import { authStore } from '$core/stores/auth.store';
 
 	type Props = {
@@ -12,10 +12,10 @@
 
 	let { signer }: Props = $props();
 
-	let confirm = $state<AccountsConfirmation | undefined>(undefined);
+	let approve = $state<AccountsApproval | undefined>(undefined);
 
 	const resetPrompt = () => {
-		confirm = undefined;
+		approve = undefined;
 	};
 
 	$effect(() => {
@@ -26,14 +26,14 @@
 
 		signer.register({
 			method: ICRC27_ACCOUNTS,
-			prompt: ({ confirmAccounts }: AccountsPromptPayload) => {
-				confirm = confirmAccounts;
+			prompt: ({ approve: approveAccounts }: AccountsPromptPayload) => {
+				approve = approveAccounts;
 			}
 		});
 	});
 
 	$effect(() => {
-		if (isNullish(confirm)) {
+		if (isNullish(approve)) {
 			return;
 		}
 
@@ -42,7 +42,7 @@
 			return;
 		}
 
-		confirm([
+		approve([
 			{
 				owner: $authStore.identity.getPrincipal().toText()
 			}

--- a/demo/src/wallet_frontend/src/lib/ConfirmPermissions.svelte
+++ b/demo/src/wallet_frontend/src/lib/ConfirmPermissions.svelte
@@ -4,10 +4,7 @@
 	import { isNullish, nonNullish } from '@dfinity/utils';
 	import { ICRC25_REQUEST_PERMISSIONS, type IcrcScope } from '@dfinity/oisy-wallet-signer';
 	import Button from '$core/components/Button.svelte';
-	import type {
-		PermissionsConfirmation,
-		PermissionsPromptPayload
-	} from '@dfinity/oisy-wallet-signer';
+	import type { PermissionsApproval, PermissionsPromptPayload } from '@dfinity/oisy-wallet-signer';
 
 	type Props = {
 		signer: Signer | undefined;
@@ -16,7 +13,7 @@
 	let { signer }: Props = $props();
 
 	let scopes = $state<IcrcScope[] | undefined>(undefined);
-	let confirm = $state<PermissionsConfirmation | undefined>(undefined);
+	let approve = $state<PermissionsApproval | undefined>(undefined);
 
 	const sortScope = (
 		{ scope: { method: methodA } }: IcrcScope,
@@ -24,7 +21,7 @@
 	): number => methodA.localeCompare(methodB);
 
 	const resetPrompt = () => {
-		confirm = undefined;
+		approve = undefined;
 		scopes = undefined;
 	};
 
@@ -36,8 +33,8 @@
 
 		signer.register({
 			method: ICRC25_REQUEST_PERMISSIONS,
-			prompt: ({ confirmScopes, requestedScopes }: PermissionsPromptPayload) => {
-				confirm = confirmScopes;
+			prompt: ({ approve: approveScopes, requestedScopes }: PermissionsPromptPayload) => {
+				approve = approveScopes;
 				scopes = requestedScopes;
 			}
 		});
@@ -48,7 +45,7 @@
 
 		// TODO: alert errors
 
-		confirm?.($state.snapshot(scopes)!);
+		approve?.($state.snapshot(scopes)!);
 
 		resetPrompt();
 	};

--- a/src/signer.spec.ts
+++ b/src/signer.spec.ts
@@ -35,11 +35,11 @@ import {
   AccountsPromptSchema,
   CallCanisterPromptSchema,
   PermissionsPromptSchema,
-  type AccountsConfirmation,
+  type AccountsApproval,
   type AccountsPromptPayload,
   type ConsentMessageAnswer,
   type ConsentMessagePromptPayload,
-  type PermissionsConfirmation,
+  type PermissionsApproval,
   type PermissionsPromptPayload
 } from './types/signer-prompts';
 import type {SessionPermissions} from './types/signer-sessions';
@@ -537,7 +537,7 @@ describe('Signer', () => {
             scope: {...scope},
             state: IcrcPermissionStateSchema.enum.denied
           })),
-          confirmScopes: expect.any(Function),
+          approve: expect.any(Function),
           origin: testOrigin
         });
 
@@ -560,7 +560,7 @@ describe('Signer', () => {
             scope: {...scope},
             state: IcrcPermissionStateSchema.enum.denied
           })),
-          confirmScopes: expect.any(Function),
+          approve: expect.any(Function),
           origin: testOrigin
         });
 
@@ -597,7 +597,7 @@ describe('Signer', () => {
             scope: {...scope},
             state: IcrcPermissionStateSchema.enum.denied
           })),
-          confirmScopes: expect.any(Function),
+          approve: expect.any(Function),
           origin: testOrigin
         });
 
@@ -720,7 +720,7 @@ describe('Signer', () => {
                   state: IcrcPermissionStateSchema.enum.denied
                 }
               ],
-              confirmScopes: expect.any(Function),
+              approve: expect.any(Function),
               origin: testOrigin
             });
           });
@@ -729,12 +729,12 @@ describe('Signer', () => {
         });
 
         it('should save granted permission after prompt for permissions', async () => {
-          let confirmScopes: PermissionsConfirmation | undefined;
+          let approve: PermissionsApproval | undefined;
 
           signer.register({
             method: ICRC25_REQUEST_PERMISSIONS,
-            prompt: ({confirmScopes: confirm, requestedScopes: _}: PermissionsPromptPayload) => {
-              confirmScopes = confirm;
+            prompt: ({approve: confirm, requestedScopes: _}: PermissionsPromptPayload) => {
+              approve = confirm;
             }
           });
 
@@ -742,10 +742,10 @@ describe('Signer', () => {
           window.dispatchEvent(messageEvent);
 
           await vi.waitFor(() => {
-            expect(confirmScopes).not.toBeUndefined();
+            expect(approve).not.toBeUndefined();
           });
 
-          confirmScopes?.([
+          approve?.([
             {
               scope: {method},
               state: IcrcPermissionStateSchema.enum.granted
@@ -771,12 +771,12 @@ describe('Signer', () => {
         });
 
         it('should notify error after prompt for permissions', async () => {
-          let confirmScopes: PermissionsConfirmation | undefined;
+          let approve: PermissionsApproval | undefined;
 
           signer.register({
             method: ICRC25_REQUEST_PERMISSIONS,
-            prompt: ({confirmScopes: confirm, requestedScopes: _}: PermissionsPromptPayload) => {
-              confirmScopes = confirm;
+            prompt: ({approve: confirm, requestedScopes: _}: PermissionsPromptPayload) => {
+              approve = confirm;
             }
           });
 
@@ -784,10 +784,10 @@ describe('Signer', () => {
           window.dispatchEvent(messageEvent);
 
           await vi.waitFor(() => {
-            expect(confirmScopes).not.toBeUndefined();
+            expect(approve).not.toBeUndefined();
           });
 
-          confirmScopes?.([
+          approve?.([
             {
               scope: {method},
               state: IcrcPermissionStateSchema.enum.denied
@@ -819,12 +819,12 @@ describe('Signer', () => {
         };
 
         it('should notify account for icrc27_accounts if permissions were already granted', async () => {
-          let confirmAccounts: AccountsConfirmation | undefined;
+          let approve: AccountsApproval | undefined;
 
           signer.register({
             method: ICRC27_ACCOUNTS,
-            prompt: ({confirmAccounts: confirm}: AccountsPromptPayload) => {
-              confirmAccounts = confirm;
+            prompt: ({approve: confirm}: AccountsPromptPayload) => {
+              approve = confirm;
             }
           });
 
@@ -843,10 +843,10 @@ describe('Signer', () => {
           window.dispatchEvent(messageEvent);
 
           await vi.waitFor(() => {
-            expect(confirmAccounts).not.toBeUndefined();
+            expect(approve).not.toBeUndefined();
           });
 
-          confirmAccounts?.(mockAccounts);
+          approve?.(mockAccounts);
 
           await vi.waitFor(() => {
             expect(postMessageMock).toHaveBeenNthCalledWith(
@@ -864,20 +864,20 @@ describe('Signer', () => {
         });
 
         it('should notify accounts after prompt for icrc27_accounts permissions', async () => {
-          let confirmScopes: PermissionsConfirmation | undefined;
-          let confirmAccounts: AccountsConfirmation | undefined;
+          let approveScopes: PermissionsApproval | undefined;
+          let approveAccounts: AccountsApproval | undefined;
 
           signer.register({
             method: ICRC25_REQUEST_PERMISSIONS,
-            prompt: ({confirmScopes: confirm, requestedScopes: _}: PermissionsPromptPayload) => {
-              confirmScopes = confirm;
+            prompt: ({approve, requestedScopes: _}: PermissionsPromptPayload) => {
+              approveScopes = approve;
             }
           });
 
           signer.register({
             method: ICRC27_ACCOUNTS,
-            prompt: ({confirmAccounts: confirm}: AccountsPromptPayload) => {
-              confirmAccounts = confirm;
+            prompt: ({approve}: AccountsPromptPayload) => {
+              approveAccounts = approve;
             }
           });
 
@@ -885,10 +885,10 @@ describe('Signer', () => {
           window.dispatchEvent(messageEvent);
 
           await vi.waitFor(() => {
-            expect(confirmScopes).not.toBeUndefined();
+            expect(approveScopes).not.toBeUndefined();
           });
 
-          confirmScopes?.([
+          approveScopes?.([
             {
               scope: {method: ICRC27_ACCOUNTS},
               state: IcrcPermissionStateSchema.enum.granted
@@ -896,10 +896,10 @@ describe('Signer', () => {
           ]);
 
           await vi.waitFor(() => {
-            expect(confirmAccounts).not.toBeUndefined();
+            expect(approveAccounts).not.toBeUndefined();
           });
 
-          confirmAccounts?.(mockAccounts);
+          approveAccounts?.(mockAccounts);
 
           await vi.waitFor(() => {
             expect(postMessageMock).toHaveBeenNthCalledWith(
@@ -966,13 +966,13 @@ describe('Signer', () => {
           });
 
           it('should prompt consent message after prompt for icrc49_call_canister permissions', async () => {
-            let confirmScopes: PermissionsConfirmation | undefined;
+            let approve: PermissionsApproval | undefined;
             const promptSpy = vi.fn();
 
             signer.register({
               method: ICRC25_REQUEST_PERMISSIONS,
-              prompt: ({confirmScopes: confirm, requestedScopes: _}: PermissionsPromptPayload) => {
-                confirmScopes = confirm;
+              prompt: ({approve: confirm, requestedScopes: _}: PermissionsPromptPayload) => {
+                approve = confirm;
               }
             });
 
@@ -985,10 +985,10 @@ describe('Signer', () => {
             window.dispatchEvent(messageEvent);
 
             await vi.waitFor(() => {
-              expect(confirmScopes).not.toBeUndefined();
+              expect(approve).not.toBeUndefined();
             });
 
-            confirmScopes?.([
+            approve?.([
               {
                 scope: {method: ICRC49_CALL_CANISTER},
                 state: IcrcPermissionStateSchema.enum.granted
@@ -1183,7 +1183,7 @@ describe('Signer', () => {
       });
 
       it('should notify scopes for selected permissions', async () => {
-        payload.confirmScopes(scopes);
+        payload.approve(scopes);
 
         await vi.waitFor(() => {
           expect(postMessageMock).toHaveBeenCalledWith(
@@ -1200,7 +1200,7 @@ describe('Signer', () => {
       });
 
       it('should save permissions in storage', async () => {
-        payload.confirmScopes(scopes);
+        payload.approve(scopes);
 
         const expectedKey = `oisy_signer_${testOrigin}_${signerOptions.owner.getPrincipal().toText()}`;
         const expectedData = {

--- a/src/signer.ts
+++ b/src/signer.ts
@@ -50,11 +50,11 @@ import {
   AccountsPromptSchema,
   CallCanisterPromptSchema,
   PermissionsPromptSchema,
-  type AccountsConfirmation,
+  type AccountsApproval,
   type AccountsPrompt,
   type AccountsPromptPayload,
   type CallCanisterPrompt,
-  type PermissionsConfirmation,
+  type PermissionsApproval,
   type PermissionsPrompt,
   type PermissionsPromptPayload,
   type PromptMethod
@@ -354,10 +354,10 @@ export class Signer {
   }
 
   private async promptPermissions(
-    payload: Omit<PermissionsPromptPayload, 'confirmScopes'>
+    payload: Omit<PermissionsPromptPayload, 'approve'>
   ): Promise<IcrcScopesArray> {
     const promise = new Promise<IcrcScopesArray>((resolve, reject) => {
-      const confirmScopes: PermissionsConfirmation = (scopes) => {
+      const approve: PermissionsApproval = (scopes) => {
         resolve(scopes);
       };
 
@@ -367,7 +367,7 @@ export class Signer {
         return;
       }
 
-      this.#permissionsPrompt({...payload, confirmScopes});
+      this.#permissionsPrompt({...payload, approve});
     });
 
     return await promise;
@@ -472,10 +472,10 @@ export class Signer {
 
   // TODO: this can maybe be made generic. It's really similar to promptPermissions.
   private async promptAccounts(
-    payload: Omit<AccountsPromptPayload, 'confirmAccounts'>
+    payload: Omit<AccountsPromptPayload, 'approve'>
   ): Promise<IcrcAccounts> {
     const promise = new Promise<IcrcAccounts>((resolve, reject) => {
-      const confirmAccounts: AccountsConfirmation = (accounts) => {
+      const approve: AccountsApproval = (accounts) => {
         resolve(accounts);
       };
 
@@ -485,7 +485,7 @@ export class Signer {
         return;
       }
 
-      this.#accountsPrompt({confirmAccounts, ...payload});
+      this.#accountsPrompt({approve, ...payload});
     });
 
     return await promise;

--- a/src/types/signer-prompts.spec.ts
+++ b/src/types/signer-prompts.spec.ts
@@ -77,7 +77,7 @@ describe('SignerPrompts', () => {
 
     it('should validate a prompt', () => {
       const prompt = (payload: PermissionsPromptPayload): void => {
-        payload.confirmScopes(scopes);
+        payload.approve(scopes);
       };
 
       expect(() => PermissionsPromptSchema.parse(prompt)).not.toThrow();
@@ -93,7 +93,7 @@ describe('SignerPrompts', () => {
   describe('Accounts', () => {
     it('should validate an AccountsPrompt', () => {
       const prompt = (payload: AccountsPromptPayload): void => {
-        payload.confirmAccounts(mockAccounts);
+        payload.approve(mockAccounts);
       };
 
       expect(() => AccountsPromptSchema.parse(prompt)).not.toThrow();

--- a/src/types/signer-prompts.ts
+++ b/src/types/signer-prompts.ts
@@ -23,13 +23,13 @@ const PromptPayloadSchema = z.object({
 
 // Prompt for permissions
 
-const PermissionsConfirmationSchema = z.function().args(IcrcScopesArraySchema).returns(z.void());
+const PermissionsApprovalSchema = z.function().args(IcrcScopesArraySchema).returns(z.void());
 
-export type PermissionsConfirmation = z.infer<typeof PermissionsConfirmationSchema>;
+export type PermissionsApproval = z.infer<typeof PermissionsApprovalSchema>;
 
 const PermissionsPromptPayloadSchema = PromptPayloadSchema.extend({
   requestedScopes: IcrcScopesArraySchema,
-  confirmScopes: PermissionsConfirmationSchema
+  approve: PermissionsApprovalSchema
 });
 
 export type PermissionsPromptPayload = z.infer<typeof PermissionsPromptPayloadSchema>;
@@ -43,7 +43,7 @@ export type PermissionsPromptPayload = z.infer<typeof PermissionsPromptPayloadSc
  *
  * @param {PermissionsPromptPayload} params - An object containing the requested permissions and a function to confirm them.
  * @param {IcrcScopes[]} params.requestedScopes - An array of IcrcScopes representing the permissions being requested.
- * @param {PermissionsConfirmation} params.confirmScopes - A function to be called by the consumer to confirm (grant or deny) the requested permissions.
+ * @param {PermissionsApproval} params.approve - A function to be called by the consumer to confirm (grant or deny) the requested permissions.
  */
 export const PermissionsPromptSchema = z
   .function()
@@ -54,12 +54,12 @@ export type PermissionsPrompt = z.infer<typeof PermissionsPromptSchema>;
 
 // Prompt for accounts
 
-const AccountsConfirmationSchema = z.function().args(IcrcAccountsSchema).returns(z.void());
+const AccountsApprovalSchema = z.function().args(IcrcAccountsSchema).returns(z.void());
 
-export type AccountsConfirmation = z.infer<typeof AccountsConfirmationSchema>;
+export type AccountsApproval = z.infer<typeof AccountsApprovalSchema>;
 
 const AccountsPromptPayloadSchema = PromptPayloadSchema.extend({
-  confirmAccounts: AccountsConfirmationSchema
+  approve: AccountsApprovalSchema
 });
 
 export type AccountsPromptPayload = z.infer<typeof AccountsPromptPayloadSchema>;
@@ -68,7 +68,7 @@ export type AccountsPromptPayload = z.infer<typeof AccountsPromptPayloadSchema>;
  * A function that is invoked when the signer requires the user - or consumer of the library - to confirm (select or reject) accounts.
  *
  * @param {AccountsPromptPayload} params - An object containing a function to confirm the accounts.
- * @param {IcrcAccounts[]} params.confirmAccounts - A function to be called by the consumer to confirm (select or reject) the provided accounts.
+ * @param {IcrcAccounts[]} params.approve - A function to be called by the consumer to confirm (select or reject) the provided accounts.
  */
 export const AccountsPromptSchema = z
   .function()


### PR DESCRIPTION
# Motivation

Let's add some consistency in the naming of the prompts. This makes the implementation / usage of the lib easier and more readable.