### PR TITLE
refactor: split signer success handlers

### DIFF
--- a/src/handlers/signer-success.handlers.spec.ts
+++ b/src/handlers/signer-success.handlers.spec.ts
@@ -1,0 +1,110 @@
+import type {Mock} from 'vitest';
+import {ICRC27_ACCOUNTS} from '../constants/icrc.constants';
+import {SIGNER_SUPPORTED_STANDARDS} from '../constants/signer.constants';
+import {mockAccounts} from '../mocks/icrc-accounts.mocks';
+import type {
+  IcrcReadyResponse,
+  IcrcScopesArray,
+  IcrcScopesResponse,
+  IcrcSupportedStandardsResponse
+} from '../types/icrc-responses';
+import {JSON_RPC_VERSION_2, type RpcId} from '../types/rpc';
+import {
+  notifyAccounts,
+  notifyPermissionScopes,
+  notifyReady,
+  notifySupportedStandards
+} from './signer-success.handlers';
+
+describe('Signer-success.handlers', () => {
+  let id: RpcId;
+  const origin = 'https://hello.com';
+
+  let originalOpener: typeof window.opener;
+
+  let postMessageMock: Mock;
+
+  beforeEach(() => {
+    id = crypto.randomUUID();
+    originalOpener = window.opener;
+
+    postMessageMock = vi.fn();
+
+    vi.stubGlobal('opener', {postMessage: postMessageMock});
+  });
+
+  afterEach(() => {
+    window.opener = originalOpener;
+
+    vi.restoreAllMocks();
+  });
+
+  describe('notifyReady', () => {
+    it('should post a message with the msg', () => {
+      notifyReady({id, origin});
+
+      const expectedMessage: IcrcReadyResponse = {
+        jsonrpc: JSON_RPC_VERSION_2,
+        id,
+        result: 'ready'
+      };
+
+      expect(postMessageMock).toHaveBeenCalledWith(expectedMessage, origin);
+    });
+  });
+
+  describe('notifySupportedStandards', () => {
+    it('should post a message with the msg', () => {
+      notifySupportedStandards({id, origin});
+
+      const expectedMessage: IcrcSupportedStandardsResponse = {
+        jsonrpc: JSON_RPC_VERSION_2,
+        id,
+        result: {
+          supportedStandards: SIGNER_SUPPORTED_STANDARDS
+        }
+      };
+
+      expect(postMessageMock).toHaveBeenCalledWith(expectedMessage, origin);
+    });
+  });
+
+  describe('notifyPermissionScopes', () => {
+    it('should post a message with the msg', () => {
+      const scopes: IcrcScopesArray = [
+        {
+          scope: {
+            method: ICRC27_ACCOUNTS
+          },
+          state: 'granted'
+        }
+      ];
+
+      notifyPermissionScopes({id, origin, scopes});
+
+      const expectedMessage: IcrcScopesResponse = {
+        jsonrpc: JSON_RPC_VERSION_2,
+        id,
+        result: {
+          scopes
+        }
+      };
+
+      expect(postMessageMock).toHaveBeenCalledWith(expectedMessage, origin);
+    });
+  });
+
+  describe('notifyAccounts', () => {
+    it('should post a message with the accounts', () => {
+      notifyAccounts({id, origin, accounts: mockAccounts});
+
+      const expectedMessage = {
+        jsonrpc: JSON_RPC_VERSION_2,
+        id,
+        result: {accounts: mockAccounts}
+      };
+
+      expect(postMessageMock).toHaveBeenCalledWith(expectedMessage, origin);
+    });
+  });
+});

