### PR TITLE
feat: extract a utility to encode args

### DIFF
--- a/src/icp-wallet.ts
+++ b/src/icp-wallet.ts
@@ -1,4 +1,3 @@
-import {IDL} from '@dfinity/candid';
 import {toIcrc1TransferRawRequest, type Icrc1TransferRequest} from '@dfinity/ledger-icp';
 import {TransferArgs} from './constants/icrc.idl.constants';
 import {RelyingParty} from './relying-party';
@@ -7,7 +6,7 @@ import type {IcrcCallCanisterResult} from './types/icrc-responses';
 import type {Origin} from './types/post-message';
 import type {PrincipalText} from './types/principal';
 import type {RelyingPartyOptions} from './types/relying-party-options';
-import {uint8ArrayToBase64} from './utils/base64.utils';
+import {encodeArg} from './utils/call.utils';
 
 const ICP_LEDGER_CANISTER_ID = 'ryjl3-tyaaa-aaaaa-aaaba-cai';
 
@@ -38,9 +37,12 @@ export class IcpWallet extends RelyingParty {
     request: Icrc1TransferRequest;
     ledgerCanisterId?: PrincipalText;
   } & Pick<IcrcAccount, 'owner'>): Promise<IcrcCallCanisterResult> => {
-    const rawRequest = toIcrc1TransferRawRequest(request);
+    const rawArgs = toIcrc1TransferRawRequest(request);
 
-    const arg = uint8ArrayToBase64(new Uint8Array(IDL.encode([TransferArgs], [rawRequest])));
+    const arg = encodeArg({
+      recordClass: TransferArgs,
+      rawArgs
+    });
 
     // TODO: uncomment nonce and add TODO - not yet supported by agent-js
 

--- a/src/types/blob.ts
+++ b/src/types/blob.ts
@@ -12,3 +12,5 @@ export const IcrcBlobSchema = z.string().refine(
     message: 'Invalid base64 string'
   }
 );
+
+export type IcrcBlob = z.infer<typeof IcrcBlobSchema>;

--- a/src/utils/call.utils.spec.ts
+++ b/src/utils/call.utils.spec.ts
@@ -1,0 +1,31 @@
+import {Principal} from '@dfinity/principal';
+import {TransferArgs} from '../constants/icrc.idl.constants';
+import {TransferArgs as TransferArgsType} from '../declarations/icrc-1';
+import {encodeArg} from './call.utils';
+
+describe('call.utils', () => {
+  it('should encode arguments', () => {
+    const rawArgs: TransferArgsType = {
+      amount: 5000000n,
+      created_at_time: [1727696940356000000n],
+      fee: [10000n],
+      from_subaccount: [],
+      memo: [],
+      to: {
+        owner: Principal.fromText(
+          'ids2f-skxn7-4uwrl-lgtdm-mcv3m-m324f-vjn73-xg6xq-uea7b-37klk-nqe'
+        ),
+        subaccount: []
+      }
+    };
+
+    const arg = encodeArg({
+      recordClass: TransferArgs,
+      rawArgs
+    });
+
+    expect(arg).toEqual(
+      'RElETAZte24AbAKzsNrDA2ithsqDBQFufW54bAb7ygECxvy2AgO6ieXCBAGi3pTrBgGC8/ORDATYo4yoDX0BBQEdV2/5S0VrNMbGCrtjN64WqW/3c3rwoQHw7+pamwIAAZBOAAABANlyqTYD+hfAlrEC'
+    );
+  });
+});

--- a/src/utils/call.utils.ts
+++ b/src/utils/call.utils.ts
@@ -1,0 +1,12 @@
+import {IDL} from '@dfinity/candid';
+import {RecordClass} from '@dfinity/candid/lib/cjs/idl';
+import {IcrcBlob} from '../types/blob';
+import {uint8ArrayToBase64} from './base64.utils';
+
+export const encodeArg = <T>({
+  recordClass,
+  rawArgs
+}: {
+  recordClass: RecordClass;
+  rawArgs: T;
+}): IcrcBlob => uint8ArrayToBase64(new Uint8Array(IDL.encode([recordClass], [rawArgs])));


### PR DESCRIPTION
# Motivation

In our opiniated client we may need to always encode the args the same way.
