### PR TITLE
chore: todo 4001 on beforeupload

### DIFF
--- a/src/signer.ts
+++ b/src/signer.ts
@@ -101,7 +101,7 @@ export class Signer {
 
   // TODO: onbeforeupload, the signer should notify an error 4001 if and only if there is a pending request at the same time.
   // This means that the signer will have to keep track of its activity.
-  // See https://dfinity.slack.com/archives/D033WHSRZLH/p1726830103487179
+  // See https://github.com/dfinity/wg-identity-authentication/pull/212
 
   private readonly onMessageListener = (message: SignerMessageEvent): void => {
     void this.onMessage(message);


### PR DESCRIPTION
# Motivation

`onbeforeunload`, the signer should notify an error 4001 if and only if there is a pending request at the same time.
This means that the signer will have to keep track of its activity.
See https://github.com/dfinity/wg-identity-authentication/pull/212

# Notes

We still need to impement the polling in the relying party.