--- a/src/handlers/signer-success.handlers.ts
+++ b/src/handlers/signer-success.handlers.ts
@@ -1,0 +1,53 @@
+import {SIGNER_SUPPORTED_STANDARDS} from '../constants/signer.constants';
+import type {IcrcAccounts} from '../types/icrc-accounts';
+import type {
+  IcrcAccountsResponse,
+  IcrcReadyResponse,
+  IcrcScopesArray,
+  IcrcScopesResponse,
+  IcrcSupportedStandardsResponse
+} from '../types/icrc-responses';
+import {JSON_RPC_VERSION_2} from '../types/rpc';
+import type {Notify} from '../types/signer-handlers';
+import {notify} from './signer.handlers';
+
+export const notifyReady = ({id, origin}: Notify): void => {
+  const msg: IcrcReadyResponse = {
+    jsonrpc: JSON_RPC_VERSION_2,
+    id,
+    result: 'ready'
+  };
+
+  notify({msg, origin});
+};
+export const notifySupportedStandards = ({id, origin}: Notify): void => {
+  const msg: IcrcSupportedStandardsResponse = {
+    jsonrpc: JSON_RPC_VERSION_2,
+    id,
+    result: {
+      supportedStandards: SIGNER_SUPPORTED_STANDARDS
+    }
+  };
+
+  notify({msg, origin});
+};
+export type NotifyPermissions = Notify & {scopes: IcrcScopesArray};
+export const notifyPermissionScopes = ({id, origin, scopes}: NotifyPermissions): void => {
+  const msg: IcrcScopesResponse = {
+    jsonrpc: JSON_RPC_VERSION_2,
+    id,
+    result: {scopes}
+  };
+
+  notify({msg, origin});
+};
+export type NotifyAccounts = Notify & {accounts: IcrcAccounts};
+export const notifyAccounts = ({id, origin, accounts}: NotifyAccounts): void => {
+  const msg: IcrcAccountsResponse = {
+    jsonrpc: JSON_RPC_VERSION_2,
+    id,
+    result: {accounts}
+  };
+
+  notify({msg, origin});
+};

--- a/src/handlers/signer.handlers.spec.ts
+++ b/src/handlers/signer.handlers.spec.ts
@@ -1,21 +1,8 @@
 import {beforeEach, type Mock} from 'vitest';
-import {ICRC27_ACCOUNTS} from '../constants/icrc.constants';
-import {SIGNER_SUPPORTED_STANDARDS, SignerErrorCode} from '../constants/signer.constants';
-import {mockAccounts} from '../mocks/icrc-accounts.mocks';
-import type {
-  IcrcReadyResponse,
-  IcrcScopesArray,
-  IcrcScopesResponse,
-  IcrcSupportedStandardsResponse
-} from '../types/icrc-responses';
+import {SignerErrorCode} from '../constants/signer.constants';
+import type {IcrcReadyResponse} from '../types/icrc-responses';
 import {JSON_RPC_VERSION_2, type RpcId, type RpcResponseWithError} from '../types/rpc';
