### PR TITLE
feat: use custom http agent

### DIFF
--- a/src/agent/custom-http-agent.spec.ts
+++ b/src/agent/custom-http-agent.spec.ts
@@ -27,6 +27,7 @@ vi.mock('@dfinity/agent', async (importOriginal) => {
 
   class MockHttpAgent {
     call = vi.fn();
+    create = vi.fn();
 
     get rootKey(): ArrayBuffer {
       return mockLocalIcRootKey.buffer;
@@ -104,6 +105,17 @@ describe('CustomHttpAgent', () => {
     const agent = await CustomHttpAgent.create({});
     expect(agent.agent).toBeDefined();
     expect(agent.agent).toBeInstanceOf(httpAgent.HttpAgent);
+  });
+
+  it('should call HttpAgent.create once with the provided options', async () => {
+    const agentOptions = {shouldFetchRootKey: true};
+
+    await CustomHttpAgent.create(agentOptions);
+
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(httpAgent.HttpAgent.create).toHaveBeenCalledTimes(1);
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(httpAgent.HttpAgent.create).toHaveBeenCalledWith(agentOptions);
   });
 
   describe('Success call', () => {

--- a/src/api/agent.api.ts
+++ b/src/api/agent.api.ts
@@ -1,11 +1,11 @@
-import type {Agent, HttpAgent} from '@dfinity/agent';
-import {createAgent as createAgentUtils, isNullish} from '@dfinity/utils';
+import {isNullish} from '@dfinity/utils';
+import {CustomHttpAgent} from '../agent/custom-http-agent';
 import type {SignerOptions} from '../types/signer-options';
 
 export abstract class AgentApi {
-  #agents: Record<string, HttpAgent> | undefined = undefined;
+  #agents: Record<string, CustomHttpAgent> | undefined = undefined;
 
-  protected async getAgent({owner, ...rest}: SignerOptions): Promise<Agent> {
+  protected async getAgent({owner, ...rest}: SignerOptions): Promise<CustomHttpAgent> {
     const key = owner.getPrincipal().toText();
 
     if (isNullish(this.#agents) || isNullish(this.#agents[key])) {
@@ -22,17 +22,17 @@ export abstract class AgentApi {
     return this.#agents[key];
   }
 
-  private async createAgent({owner: identity, host}: SignerOptions): Promise<HttpAgent> {
+  private async createAgent({owner: identity, host}: SignerOptions): Promise<CustomHttpAgent> {
     const mainnetHost = 'https://icp-api.io';
 
     const {hostname} = new URL(host ?? mainnetHost);
 
-    const local = ['localhost', '127.0.0.1'].includes(hostname);
+    const shouldFetchRootKey = ['localhost', '127.0.0.1'].includes(hostname);
 
-    return await createAgentUtils({
+    return await CustomHttpAgent.create({
       identity,
-      ...(local && {fetchRootKey: true}),
-      host: host ?? mainnetHost
+      host: host ?? mainnetHost,
+      shouldFetchRootKey
     });
   }
 }

--- a/src/api/icrc21-canister.api.ts
+++ b/src/api/icrc21-canister.api.ts
@@ -64,7 +64,7 @@ export class Icrc21Canister extends AgentApi {
     canisterId: string | Principal;
     idlFactory: IDL.InterfaceFactory;
   } & SignerOptions): Promise<ActorSubclass<T>> {
-    const agent = await this.getAgent({host, owner});
+    const {agent} = await this.getAgent({host, owner});
 
     return await Actor.createActor(idlFactory, {
       agent,


### PR DESCRIPTION
# Motivation

Given that we have a implemented a custom wrapper for the http agent, that takes care of the logic to pass calls, we can start using it for our actors and cache of agents.
