### PR TITLE
feat: copy cbor and borc implementation of agent-js (without tests)

### DIFF
--- a/src/agent/agentjs-borc-copy.d.ts
+++ b/src/agent/agentjs-borc-copy.d.ts
@@ -1,0 +1,27 @@
+/* eslint-disable */
+
+/**
+ * ⚠️ !!!WARNING!!! ⚠️
+ * This module is a copy/paste of the CBOR module, which is not exposed by Agent-js.
+ * It is not covered by any tests (‼️) in this library and contain multiple issues (‼️) based on ESLint results.
+ */
+
+declare module 'borc' {
+  import {Buffer} from 'buffer/';
+
+  class Decoder {
+    constructor(opts: {size: number; tags: Record<number, (val: any) => any>});
+
+    decodeFirst(input: ArrayBuffer): any;
+  }
+
+  export function decodeFirst(input: ArrayBuffer): any;
+
+  export function encode(o: any): Buffer;
+
+  class Tagged {
+    tag: number;
+    value: any;
+    constructor(tag: Number, value: any);
+  }
+}

--- a/src/agent/agentjs-cbor-copy.ts
+++ b/src/agent/agentjs-cbor-copy.ts
@@ -1,0 +1,141 @@
+/* eslint-disable */
+
+/**
+ * ⚠️ !!!WARNING!!! ⚠️
+ * This module is a copy/paste of the CBOR module, which is not exposed by Agent-js.
+ * It is not covered by any tests (‼️) in this library and contain multiple issues (‼️) based on ESLint results.
+ */
+
+// This file is based on:
+// https://github.com/dfinity-lab/dfinity/blob/9bca65f8edd65701ea6bdb00e0752f9186bbc893/docs/spec/public/index.adoc#cbor-encoding-of-requests-and-responses
+import {concat, fromHex, toHex} from '@dfinity/agent';
+import {Principal} from '@dfinity/principal';
+import borc from 'borc';
+import * as cbor from 'simple-cbor';
+import {CborEncoder, SelfDescribeCborSerializer} from 'simple-cbor';
+
+// We are using hansl/simple-cbor for CBOR serialization, to avoid issues with
+// encoding the uint64 values that the HTTP handler of the client expects for
+// canister IDs. However, simple-cbor does not yet provide deserialization so
+// we are using `Uint8Array` so that we can use the dignifiedquire/borc CBOR
+// decoder.
+
+class PrincipalEncoder implements CborEncoder<Principal> {
+  public get name() {
+    return 'Principal';
+  }
+
+  public get priority() {
+    return 0;
+  }
+
+  public match(value: any): boolean {
+    return value && value._isPrincipal === true;
+  }
+
+  public encode(v: Principal): cbor.CborValue {
+    return cbor.value.bytes(v.toUint8Array());
+  }
+}
+
+class BufferEncoder implements CborEncoder<ArrayBuffer> {
+  public get name() {
+    return 'Buffer';
+  }
+
+  public get priority() {
+    return 1;
+  }
+
+  public match(value: any): boolean {
+    return value instanceof ArrayBuffer || ArrayBuffer.isView(value);
+  }
+
+  public encode(v: ArrayBuffer): cbor.CborValue {
+    return cbor.value.bytes(new Uint8Array(v));
+  }
+}
+
+class BigIntEncoder implements CborEncoder<BigInt> {
+  public get name() {
+    return 'BigInt';
+  }
+
+  public get priority() {
+    return 1;
+  }
+
+  public match(value: any): boolean {
+    return typeof value === `bigint`;
+  }
+
+  public encode(v: bigint): cbor.CborValue {
+    // Always use a bigint encoding.
+    if (v > BigInt(0)) {
+      return cbor.value.tagged(2, cbor.value.bytes(fromHex(v.toString(16))));
+    } else {
+      return cbor.value.tagged(3, cbor.value.bytes(fromHex((BigInt('-1') * v).toString(16))));
+    }
+  }
+}
+
+const serializer = SelfDescribeCborSerializer.withDefaultEncoders(true);
+serializer.addEncoder(new PrincipalEncoder());
+serializer.addEncoder(new BufferEncoder());
+serializer.addEncoder(new BigIntEncoder());
+
+export enum CborTag {
+  Uint64LittleEndian = 71,
+  Semantic = 55799
+}
+
+/**
+ * Encode a JavaScript value into CBOR.
+ */
+export function encode(value: any): ArrayBuffer {
+  return serializer.serialize(value);
+}
+
+function decodePositiveBigInt(buf: Uint8Array): bigint {
+  const len = buf.byteLength;
+  let res = BigInt(0);
+  for (let i = 0; i < len; i++) {
+    res = res * BigInt(0x100) + BigInt(buf[i]);
+  }
+
+  return res;
+}
+
+// A BORC subclass that decodes byte strings to ArrayBuffer instead of the Buffer class.
+class Uint8ArrayDecoder extends borc.Decoder {
+  public createByteString(raw: ArrayBuffer[]): ArrayBuffer {
+    return concat(...raw);
+  }
+
+  public createByteStringFromHeap(start: number, end: number): ArrayBuffer {
+    if (start === end) {
+      return new ArrayBuffer(0);
+    }
+
+    return new Uint8Array((this as any)._heap.slice(start, end));
+  }
+}
+
+export function decode<T>(input: ArrayBuffer): T {
+  const buffer = new Uint8Array(input);
+  const decoder = new Uint8ArrayDecoder({
+    size: buffer.byteLength,
+    tags: {
+      // Override tags 2 and 3 for BigInt support (borc supports only BigNumber).
+      2: (val) => decodePositiveBigInt(val),
+      3: (val) => -decodePositiveBigInt(val),
+      [CborTag.Semantic]: (value: T): T => value
+    }
+  });
+
+  try {
+    return decoder.decodeFirst(buffer);
+  } catch (e: unknown) {
+    throw new Error(`Failed to decode CBOR: ${e}, input: ${toHex(buffer)}`);
+  }
+}


### PR DESCRIPTION
# Motivation

We need to implement some logic that ideally should have been part of agent-js from the beginning. As a result, we must encode and decode certificates and content maps, since agent-js only exposes structured data—which makes sense. However, to achieve this, we need to encode and decode using CBOR and borc, both of which require specific serializers, particularly for handling principals. Since these are not exposed by agent-js, we have no choice but to copy those modules.

⚠️ These modules are copied without any accompanying tests.