### PR TITLE
build: deploy to Juno in CI

### DIFF
--- a/.github/workflows/demo-deploy.yaml
+++ b/.github/workflows/demo-deploy.yaml
@@ -22,7 +22,7 @@ jobs:
         working-directory: 'demo'
 
       - name: Deploy to Juno
-        uses: buildwithjuno/juno-action@main
+        uses: junobuild/juno-action@main
         working-directory: 'demo'
         with:
           args: deploy


### PR DESCRIPTION
# Motivation

I deployed once manually, I'm already tired of doing so even if it takes a single command.
Let's let the CI do the job for us.
