### PR TITLE
feat: link signer api call into service

### DIFF
--- a/src/mocks/consent-message.mocks.ts
+++ b/src/mocks/consent-message.mocks.ts
@@ -1,4 +1,11 @@
+import {fromHex} from '@dfinity/agent';
+import {arrayBufferToUint8Array} from '@dfinity/utils';
+import {encode} from '../agent/agentjs-cbor-copy';
 import type {icrc21_consent_info} from '../declarations/icrc-21';
+import type {IcrcCallCanisterResult} from '../types/icrc-responses';
+import {uint8ArrayToBase64} from '../utils/base64.utils';
+import {mockRepliedLocalCertificate} from './custom-http-agent-responses.mocks';
+import {mockRequestDetails} from './custom-http-agent.mocks';
 
 export const mockConsentInfo: icrc21_consent_info = {
   consent_message: {GenericDisplayMessage: 'Test Consent Message'},
@@ -6,4 +13,11 @@ export const mockConsentInfo: icrc21_consent_info = {
     language: 'en',
     utc_offset_minutes: [0]
   }
+};
+
+export const mockCanisterCallSuccess: IcrcCallCanisterResult = {
+  certificate: uint8ArrayToBase64(
+    arrayBufferToUint8Array(encode(fromHex(mockRepliedLocalCertificate)))
+  ),
+  contentMap: uint8ArrayToBase64(arrayBufferToUint8Array(encode(mockRequestDetails)))
 };

--- a/src/services/signer.service.ts
+++ b/src/services/signer.service.ts
@@ -1,6 +1,6 @@
 import {Principal} from '@dfinity/principal';
 import {isNullish} from '@dfinity/utils';
