### PR TITLE
test: beforeAll timeout of 2min

### DIFF
--- a/e2e/utils/init.utils.ts
+++ b/e2e/utils/init.utils.ts
@@ -7,6 +7,8 @@ export const initTestSuite = (): (() => PartyPage) => {
   let partyPage: PartyPage;
 
   testWithII.beforeAll(async ({playwright}) => {
+    testWithII.setTimeout(120000);
+
     const browser = await playwright.chromium.launch();
 
     const context = await browser.newContext();


### PR DESCRIPTION
# Motivation

Tests are flaky but, it seems that setting a 2min timeout for the `beforeAll` generally improve the situation and might even resolve it.
