### PR TITLE
feat: ICRC-49 call canister prompt

### DIFF
--- a/demo/src/wallet_frontend/src/lib/ConfirmConsentMessage.svelte
+++ b/demo/src/wallet_frontend/src/lib/ConfirmConsentMessage.svelte
@@ -5,7 +5,7 @@
 	import {
 		type ConsentMessageApproval,
 		type ConsentMessagePromptPayload,
-		type ConsentMessageResult,
+		type ResultConsentMessage,
 		ICRC21_CALL_CONSENT_MESSAGE,
 		type Rejection
 	} from '@dfinity/oisy-wallet-signer';
@@ -47,9 +47,9 @@
 			prompt: ({ status, ...rest }: ConsentMessagePromptPayload) => {
 				switch (status) {
 					case 'result': {
-						approve = (rest as ConsentMessageResult).approve;
-						reject = (rest as ConsentMessageResult).reject;
-						consentInfo = (rest as ConsentMessageResult).consentInfo;
+						approve = (rest as ResultConsentMessage).approve;
+						reject = (rest as ResultConsentMessage).reject;
+						consentInfo = (rest as ResultConsentMessage).consentInfo;
 						loading = false;
 						break;
 					}

--- a/src/services/signer.service.ts
+++ b/src/services/signer.service.ts
@@ -15,7 +15,7 @@ import type {SignerOptions} from '../types/signer-options';
 import type {
   ConsentMessageApproval,
   ConsentMessagePrompt,
-  ConsentMessageResult
+  ResultConsentMessage
 } from '../types/signer-prompts';
 import {base64ToUint8Array} from '../utils/base64.utils';
 import {mapIcrc21ErrorToString} from '../utils/icrc-21.utils';
@@ -165,7 +165,7 @@ export class SignerService {
     ...payload
   }: {
     prompt: ConsentMessagePrompt;
-  } & Pick<ConsentMessageResult, 'consentInfo' | 'origin'>): Promise<{
+  } & Pick<ResultConsentMessage, 'consentInfo' | 'origin'>): Promise<{
     result: 'approved' | 'rejected';
   }> {
     const promise = new Promise<{result: 'approved' | 'rejected'}>((resolve) => {

--- a/src/signer.spec.ts
+++ b/src/signer.spec.ts
@@ -38,6 +38,7 @@ import type {SignerMessageEventData} from './types/signer';
 import type {SignerOptions} from './types/signer-options';
 import {
   AccountsPromptSchema,
+  CallCanisterPromptSchema,
   ConsentMessagePromptSchema,
   PermissionsPromptSchema,
   type AccountsApproval,
@@ -1618,6 +1619,21 @@ describe('Signer', () => {
       }).not.toThrow();
 
       expect(spy).toHaveBeenCalledWith(mockConsentMessagePrompt);
+    });
+
+    it('should validate a call canister prompt on register', () => {
+      const mockCallCanisterPrompt = vi.fn();
+
+      const spy = vi.spyOn(CallCanisterPromptSchema, 'parse');
+
+      expect(() => {
+        signer.register({
+          method: ICRC49_CALL_CANISTER,
+          prompt: mockCallCanisterPrompt
+        });
+      }).not.toThrow();
+
+      expect(spy).toHaveBeenCalledWith(mockCallCanisterPrompt);
     });
 
     it('should throw on register if prompt not supported', () => {

--- a/src/signer.ts
+++ b/src/signer.ts
@@ -50,11 +50,13 @@ import type {Notify} from './types/signer-handlers';
 import type {SignerOptions} from './types/signer-options';
 import {
   AccountsPromptSchema,
+  CallCanisterPromptSchema,
   ConsentMessagePromptSchema,
   PermissionsPromptSchema,
   type AccountsApproval,
   type AccountsPrompt,
   type AccountsPromptPayload,
+  type CallCanisterPrompt,
   type ConsentMessagePrompt,
   type PermissionsConfirmation,
   type PermissionsPrompt,
@@ -71,6 +73,7 @@ export class Signer {
   #permissionsPrompt: PermissionsPrompt | undefined;
   #accountsPrompt: AccountsPrompt | undefined;
   #consentMessagePrompt: ConsentMessagePrompt | undefined;
+  #callCanisterPrompt: CallCanisterPrompt | undefined;
 
   readonly #signerService = new SignerService();
 
@@ -196,6 +199,11 @@ export class Signer {
     // TODO: maybe we should replace method here with another custom enum or type, that would be maybe a bit more comprehensive?
     // TODO: is there a way to avoid casting?
     switch (method) {
+      case ICRC21_CALL_CONSENT_MESSAGE: {
+        ConsentMessagePromptSchema.parse(prompt);
+        this.#consentMessagePrompt = prompt as ConsentMessagePrompt;
+        return;
+      }
       case ICRC25_REQUEST_PERMISSIONS: {
         PermissionsPromptSchema.parse(prompt);
         this.#permissionsPrompt = prompt as PermissionsPrompt;
@@ -206,9 +214,9 @@ export class Signer {
         this.#accountsPrompt = prompt as AccountsPrompt;
         return;
       }
-      case ICRC21_CALL_CONSENT_MESSAGE: {
-        ConsentMessagePromptSchema.parse(prompt);
-        this.#consentMessagePrompt = prompt as ConsentMessagePrompt;
+      case ICRC49_CALL_CANISTER: {
+        CallCanisterPromptSchema.parse(prompt);
+        this.#callCanisterPrompt = prompt as CallCanisterPrompt;
         return;
       }
     }

--- a/src/types/icrc-responses.spec.ts
+++ b/src/types/icrc-responses.spec.ts
@@ -9,6 +9,7 @@ import {uint8ArrayToBase64} from '../utils/base64.utils';
 import {
   IcrcAccountsResponseSchema,
   IcrcCallCanisterResponseSchema,
+  IcrcCallCanisterResultSchema,
   IcrcReadyResponseSchema,
   IcrcScopeSchema,
   IcrcScopesResponseSchema,
@@ -657,82 +658,124 @@ describe('icrc-responses', () => {
       }
     };
 
-    it('should validate a correct response', () => {
-      expect(() => IcrcCallCanisterResponseSchema.parse(validResponse)).not.toThrow();
-    });
+    describe('Result', () => {
+      it('should validate a correct result payload', () => {
+        expect(() => IcrcCallCanisterResultSchema.parse(validResponse.result)).not.toThrow();
+      });
 
-    it('should throw if response has invalid contentMap (not Uint8Array)', () => {
-      const invalidResponse = {
-        ...validResponse,
-        result: {
+      it('should throw if contentMap is invalid (not Base64 string)', () => {
+        const invalidPayload = {
           ...validResponse.result,
-          contentMap: 'invalid-content' // Not a Uint8Array
-        }
-      };
-      expect(() => IcrcCallCanisterResponseSchema.parse(invalidResponse)).toThrow();
-    });
+          contentMap: 'invalid-content'
+        };
+        expect(() => IcrcCallCanisterResultSchema.parse(invalidPayload)).toThrow();
+      });
 
-    it('should throw if response has invalid certificate (not Uint8Array)', () => {
-      const invalidResponse = {
-        ...validResponse,
-        result: {
+      it('should throw if certificate is invalid (not Base64 string)', () => {
+        const invalidPayload = {
           ...validResponse.result,
-          certificate: 'invalid-certificate' // Not a Uint8Array
-        }
-      };
-      expect(() => IcrcCallCanisterResponseSchema.parse(invalidResponse)).toThrow();
-    });
+          certificate: 'invalid-certificate'
+        };
+        expect(() => IcrcCallCanisterResultSchema.parse(invalidPayload)).toThrow();
+      });
 
-    it('should throw if response has missing contentMap', () => {
-      const {contentMap: _, ...rest} = validResponse.result;
+      it('should throw if contentMap is missing', () => {
+        const {contentMap: _, ...rest} = validResponse.result;
+        expect(() => IcrcCallCanisterResultSchema.parse(rest)).toThrow();
+      });
 
-      const invalidResponse = {
-        ...validResponse,
-        result: rest
-      };
-      expect(() => IcrcCallCanisterResponseSchema.parse(invalidResponse)).toThrow();
-    });
+      it('should throw if certificate is missing', () => {
+        const {certificate: _, ...rest} = validResponse.result;
+        expect(() => IcrcCallCanisterResultSchema.parse(rest)).toThrow();
+      });
 
-    it('should throw if response has missing certificate', () => {
-      const {certificate: _, ...rest} = validResponse.result;
-
-      const invalidResponse = {
-        ...validResponse,
-        result: rest
-      };
-      expect(() => IcrcCallCanisterResponseSchema.parse(invalidResponse)).toThrow();
-    });
-
-    it('should throw if response has extra fields in result', () => {
-      const invalidResponse = {
-        ...validResponse,
-        result: {
+      it('should throw if there are extra fields in the payload', () => {
+        const invalidPayload = {
           ...validResponse.result,
           extraField: 'unexpected'
-        }
-      };
-      expect(() => IcrcCallCanisterResponseSchema.parse(invalidResponse)).toThrow();
+        };
+        expect(() => IcrcCallCanisterResultSchema.parse(invalidPayload)).toThrow();
+      });
     });
 
-    it('should throw if response has no result field', () => {
-      const {result: _, ...rest} = validResponse;
+    describe('Response', () => {
+      it('should validate a correct response', () => {
+        expect(() => IcrcCallCanisterResponseSchema.parse(validResponse)).not.toThrow();
+      });
 
-      const invalidResponse = rest;
-      expect(() => IcrcCallCanisterResponseSchema.parse(invalidResponse)).toThrow();
-    });
+      it('should throw if response has invalid contentMap (not Base64 string)', () => {
+        const invalidResponse = {
+          ...validResponse,
+          result: {
+            ...validResponse.result,
+            contentMap: 'invalid-content'
+          }
+        };
+        expect(() => IcrcCallCanisterResponseSchema.parse(invalidResponse)).toThrow();
+      });
 
-    it('should throw if response has no id', () => {
-      const {id: _, ...rest} = validResponse;
+      it('should throw if response has invalid certificate (not Base64 string)', () => {
+        const invalidResponse = {
+          ...validResponse,
+          result: {
+            ...validResponse.result,
+            certificate: 'invalid-certificate'
+          }
+        };
+        expect(() => IcrcCallCanisterResponseSchema.parse(invalidResponse)).toThrow();
+      });
 
-      const invalidResponse = rest;
-      expect(() => IcrcCallCanisterResponseSchema.parse(invalidResponse)).toThrow();
-    });
+      it('should throw if response has missing contentMap', () => {
+        const {contentMap: _, ...rest} = validResponse.result;
 
-    it('should throw if response has no jsonrpc field', () => {
-      const {jsonrpc: _, ...rest} = validResponse;
+        const invalidResponse = {
+          ...validResponse,
+          result: rest
+        };
+        expect(() => IcrcCallCanisterResponseSchema.parse(invalidResponse)).toThrow();
+      });
 
-      const invalidResponse = rest;
-      expect(() => IcrcCallCanisterResponseSchema.parse(invalidResponse)).toThrow();
+      it('should throw if response has missing certificate', () => {
+        const {certificate: _, ...rest} = validResponse.result;
+
+        const invalidResponse = {
+          ...validResponse,
+          result: rest
+        };
+        expect(() => IcrcCallCanisterResponseSchema.parse(invalidResponse)).toThrow();
+      });
+
+      it('should throw if response has extra fields in result', () => {
+        const invalidResponse = {
+          ...validResponse,
+          result: {
+            ...validResponse.result,
+            extraField: 'unexpected'
+          }
+        };
+        expect(() => IcrcCallCanisterResponseSchema.parse(invalidResponse)).toThrow();
+      });
+
+      it('should throw if response has no result field', () => {
+        const {result: _, ...rest} = validResponse;
+
+        const invalidResponse = rest;
+        expect(() => IcrcCallCanisterResponseSchema.parse(invalidResponse)).toThrow();
+      });
+
+      it('should throw if response has no id', () => {
+        const {id: _, ...rest} = validResponse;
+
+        const invalidResponse = rest;
+        expect(() => IcrcCallCanisterResponseSchema.parse(invalidResponse)).toThrow();
+      });
+
+      it('should throw if response has no jsonrpc field', () => {
+        const {jsonrpc: _, ...rest} = validResponse;
+
+        const invalidResponse = rest;
+        expect(() => IcrcCallCanisterResponseSchema.parse(invalidResponse)).toThrow();
+      });
     });
   });
 });

--- a/src/types/icrc-responses.ts
+++ b/src/types/icrc-responses.ts
@@ -108,10 +108,12 @@ export type IcrcAccountsResponse = z.infer<typeof IcrcAccountsResponseSchema>;
 // icrc49_call_canister
 // https://github.com/dfinity/wg-identity-authentication/blob/main/topics/icrc_49_call_canister.md
 
-const IcrcCallCanisterResultSchema = z.object({
-  contentMap: IcrcBlob,
-  certificate: IcrcBlob
-});
+export const IcrcCallCanisterResultSchema = z
+  .object({
+    contentMap: IcrcBlob,
+    certificate: IcrcBlob
+  })
+  .strict();
 
 export type IcrcCallCanisterResult = z.infer<typeof IcrcCallCanisterResultSchema>;
 

--- a/src/types/signer-prompts.spec.ts
+++ b/src/types/signer-prompts.spec.ts
@@ -4,16 +4,19 @@ import {
   ICRC25_REQUEST_PERMISSIONS,
   ICRC25_SUPPORTED_STANDARDS,
   ICRC27_ACCOUNTS,
-  ICRC29_STATUS
+  ICRC29_STATUS,
+  ICRC49_CALL_CANISTER
 } from '../constants/icrc.constants';
 import {mockAccounts} from '../mocks/icrc-accounts.mocks';
 import type {IcrcScopesArray} from './icrc-responses';
 import {
   AccountsPromptSchema,
+  CallCanisterPromptSchema,
   ConsentMessagePromptSchema,
   PermissionsPromptSchema,
   PromptMethodSchema,
   type AccountsPromptPayload,
+  type CallCanisterPromptPayload,
   type ConsentMessagePrompt,
   type PermissionsPromptPayload
 } from './signer-prompts';
@@ -21,6 +24,10 @@ import {
 describe('SignerPrompts', () => {
   describe('Prompts', () => {
     const approveEnums = [
+      {
+        title: 'ICRC21_CALL_CONSENT_MESSAGE',
+        validEnum: ICRC21_CALL_CONSENT_MESSAGE
+      },
       {
         title: 'ICRC25_REQUEST_PERMISSIONS',
         validEnum: ICRC25_REQUEST_PERMISSIONS
@@ -30,8 +37,8 @@ describe('SignerPrompts', () => {
         validEnum: ICRC27_ACCOUNTS
       },
       {
-        title: 'ICRC21_CALL_CONSENT_MESSAGE',
-        validEnum: ICRC21_CALL_CONSENT_MESSAGE
+        title: 'ICRC49_CALL_CANISTER',
+        validEnum: ICRC49_CALL_CANISTER
       }
     ];
 
@@ -135,6 +142,44 @@ describe('SignerPrompts', () => {
       };
 
       expect(() => ConsentMessagePromptSchema.parse(prompt)).not.toThrow();
+    });
+  });
+
+  describe('CallCanister prompt', () => {
+    it('should validate a CallCanisterPrompt with status "loading"', () => {
+      const prompt = (payload: CallCanisterPromptPayload): void => {
+        if (payload.status === 'loading') {
+          // Do nothing
+        }
+      };
+
+      expect(() => CallCanisterPromptSchema.parse(prompt)).not.toThrow();
+    });
+
+    it('should validate a CallCanisterPrompt with status "result"', () => {
+      const prompt = (payload: CallCanisterPromptPayload): void => {
+        if (payload.status === 'result') {
+          // Do nothing
+        }
+      };
+
+      expect(() => CallCanisterPromptSchema.parse(prompt)).not.toThrow();
+    });
+
+    it('should validate a CallCanisterPrompt with status "error"', () => {
+      const prompt = (payload: CallCanisterPromptPayload): void => {
+        if (payload.status === 'error') {
+          // Do nothing
+        }
+      };
+
+      expect(() => CallCanisterPromptSchema.parse(prompt)).not.toThrow();
+    });
+
+    it('should fail with an invalid CallCanisterPrompt', () => {
+      const invalidPrompt = 123;
+
+      expect(() => CallCanisterPromptSchema.parse(invalidPrompt)).toThrow();
     });
   });
 });

--- a/src/types/signer-prompts.ts
+++ b/src/types/signer-prompts.ts
@@ -2,22 +2,24 @@ import {z} from 'zod';
 import {
   ICRC21_CALL_CONSENT_MESSAGE,
   ICRC25_REQUEST_PERMISSIONS,
-  ICRC27_ACCOUNTS
+  ICRC27_ACCOUNTS,
+  ICRC49_CALL_CANISTER
 } from '../constants/icrc.constants';
 import type {icrc21_consent_info} from '../declarations/icrc-21';
 import {IcrcAccountsSchema} from './icrc-accounts';
-import {IcrcScopesArraySchema} from './icrc-responses';
+import {IcrcCallCanisterResultSchema, IcrcScopesArraySchema} from './icrc-responses';
 import {OriginSchema} from './post-message';
 
 export const PromptMethodSchema = z.enum([
+  ICRC21_CALL_CONSENT_MESSAGE,
   ICRC25_REQUEST_PERMISSIONS,
   ICRC27_ACCOUNTS,
-  ICRC21_CALL_CONSENT_MESSAGE
+  ICRC49_CALL_CANISTER
 ]);
 
 export type PromptMethod = z.infer<typeof PromptMethodSchema>;
 
-const PromptPayloadSchema = z.object({
+const PayloadOriginSchema = z.object({
   origin: OriginSchema
 });
 
@@ -27,7 +29,14 @@ export type Rejection = z.infer<typeof RejectionSchema>;
 
 export const StatusSchema = z.enum(['loading', 'result', 'error']);
 
-export type Status = z.infer<typeof StatusSchema>;
+const LoadingSchema = PayloadOriginSchema.extend({
+  status: z.literal(StatusSchema.enum.loading)
+});
+
+const ErrorSchema = PayloadOriginSchema.extend({
+  status: z.literal(StatusSchema.enum.error),
+  details: z.unknown().optional()
+});
 
 // Prompt for permissions
 
@@ -35,7 +44,7 @@ const PermissionsConfirmationSchema = z.function().args(IcrcScopesArraySchema).r
 
 export type PermissionsConfirmation = z.infer<typeof PermissionsConfirmationSchema>;
 
-const PermissionsPromptPayloadSchema = PromptPayloadSchema.extend({
+const PermissionsPromptPayloadSchema = PayloadOriginSchema.extend({
   requestedScopes: IcrcScopesArraySchema,
   confirm: PermissionsConfirmationSchema
 });
@@ -66,7 +75,7 @@ const AccountsApprovalSchema = z.function().args(IcrcAccountsSchema).returns(z.v
 
 export type AccountsApproval = z.infer<typeof AccountsApprovalSchema>;
 
-const AccountsPromptPayloadSchema = PromptPayloadSchema.extend({
+const AccountsPromptPayloadSchema = PayloadOriginSchema.extend({
   approve: AccountsApprovalSchema,
   reject: RejectionSchema
 });
@@ -88,32 +97,23 @@ export type AccountsPrompt = z.infer<typeof AccountsPromptSchema>;
 
 // Prompt for consent message
 
-const ConsentMessageLoadingSchema = PromptPayloadSchema.extend({
-  status: z.literal(StatusSchema.enum.loading)
-});
-
 const ConsentMessageApprovalSchema = z.function().returns(z.void());
 
 export type ConsentMessageApproval = z.infer<typeof ConsentMessageApprovalSchema>;
 
-const ConsentMessageResultSchema = PromptPayloadSchema.extend({
+const ResultConsentMessageSchema = PayloadOriginSchema.extend({
   status: z.literal(StatusSchema.enum.result),
   consentInfo: z.custom<icrc21_consent_info>(),
   approve: ConsentMessageApprovalSchema,
   reject: RejectionSchema
 });
 
-export type ConsentMessageResult = z.infer<typeof ConsentMessageResultSchema>;
-
-const ConsentMessageErrorSchema = PromptPayloadSchema.extend({
-  status: z.literal(StatusSchema.enum.error),
-  details: z.unknown().optional()
-});
+export type ResultConsentMessage = z.infer<typeof ResultConsentMessageSchema>;
 
 const ConsentMessagePromptPayloadSchema = z.union([
-  ConsentMessageLoadingSchema,
-  ConsentMessageResultSchema,
-  ConsentMessageErrorSchema
+  LoadingSchema,
+  ResultConsentMessageSchema,
+  ErrorSchema
 ]);
 
 export type ConsentMessagePromptPayload = z.infer<typeof ConsentMessagePromptPayloadSchema>;
@@ -132,3 +132,27 @@ export const ConsentMessagePromptSchema = z
   .returns(z.void());
 
 export type ConsentMessagePrompt = z.infer<typeof ConsentMessagePromptSchema>;
+
+// Prompt for call canister
+
+const ResultCallCanisterSchema = z.intersection(
+  PayloadOriginSchema.extend({
+    status: z.literal(StatusSchema.enum.result)
+  }),
+  IcrcCallCanisterResultSchema
+);
+
+const CallCanisterPromptPayloadSchema = z.union([
+  LoadingSchema,
+  ResultCallCanisterSchema,
+  ErrorSchema
+]);
+
+export type CallCanisterPromptPayload = z.infer<typeof CallCanisterPromptPayloadSchema>;
+
+export const CallCanisterPromptSchema = z
+  .function()
+  .args(CallCanisterPromptPayloadSchema)
+  .returns(z.void());
+
+export type CallCanisterPrompt = z.infer<typeof CallCanisterPromptSchema>;


### PR DESCRIPTION
# Motivation

We can (re-)declare a prompt for call canister which will emit loading, result and error.

# Notes

Solely the declaration. The prompt is not yet used.