-import {Icrc21Canister} from '../api/icrc21-canister.api';
+import {SignerApi} from '../api/signer.api';
 import {
   notifyErrorActionAborted,
   notifyErrorRequestNotSupported,
@@ -20,7 +20,7 @@ import {base64ToUint8Array} from '../utils/base64.utils';
 import {mapIcrc21ErrorToString} from '../utils/icrc-21.utils';
 
 export class SignerService {
-  readonly #icrc21Canister = new Icrc21Canister();
+  readonly #signerApi = new SignerApi();
 
   async assertAndPromptConsentMessage({
     params: {canisterId, method, arg, sender},
@@ -46,7 +46,7 @@ export class SignerService {
     }
 
     try {
-      const response = await this.#icrc21Canister.consentMessage({
+      const response = await this.#signerApi.consentMessage({
         owner,
         host,
         canisterId,
@@ -97,6 +97,22 @@ export class SignerService {
 
       return {result: 'error'};
     }
+  }
+
+  // TODO: return, error, notify, result, etc.
+  async callCanister({
+    params,
+    notify: _TODO,
+    options
+  }: {
+    params: IcrcCallCanisterRequestParams;
+    notify: Notify;
+    options: SignerOptions;
+  }): Promise<void> {
+    await this.#signerApi.call({
+      ...options,
+      params
+    });
   }
 
   private assertSender({

--- a/src/services/signer.services.spec.ts
+++ b/src/services/signer.services.spec.ts
@@ -1,8 +1,9 @@
 import {Ed25519KeyIdentity} from '@dfinity/identity';
 import type {Mock, MockInstance} from 'vitest';
 import {Icrc21Canister} from '../api/icrc21-canister.api';
+import {SignerApi} from '../api/signer.api';
 import {SignerErrorCode} from '../constants/signer.constants';
-import {mockConsentInfo} from '../mocks/consent-message.mocks';
+import {mockCanisterCallSuccess, mockConsentInfo} from '../mocks/consent-message.mocks';
 import {mockPrincipalText} from '../mocks/icrc-accounts.mocks';
 import {mockErrorNotify} from '../mocks/signer-error.mocks';
 import type {IcrcCallCanisterRequestParams} from '../types/icrc-requests';
@@ -16,7 +17,6 @@ import {SignerService} from './signer.service';
 
 describe('Signer services', () => {
   let requestId: RpcId;
-  let spy: MockInstance;
   let signerService: SignerService;
 
   const testOrigin = 'https://hello.com';
@@ -48,7 +48,6 @@ describe('Signer services', () => {
     vi.stubGlobal('opener', {postMessage: postMessageMock});
 
     requestId = crypto.randomUUID();
-    spy = vi.spyOn(Icrc21Canister.prototype, 'consentMessage');
 
     notify = {
       id: requestId,
@@ -64,48 +63,20 @@ describe('Signer services', () => {
     vi.clearAllMocks();
   });
 
-  it('should return approved when user approves the consent message', async () => {
-    spy.mockResolvedValue({
-      Ok: mockConsentInfo
-    });
+  describe('Consent message', () => {
+    let spyIcrc21CanisterConsentMessage: MockInstance;
 
-    const prompt = ({approve}: ConsentMessagePromptPayload): void => {
-      approve();
-    };
-
-    const result = await signerService.assertAndPromptConsentMessage({
-      notify,
-      params,
-      prompt,
-      options: signerOptions
-    });
-
-    expect(result).toEqual({result: 'approved'});
-
-    expect(spy).toHaveBeenCalledWith({
-      ...signerOptions,
-      canisterId: params.canisterId,
-      request: {
-        method: params.method,
-        arg: base64ToUint8Array(params.arg),
-        user_preferences: {
-          metadata: {language: 'en', utc_offset_minutes: []},
-          device_spec: []
-        }
-      }
-    });
-  });
-
-  describe('User reject consent', () => {
     beforeEach(() => {
-      spy.mockResolvedValue({
+      spyIcrc21CanisterConsentMessage = vi.spyOn(Icrc21Canister.prototype, 'consentMessage');
+    });
+
+    it('should return approved when user approves the consent message', async () => {
+      spyIcrc21CanisterConsentMessage.mockResolvedValue({
         Ok: mockConsentInfo
       });
-    });
 
-    it('should return rejected when user rejects the consent message', async () => {
-      const prompt = ({reject}: ConsentMessagePromptPayload): void => {
-        reject();
+      const prompt = ({approve}: ConsentMessagePromptPayload): void => {
+        approve();
       };
 
       const result = await signerService.assertAndPromptConsentMessage({
@@ -115,41 +86,213 @@ describe('Signer services', () => {
         options: signerOptions
       });
 
-      expect(result).toEqual({result: 'rejected'});
+      expect(result).toEqual({result: 'approved'});
+
+      expect(spyIcrc21CanisterConsentMessage).toHaveBeenCalledWith({
+        ...signerOptions,
+        canisterId: params.canisterId,
+        request: {
+          method: params.method,
+          arg: base64ToUint8Array(params.arg),
+          user_preferences: {
+            metadata: {language: 'en', utc_offset_minutes: []},
+            device_spec: []
+          }
+        }
+      });
     });
 
-    it('should call notifyErrorActionAborted when user rejects consent message', async () => {
-      const prompt = ({reject}: ConsentMessagePromptPayload): void => {
-        reject();
-      };
+    describe('User reject consent', () => {
+      beforeEach(() => {
+        spyIcrc21CanisterConsentMessage.mockResolvedValue({
+          Ok: mockConsentInfo
+        });
+      });
 
+      it('should return rejected when user rejects the consent message', async () => {
+        const prompt = ({reject}: ConsentMessagePromptPayload): void => {
+          reject();
+        };
+
+        const result = await signerService.assertAndPromptConsentMessage({
+          notify,
+          params,
+          prompt,
+          options: signerOptions
+        });
+
+        expect(result).toEqual({result: 'rejected'});
+      });
+
+      it('should call notifyErrorActionAborted when user rejects consent message', async () => {
+        const prompt = ({reject}: ConsentMessagePromptPayload): void => {
+          reject();
+        };
+
+        await signerService.assertAndPromptConsentMessage({
+          notify,
+          params,
+          prompt,
+          options: signerOptions
+        });
+
+        const expectedMessage: RpcResponseWithError = {
+          jsonrpc: JSON_RPC_VERSION_2,
+          id: requestId,
+          error: mockErrorNotify
+        };
+
+        expect(postMessageMock).toHaveBeenCalledWith(expectedMessage, testOrigin);
+      });
+    });
+
+    describe('Call consent message responds with an error', () => {
+      const error = {GenericError: {description: 'Error', error_code: 1n}};
+
+      beforeEach(() => {
+        spyIcrc21CanisterConsentMessage.mockResolvedValue({
+          Err: error
+        });
+      });
+
+      it('should return error when consentMessage returns error', async () => {
+        const prompt = vi.fn();
+
+        const result = await signerService.assertAndPromptConsentMessage({
+          notify,
+          params,
+          prompt,
+          options: signerOptions
+        });
+
+        expect(result).toEqual({result: 'error'});
+        expect(prompt).not.toHaveBeenCalled();
+      });
+
+      it('should call notifyErrorRequestNotSupported when consentMessage returns error', async () => {
+        await signerService.assertAndPromptConsentMessage({
+          notify,
+          params,
+          prompt: vi.fn(),
+          options: signerOptions
+        });
+
+        const errorNotify = {
+          code: SignerErrorCode.REQUEST_NOT_SUPPORTED,
+          message: mapIcrc21ErrorToString(error)
+        };
+
+        const expectedMessage: RpcResponseWithError = {
+          jsonrpc: JSON_RPC_VERSION_2,
+          id: requestId,
+          error: errorNotify
+        };
+
+        expect(postMessageMock).toHaveBeenCalledWith(expectedMessage, testOrigin);
+      });
+    });
+
+    describe('Call consent message throws an error', () => {
+      it('should return error when consentMessage throws an error', async () => {
+        spyIcrc21CanisterConsentMessage.mockImplementation(() => {
+          // eslint-disable-next-line @typescript-eslint/no-throw-literal
+          throw 'Test';
+        });
+
+        const mockSpy = vi.fn();
+
+        const result = await signerService.assertAndPromptConsentMessage({
+          notify,
+          params,
+          prompt: mockSpy,
+          options: signerOptions
+        });
+
+        expect(result).toEqual({result: 'error'});
+        expect(mockSpy).not.toHaveBeenCalled();
+      });
+
+      it('should call notifyNetworkError with an unknown error message when consentMessage throws some error', async () => {
+        spyIcrc21CanisterConsentMessage.mockImplementation(() => {
+          // eslint-disable-next-line @typescript-eslint/no-throw-literal
+          throw 'Test';
+        });
+
+        await signerService.assertAndPromptConsentMessage({
+          notify,
+          params,
+          prompt: vi.fn(),
+          options: signerOptions
+        });
+
+        const errorNotify = {
+          code: SignerErrorCode.NETWORK_ERROR,
+          message: 'An unknown error occurred'
+        };
+
+        const expectedMessage: RpcResponseWithError = {
+          jsonrpc: JSON_RPC_VERSION_2,
+          id: requestId,
+          error: errorNotify
+        };
+
+        expect(postMessageMock).toHaveBeenCalledWith(expectedMessage, testOrigin);
+      });
+
+      it('should call notifyNetworkError with an the error message when consentMessage throws an error', async () => {
+        const errorMessage = 'This is a test';
+
+        spyIcrc21CanisterConsentMessage.mockImplementation(() => {
+          throw new Error(errorMessage);
+        });
+
+        await signerService.assertAndPromptConsentMessage({
+          notify,
+          params,
+          prompt: vi.fn(),
+          options: signerOptions
+        });
+
+        const errorNotify = {
+          code: SignerErrorCode.NETWORK_ERROR,
+          message: errorMessage
+        };
+
+        const expectedMessage: RpcResponseWithError = {
+          jsonrpc: JSON_RPC_VERSION_2,
+          id: requestId,
+          error: errorNotify
+        };
+
+        expect(postMessageMock).toHaveBeenCalledWith(expectedMessage, testOrigin);
+      });
+    });
+
+    it('should notify MissingPromptError if prompt is undefined', async () => {
       await signerService.assertAndPromptConsentMessage({
         notify,
         params,
-        prompt,
+        prompt: undefined,
         options: signerOptions
       });
+
+      const errorNotify = {
+        code: SignerErrorCode.PERMISSIONS_PROMPT_NOT_REGISTERED,
+        message: 'The signer has not registered a prompt to respond to permission requests.'
+      };
 
       const expectedMessage: RpcResponseWithError = {
         jsonrpc: JSON_RPC_VERSION_2,
         id: requestId,
-        error: mockErrorNotify
+        error: errorNotify
       };
 
       expect(postMessageMock).toHaveBeenCalledWith(expectedMessage, testOrigin);
     });
-  });
 
-  describe('Call consent message responds with an error', () => {
-    const error = {GenericError: {description: 'Error', error_code: 1n}};
+    it('should return error if consentMessage throws', async () => {
+      spyIcrc21CanisterConsentMessage.mockRejectedValue(new Error('Test Error'));
 
-    beforeEach(() => {
-      spy.mockResolvedValue({
-        Err: error
-      });
-    });
-
-    it('should return error when consentMessage returns error', async () => {
       const prompt = vi.fn();
 
       const result = await signerService.assertAndPromptConsentMessage({
@@ -160,188 +303,87 @@ describe('Signer services', () => {
       });
 
       expect(result).toEqual({result: 'error'});
+
       expect(prompt).not.toHaveBeenCalled();
     });
 
-    it('should call notifyErrorRequestNotSupported when consentMessage returns error', async () => {
-      await signerService.assertAndPromptConsentMessage({
-        notify,
-        params,
-        prompt: vi.fn(),
-        options: signerOptions
+    describe('Assert sender', () => {
+      const prompt = vi.fn();
+
+      const invalidParams = {
+        ...params,
+        sender: mockPrincipalText
+      };
+
+      it('should return error if sender does not match owner', async () => {
+        const result = await signerService.assertAndPromptConsentMessage({
+          notify,
+          params: invalidParams,
+          prompt,
+          options: signerOptions
+        });
+
+        expect(result).toEqual({result: 'error'});
+        expect(spyIcrc21CanisterConsentMessage).not.toHaveBeenCalled();
+        expect(prompt).not.toHaveBeenCalled();
       });
 
-      const errorNotify = {
-        code: SignerErrorCode.REQUEST_NOT_SUPPORTED,
-        message: mapIcrc21ErrorToString(error)
-      };
+      it('should call notifySenderNotAllowedError if sender does not match owner', async () => {
+        await signerService.assertAndPromptConsentMessage({
+          notify,
+          params: invalidParams,
+          prompt,
+          options: signerOptions
+        });
 
-      const expectedMessage: RpcResponseWithError = {
-        jsonrpc: JSON_RPC_VERSION_2,
-        id: requestId,
-        error: errorNotify
-      };
+        const errorNotify = {
+          code: SignerErrorCode.SENDER_NOT_ALLOWED,
+          message: 'The sender must match the owner of the signer.'
+        };
 
-      expect(postMessageMock).toHaveBeenCalledWith(expectedMessage, testOrigin);
+        const expectedMessage: RpcResponseWithError = {
+          jsonrpc: JSON_RPC_VERSION_2,
+          id: requestId,
+          error: errorNotify
+        };
+
+        expect(postMessageMock).toHaveBeenCalledWith(expectedMessage, testOrigin);
+      });
     });
   });
 
-  describe('Call consent message throws an error', () => {
-    it('should return error when consentMessage throws an error', async () => {
-      spy.mockImplementation(() => {
-        // eslint-disable-next-line @typescript-eslint/no-throw-literal
-        throw 'Test';
-      });
+  describe('Call canister', () => {
+    let spySignerApiCall: MockInstance;
 
-      const mockSpy = vi.fn();
+    beforeEach(() => {
+      spySignerApiCall = vi.spyOn(SignerApi.prototype, 'call');
+    });
 
-      const result = await signerService.assertAndPromptConsentMessage({
-        notify,
+    it('should call the signer API with the correct parameters', async () => {
+      spySignerApiCall.mockResolvedValue(mockCanisterCallSuccess);
+
+      await signerService.callCanister({
         params,
-        prompt: mockSpy,
-        options: signerOptions
-      });
-
-      expect(result).toEqual({result: 'error'});
-      expect(mockSpy).not.toHaveBeenCalled();
-    });
-
-    it('should call notifyNetworkError with an unknown error message when consentMessage throws some error', async () => {
-      spy.mockImplementation(() => {
-        // eslint-disable-next-line @typescript-eslint/no-throw-literal
-        throw 'Test';
-      });
-
-      await signerService.assertAndPromptConsentMessage({
         notify,
-        params,
-        prompt: vi.fn(),
         options: signerOptions
       });
 
-      const errorNotify = {
-        code: SignerErrorCode.NETWORK_ERROR,
-        message: 'An unknown error occurred'
-      };
-
-      const expectedMessage: RpcResponseWithError = {
-        jsonrpc: JSON_RPC_VERSION_2,
-        id: requestId,
-        error: errorNotify
-      };
-
-      expect(postMessageMock).toHaveBeenCalledWith(expectedMessage, testOrigin);
-    });
-
-    it('should call notifyNetworkError with an the error message when consentMessage throws an error', async () => {
-      const errorMessage = 'This is a test';
-
-      spy.mockImplementation(() => {
-        throw new Error(errorMessage);
+      expect(spySignerApiCall).toHaveBeenNthCalledWith(1, {
+        ...signerOptions,
+        params
       });
-
-      await signerService.assertAndPromptConsentMessage({
-        notify,
-        params,
-        prompt: vi.fn(),
-        options: signerOptions
-      });
-
-      const errorNotify = {
-        code: SignerErrorCode.NETWORK_ERROR,
-        message: errorMessage
-      };
-
-      const expectedMessage: RpcResponseWithError = {
-        jsonrpc: JSON_RPC_VERSION_2,
-        id: requestId,
-        error: errorNotify
-      };
-
-      expect(postMessageMock).toHaveBeenCalledWith(expectedMessage, testOrigin);
-    });
-  });
-
-  it('should notify MissingPromptError if prompt is undefined', async () => {
-    await signerService.assertAndPromptConsentMessage({
-      notify,
-      params,
-      prompt: undefined,
-      options: signerOptions
     });
 
-    const errorNotify = {
-      code: SignerErrorCode.PERMISSIONS_PROMPT_NOT_REGISTERED,
-      message: 'The signer has not registered a prompt to respond to permission requests.'
-    };
+    it('should throw an error if API call fails', async () => {
+      spySignerApiCall.mockRejectedValue(new Error('Test Error'));
 
-    const expectedMessage: RpcResponseWithError = {
-      jsonrpc: JSON_RPC_VERSION_2,
-      id: requestId,
-      error: errorNotify
-    };
-
-    expect(postMessageMock).toHaveBeenCalledWith(expectedMessage, testOrigin);
-  });
-
-  it('should return error if consentMessage throws', async () => {
-    spy.mockRejectedValue(new Error('Test Error'));
-
-    const prompt = vi.fn();
-
-    const result = await signerService.assertAndPromptConsentMessage({
-      notify,
-      params,
-      prompt,
-      options: signerOptions
-    });
-
-    expect(result).toEqual({result: 'error'});
-
-    expect(prompt).not.toHaveBeenCalled();
-  });
-
-  describe('Assert sender', () => {
-    const prompt = vi.fn();
-
-    const invalidParams = {
-      ...params,
-      sender: mockPrincipalText
-    };
-
-    it('should return error if sender does not match owner', async () => {
-      const result = await signerService.assertAndPromptConsentMessage({
-        notify,
-        params: invalidParams,
-        prompt,
-        options: signerOptions
-      });
-
-      expect(result).toEqual({result: 'error'});
-      expect(spy).not.toHaveBeenCalled();
-      expect(prompt).not.toHaveBeenCalled();
-    });
-
-    it('should call notifySenderNotAllowedError if sender does not match owner', async () => {
-      await signerService.assertAndPromptConsentMessage({
-        notify,
-        params: invalidParams,
-        prompt,
-        options: signerOptions
-      });
-
-      const errorNotify = {
-        code: SignerErrorCode.SENDER_NOT_ALLOWED,
-        message: 'The sender must match the owner of the signer.'
-      };
-
-      const expectedMessage: RpcResponseWithError = {
-        jsonrpc: JSON_RPC_VERSION_2,
-        id: requestId,
-        error: errorNotify
-      };
-
-      expect(postMessageMock).toHaveBeenCalledWith(expectedMessage, testOrigin);
+      await expect(
+        signerService.callCanister({
+          params,
+          notify,
+          options: signerOptions
+        })
+      ).rejects.toThrow(new Error('Test Error'));
     });
   });
 });


### PR DESCRIPTION
# Motivation

Now that we have a `signer.api` to make the call, we can use it in our `signer.service` to bind the call to the canister.
