### PR TITLE
feat: replace ICRC-49 with 21 to register consent message prompt

### DIFF
--- a/demo/src/wallet_frontend/src/lib/ConfirmConsentMessage.svelte
+++ b/demo/src/wallet_frontend/src/lib/ConfirmConsentMessage.svelte
@@ -1,14 +1,14 @@
 <script lang="ts">
 	import type { Signer } from '@dfinity/oisy-wallet-signer/signer';
 	import { isNullish, nonNullish } from '@dfinity/utils';
+	import type { icrc21_consent_info } from '@dfinity/oisy-wallet-signer';
 	import {
-		ICRC49_CALL_CANISTER,
-		type Rejection,
 		type ConsentMessageApproval,
 		type ConsentMessagePromptPayload,
-		type ConsentMessageResult
+		type ConsentMessageResult,
+		ICRC21_CALL_CONSENT_MESSAGE,
+		type Rejection
 	} from '@dfinity/oisy-wallet-signer';
-	import type { icrc21_consent_info } from '@dfinity/oisy-wallet-signer';
 	import Button from '$core/components/Button.svelte';
 	import { fade } from 'svelte/transition';
 
@@ -43,7 +43,7 @@
 		}
 
 		signer.register({
-			method: ICRC49_CALL_CANISTER,
+			method: ICRC21_CALL_CONSENT_MESSAGE,
 			prompt: ({ status, ...rest }: ConsentMessagePromptPayload) => {
 				switch (status) {
 					case 'result': {

--- a/src/signer.spec.ts
+++ b/src/signer.spec.ts
@@ -3,6 +3,7 @@ import type {MockInstance} from 'vitest';
 import {Icrc21Canister} from './api/icrc21-canister.api';
 import {SignerApi} from './api/signer.api';
 import {
+  ICRC21_CALL_CONSENT_MESSAGE,
   ICRC25_PERMISSION_GRANTED,
   ICRC25_PERMISSIONS,
   ICRC25_REQUEST_PERMISSIONS,
@@ -1044,7 +1045,7 @@ describe('Signer', () => {
               const promptSpy = vi.fn();
 
               signer.register({
-                method: ICRC49_CALL_CANISTER,
+                method: ICRC21_CALL_CONSENT_MESSAGE,
                 prompt: promptSpy
               });
 
@@ -1083,7 +1084,7 @@ describe('Signer', () => {
               });
 
               signer.register({
-                method: ICRC49_CALL_CANISTER,
+                method: ICRC21_CALL_CONSENT_MESSAGE,
                 prompt: promptSpy
               });
 
@@ -1117,7 +1118,7 @@ describe('Signer', () => {
               };
 
               signer.register({
-                method: ICRC49_CALL_CANISTER,
+                method: ICRC21_CALL_CONSENT_MESSAGE,
                 prompt
               });
 
@@ -1164,7 +1165,7 @@ describe('Signer', () => {
               const promptSpy = vi.fn();
 
               signer.register({
-                method: ICRC49_CALL_CANISTER,
+                method: ICRC21_CALL_CONSENT_MESSAGE,
                 prompt: promptSpy
               });
 
@@ -1218,7 +1219,7 @@ describe('Signer', () => {
               const promptSpy = vi.fn();
 
               signer.register({
-                method: ICRC49_CALL_CANISTER,
+                method: ICRC21_CALL_CONSENT_MESSAGE,
                 prompt: promptSpy
               });
 
@@ -1259,7 +1260,7 @@ describe('Signer', () => {
               });
 
               signer.register({
-                method: ICRC49_CALL_CANISTER,
+                method: ICRC21_CALL_CONSENT_MESSAGE,
                 prompt: promptSpy
               });
 
@@ -1295,7 +1296,7 @@ describe('Signer', () => {
               };
 
               signer.register({
-                method: ICRC49_CALL_CANISTER,
+                method: ICRC21_CALL_CONSENT_MESSAGE,
                 prompt
               });
 
@@ -1334,7 +1335,7 @@ describe('Signer', () => {
               };
 
               signer.register({
-                method: ICRC49_CALL_CANISTER,
+                method: ICRC21_CALL_CONSENT_MESSAGE,
                 prompt
               });
 
@@ -1611,7 +1612,7 @@ describe('Signer', () => {
 
       expect(() => {
         signer.register({
-          method: ICRC49_CALL_CANISTER,
+          method: ICRC21_CALL_CONSENT_MESSAGE,
           prompt: mockConsentMessagePrompt
         });
       }).not.toThrow();

--- a/src/signer.ts
+++ b/src/signer.ts
@@ -1,5 +1,6 @@
 import {assertNonNullish, isNullish, nonNullish} from '@dfinity/utils';
 import {
+  ICRC21_CALL_CONSENT_MESSAGE,
   ICRC25_REQUEST_PERMISSIONS,
   ICRC27_ACCOUNTS,
   ICRC49_CALL_CANISTER
@@ -205,7 +206,7 @@ export class Signer {
         this.#accountsPrompt = prompt as AccountsPrompt;
         return;
       }
-      case ICRC49_CALL_CANISTER: {
+      case ICRC21_CALL_CONSENT_MESSAGE: {
         ConsentMessagePromptSchema.parse(prompt);
         this.#consentMessagePrompt = prompt as ConsentMessagePrompt;
         return;

--- a/src/types/signer-prompts.spec.ts
+++ b/src/types/signer-prompts.spec.ts
@@ -1,10 +1,10 @@
 import {
+  ICRC21_CALL_CONSENT_MESSAGE,
   ICRC25_PERMISSIONS,
   ICRC25_REQUEST_PERMISSIONS,
   ICRC25_SUPPORTED_STANDARDS,
   ICRC27_ACCOUNTS,
-  ICRC29_STATUS,
-  ICRC49_CALL_CANISTER
+  ICRC29_STATUS
 } from '../constants/icrc.constants';
 import {mockAccounts} from '../mocks/icrc-accounts.mocks';
 import type {IcrcScopesArray} from './icrc-responses';
@@ -30,8 +30,8 @@ describe('SignerPrompts', () => {
         validEnum: ICRC27_ACCOUNTS
       },
       {
-        title: 'ICRC49_CALL_CANISTER',
-        validEnum: ICRC49_CALL_CANISTER
+        title: 'ICRC21_CALL_CONSENT_MESSAGE',
+        validEnum: ICRC21_CALL_CONSENT_MESSAGE
       }
     ];
 

--- a/src/types/signer-prompts.ts
+++ b/src/types/signer-prompts.ts
@@ -1,8 +1,8 @@
 import {z} from 'zod';
 import {
+  ICRC21_CALL_CONSENT_MESSAGE,
   ICRC25_REQUEST_PERMISSIONS,
-  ICRC27_ACCOUNTS,
-  ICRC49_CALL_CANISTER
+  ICRC27_ACCOUNTS
 } from '../constants/icrc.constants';
 import type {icrc21_consent_info} from '../declarations/icrc-21';
 import {IcrcAccountsSchema} from './icrc-accounts';
@@ -12,7 +12,7 @@ import {OriginSchema} from './post-message';
 export const PromptMethodSchema = z.enum([
   ICRC25_REQUEST_PERMISSIONS,
   ICRC27_ACCOUNTS,
-  ICRC49_CALL_CANISTER
+  ICRC21_CALL_CONSENT_MESSAGE
 ]);
 
 export type PromptMethod = z.infer<typeof PromptMethodSchema>;


### PR DESCRIPTION
# Motivation

The consent message prompt should be register with ICRC-21 instead of 49. We will use 49 to register a specific prompt for call canister.
