### PR TITLE
feat: create a utility around IDL.decode to decode results

### DIFF
--- a/src/utils/idl.utils.spec.ts
+++ b/src/utils/idl.utils.spec.ts
@@ -1,31 +1,81 @@
+import {IDL} from '@dfinity/candid';
 import {Principal} from '@dfinity/principal';
 import {TransferArgs} from '../constants/icrc.idl.constants';
 import {TransferArgs as TransferArgsType} from '../declarations/icrc-1';
-import {encodeArg} from './idl.utils';
+import {decodeResult, encodeArg} from './idl.utils';
 
 describe('idl.utils', () => {
-  it('should encode arguments', () => {
-    const rawArgs: TransferArgsType = {
-      amount: 5000000n,
-      created_at_time: [1727696940356000000n],
-      fee: [10000n],
-      from_subaccount: [],
-      memo: [],
-      to: {
-        owner: Principal.fromText(
-          'ids2f-skxn7-4uwrl-lgtdm-mcv3m-m324f-vjn73-xg6xq-uea7b-37klk-nqe'
-        ),
-        subaccount: []
-      }
-    };
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
 
-    const arg = encodeArg({
-      recordClass: TransferArgs,
-      rawArgs
+  describe('encodeArg', () => {
+    it('should encode arguments', () => {
+      const rawArgs: TransferArgsType = {
+        amount: 5000000n,
+        created_at_time: [1727696940356000000n],
+        fee: [10000n],
+        from_subaccount: [],
+        memo: [],
+        to: {
+          owner: Principal.fromText(
+            'ids2f-skxn7-4uwrl-lgtdm-mcv3m-m324f-vjn73-xg6xq-uea7b-37klk-nqe'
+          ),
+          subaccount: []
+        }
+      };
+
+      const arg = encodeArg({
+        recordClass: TransferArgs,
+        rawArgs
+      });
+
+      expect(arg).toEqual(
+        'RElETAZte24AbAKzsNrDA2ithsqDBQFufW54bAb7ygECxvy2AgO6ieXCBAGi3pTrBgGC8/ORDATYo4yoDX0BBQEdV2/5S0VrNMbGCrtjN64WqW/3c3rwoQHw7+pamwIAAZBOAAABANlyqTYD+hfAlrEC'
+      );
+    });
+  });
+
+  describe('decodeResult', () => {
+    const mockRecordClass = IDL.Record({someField: IDL.Text});
+
+    it('should decode the reply and return the result', () => {
+      const mockExpectedObject = {someField: 'test value'};
+      const mockReply = IDL.encode([mockRecordClass], [mockExpectedObject]);
+
+      const result = decodeResult<{someField: string}>({
+        recordClass: mockRecordClass,
+        reply: mockReply
+      });
+
+      expect(result).toEqual(mockExpectedObject);
     });
 
-    expect(arg).toEqual(
-      'RElETAZte24AbAKzsNrDA2ithsqDBQFufW54bAb7ygECxvy2AgO6ieXCBAGi3pTrBgGC8/ORDATYo4yoDX0BBQEdV2/5S0VrNMbGCrtjN64WqW/3c3rwoQHw7+pamwIAAZBOAAABANlyqTYD+hfAlrEC'
-    );
+    it('should throw an error when IDL.decode fails due to invalid reply', () => {
+      const invalidReply = new ArrayBuffer(10);
+
+      expect(() =>
+        decodeResult({
+          recordClass: mockRecordClass,
+          reply: invalidReply
+        })
+      ).toThrowError(/Wrong magic number/);
+    });
+
+    it('should throw an error if more than one object is returned', () => {
+      const mockReply = new ArrayBuffer(10);
+
+      // I'm not sure what pattern would lead decode to return a decoded JsonValue[] with more than one element.
+      // I wonder if the type is correct; maybe the correct type should actually be [JsonValue].
+      // Therefore, mocking agent-js decode for this particular test.
+      vi.spyOn(IDL, 'decode').mockReturnValue([{someField: 'value1'}, {someField: 'value2'}]);
+
+      expect(() =>
+        decodeResult({
+          recordClass: mockRecordClass,
+          reply: mockReply
+        })
+      ).toThrow('More than one object returned. This is unexpected.');
+    });
   });
 });

--- a/src/utils/idl.utils.ts
+++ b/src/utils/idl.utils.ts
@@ -1,5 +1,5 @@
 import {IDL} from '@dfinity/candid';
-import {RecordClass} from '@dfinity/candid/lib/cjs/idl';
+import {RecordClass, VariantClass} from '@dfinity/candid/lib/cjs/idl';
 import {IcrcBlob} from '../types/blob';
 import {uint8ArrayToBase64} from './base64.utils';
 
@@ -7,6 +7,24 @@ export const encodeArg = <T>({
   recordClass,
   rawArgs
 }: {
-  recordClass: RecordClass;
+  recordClass: RecordClass | VariantClass;
   rawArgs: T;
 }): IcrcBlob => uint8ArrayToBase64(new Uint8Array(IDL.encode([recordClass], [rawArgs])));
+
+export const decodeResult = <T>({
+  recordClass,
+  reply
+}: {
+  recordClass: RecordClass | VariantClass;
+  reply: ArrayBuffer;
+}): T => {
+  const result = IDL.decode([recordClass], reply);
+
+  if (result.length !== 1) {
+    throw new Error('More than one object returned. This is unexpected.');
+  }
+
+  // We have to use another ugly type cast because IDL.decode does not accept generics. Additionally, the agent-js implementation does not provide any hints, as its decodeReturnValue relies on the type 'any,' which is bad practice.
+  const [response] = result as unknown as [T];
+  return response;
+};


### PR DESCRIPTION
# Motivation

We need a utility to decode the `result` in our opiniated relying party.

# Notes

`IDL.decode` and agent-js `decodeReturnValue` are poorly typed. Therefore this PR contains some ugly type casting.
