### PR TITLE
feat: prompt on call canister

### DIFF
--- a/src/signer.ts
+++ b/src/signer.ts
@@ -569,7 +569,8 @@ export class Signer {
       await this.#signerService.callCanister({
         notify,
         params,
-        options: this.#signerOptions
+        options: this.#signerOptions,
+        prompt: this.#callCanisterPrompt
       });
 
       return {handled: true};


### PR DESCRIPTION
# Motivation

The consumer of the signer might want to display a loader or another animation when the call canister is in progress. Likewise they might want to display a success message or the error if the wallet cannot process the call. That's why we trigger a callback for such purpose.