-import {
-  notifyAccounts,
-  notifyError,
-  notifyPermissionScopes,
-  notifyReady,
-  notifySupportedStandards
-} from './signer.handlers';
+import {notify, notifyError} from './signer.handlers';
 
 describe('Signer handlers', () => {
   let id: RpcId;
@@ -40,20 +27,6 @@ describe('Signer handlers', () => {
     vi.restoreAllMocks();
   });
 
-  describe('notifyReady', () => {
-    it('should post a message with the msg', () => {
-      notifyReady({id, origin});
-
-      const expectedMessage: IcrcReadyResponse = {
-        jsonrpc: JSON_RPC_VERSION_2,
-        id,
-        result: 'ready'
-      };
-
-      expect(postMessageMock).toHaveBeenCalledWith(expectedMessage, origin);
-    });
-  });
-
   describe('notifyError', () => {
     it('should post the error', () => {
       const error = {
@@ -73,58 +46,17 @@ describe('Signer handlers', () => {
     });
   });
 
-  describe('notifySupportedStandards', () => {
-    it('should post a message with the msg', () => {
-      notifySupportedStandards({id, origin});
-
-      const expectedMessage: IcrcSupportedStandardsResponse = {
+  describe('notify', () => {
+    it('should post a message with the correct msg and origin', () => {
+      const msg: IcrcReadyResponse = {
         jsonrpc: JSON_RPC_VERSION_2,
         id,
-        result: {
-          supportedStandards: SIGNER_SUPPORTED_STANDARDS
-        }
+        result: 'ready'
       };
 
-      expect(postMessageMock).toHaveBeenCalledWith(expectedMessage, origin);
-    });
-  });
+      notify({msg, origin});
 
-  describe('notifyPermissionScopes', () => {
-    it('should post a message with the msg', () => {
-      const scopes: IcrcScopesArray = [
-        {
-          scope: {
-            method: ICRC27_ACCOUNTS
-          },
-          state: 'granted'
-        }
-      ];
-
-      notifyPermissionScopes({id, origin, scopes});
-
-      const expectedMessage: IcrcScopesResponse = {
-        jsonrpc: JSON_RPC_VERSION_2,
-        id,
-        result: {
-          scopes
-        }
-      };
-
-      expect(postMessageMock).toHaveBeenCalledWith(expectedMessage, origin);
-    });
-  });
-
-  describe('notifyAccounts', () => {
-    it('should post a message with the accounts', () => {
-      notifyAccounts({id, origin, accounts: mockAccounts});
-
-      const expectedMessage = {
-        jsonrpc: JSON_RPC_VERSION_2,
-        id,
-        result: {accounts: mockAccounts}
-      };
-
-      expect(postMessageMock).toHaveBeenCalledWith(expectedMessage, origin);
+      expect(postMessageMock).toHaveBeenCalledWith(msg, origin);
     });
   });
 });

--- a/src/handlers/signer.handlers.ts
+++ b/src/handlers/signer.handlers.ts
@@ -1,12 +1,3 @@
-import {SIGNER_SUPPORTED_STANDARDS} from '../constants/signer.constants';
-import type {IcrcAccounts} from '../types/icrc-accounts';
-import type {
-  IcrcAccountsResponse,
-  IcrcReadyResponse,
-  IcrcScopesArray,
-  IcrcScopesResponse,
-  IcrcSupportedStandardsResponse
-} from '../types/icrc-responses';
 import {
   JSON_RPC_VERSION_2,
   type RpcResponse,
@@ -14,52 +5,6 @@ import {
   type RpcResponseWithError
 } from '../types/rpc';
 import type {Notify} from '../types/signer-handlers';
-
-export const notifyReady = ({id, origin}: Notify): void => {
-  const msg: IcrcReadyResponse = {
-    jsonrpc: JSON_RPC_VERSION_2,
-    id,
-    result: 'ready'
-  };
-
-  notify({msg, origin});
-};
-
-export const notifySupportedStandards = ({id, origin}: Notify): void => {
-  const msg: IcrcSupportedStandardsResponse = {
-    jsonrpc: JSON_RPC_VERSION_2,
-    id,
-    result: {
-      supportedStandards: SIGNER_SUPPORTED_STANDARDS
-    }
-  };
-
-  notify({msg, origin});
-};
-
-export type NotifyPermissions = Notify & {scopes: IcrcScopesArray};
-
-export const notifyPermissionScopes = ({id, origin, scopes}: NotifyPermissions): void => {
-  const msg: IcrcScopesResponse = {
-    jsonrpc: JSON_RPC_VERSION_2,
-    id,
-    result: {scopes}
-  };
-
-  notify({msg, origin});
-};
-
-export type NotifyAccounts = Notify & {accounts: IcrcAccounts};
-
-export const notifyAccounts = ({id, origin, accounts}: NotifyAccounts): void => {
-  const msg: IcrcAccountsResponse = {
-    jsonrpc: JSON_RPC_VERSION_2,
-    id,
-    result: {accounts}
-  };
-
-  notify({msg, origin});
-};
 
 export const notifyError = ({
   id,
@@ -77,5 +22,5 @@ export const notifyError = ({
   notify({msg, origin});
 };
 
-const notify = ({msg, origin}: {msg: RpcResponse} & Pick<Notify, 'origin'>): void =>
+export const notify = ({msg, origin}: {msg: RpcResponse} & Pick<Notify, 'origin'>): void =>
   window.opener.postMessage(msg, origin);

--- a/src/signer.spec.ts
+++ b/src/signer.spec.ts
@@ -16,6 +16,7 @@ import {
   SIGNER_SUPPORTED_STANDARDS,
   SignerErrorCode
 } from './constants/signer.constants';
+import * as signerSuccessHandlers from './handlers/signer-success.handlers';
 import * as signerHandlers from './handlers/signer.handlers';
 import {mockCallCanisterParams, mockCallCanisterSuccess} from './mocks/call-canister.mocks';
 import {mockConsentInfo} from './mocks/consent-message.mocks';
@@ -152,7 +153,7 @@ describe('Signer', () => {
 
     beforeEach(() => {
       signer = Signer.init(signerOptions);
-      notifyReadySpy = vi.spyOn(signerHandlers, 'notifyReady');
+      notifyReadySpy = vi.spyOn(signerSuccessHandlers, 'notifyReady');
       postMessageMock = vi.fn();
       vi.stubGlobal('opener', {postMessage: postMessageMock});
     });
@@ -304,8 +305,8 @@ describe('Signer', () => {
       let notifyErrorSpy: MockInstance;
 
       beforeEach(() => {
-        notifySupportedStandardsSpy = vi.spyOn(signerHandlers, 'notifySupportedStandards');
-        notifyPermissionsSpy = vi.spyOn(signerHandlers, 'notifyPermissionScopes');
+        notifySupportedStandardsSpy = vi.spyOn(signerSuccessHandlers, 'notifySupportedStandards');
+        notifyPermissionsSpy = vi.spyOn(signerSuccessHandlers, 'notifyPermissionScopes');
         notifyErrorSpy = vi.spyOn(signerHandlers, 'notifyError');
       });
 
@@ -348,8 +349,8 @@ describe('Signer', () => {
       let notifyErrorSpy: MockInstance;
 
       beforeEach(() => {
-        notifyReadySpy = vi.spyOn(signerHandlers, 'notifyReady');
-        notifyPermissionsSpy = vi.spyOn(signerHandlers, 'notifyPermissionScopes');
+        notifyReadySpy = vi.spyOn(signerSuccessHandlers, 'notifyReady');
+        notifyPermissionsSpy = vi.spyOn(signerSuccessHandlers, 'notifyPermissionScopes');
         notifyErrorSpy = vi.spyOn(signerHandlers, 'notifyError');
       });
 
@@ -394,8 +395,8 @@ describe('Signer', () => {
       let notifyErrorSpy: MockInstance;
 
       beforeEach(() => {
-        notifyReadySpy = vi.spyOn(signerHandlers, 'notifyReady');
-        notifySupportedStandardsSpy = vi.spyOn(signerHandlers, 'notifySupportedStandards');
+        notifyReadySpy = vi.spyOn(signerSuccessHandlers, 'notifyReady');
+        notifySupportedStandardsSpy = vi.spyOn(signerSuccessHandlers, 'notifySupportedStandards');
         notifyErrorSpy = vi.spyOn(signerHandlers, 'notifyError');
       });
 
@@ -1454,7 +1455,7 @@ describe('Signer', () => {
       let payload: PermissionsPromptPayload;
 
       beforeEach(() => {
-        notifyReadySpy = vi.spyOn(signerHandlers, 'notifyReady');
+        notifyReadySpy = vi.spyOn(signerSuccessHandlers, 'notifyReady');
 
         const messageEvent = new MessageEvent('message', {
           data: {

--- a/src/signer.ts
+++ b/src/signer.ts
@@ -13,12 +13,12 @@ import {
 } from './handlers/signer-errors.handlers';
 import {
   notifyAccounts as notifyAccountsHandlers,
-  notifyError,
   notifyPermissionScopes,
   notifyReady,
   notifySupportedStandards,
   type NotifyPermissions
-} from './handlers/signer.handlers';
+} from './handlers/signer-success.handlers';
+import {notifyError} from './handlers/signer.handlers';
 import {SignerService} from './services/signer.service';
 import {
   readSessionValidScopes,


### PR DESCRIPTION
# Motivation

It's cleaner to have the success handlers in a separate module.
