### PR TITLE
chore: demo svelte-check without tsconfig

### DIFF
--- a/demo/src/relying_party_frontend/package.json
+++ b/demo/src/relying_party_frontend/package.json
@@ -7,7 +7,7 @@
 		"build": "tsc --noEmit && vite build",
 		"preview": "vite preview",
 		"test:unit": "vitest",
-		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
+		"check": "svelte-kit sync && svelte-check --no-tsconfig",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch"
 	},
 	"type": "module"

--- a/demo/src/wallet_frontend/package.json
+++ b/demo/src/wallet_frontend/package.json
@@ -7,7 +7,7 @@
 		"build": "tsc --noEmit && vite build",
 		"preview": "vite preview",
 		"test:unit": "vitest",
-		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
+		"check": "svelte-kit sync && svelte-check --no-tsconfig",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch"
 	},
 	"type": "module"


### PR DESCRIPTION
# Motivation

In #184, svelte-check has an issue because we had to hard-copy borc and cbor from agent-js, which are not clean enough for ESLint. Therefore, we have no other choice but to configure the checks for the demo to only check the Svelte files—i.e., skip all other TS and JS files.