### PR TITLE
feat: utilities to assert call arg and method are similar

### DIFF
--- a/src/types/icrc-requests.ts
+++ b/src/types/icrc-requests.ts
@@ -85,10 +85,14 @@ export type IcrcAccountsRequest = z.infer<typeof IcrcAccountsRequestSchema>;
 // icrc49_call_canister
 // https://github.com/dfinity/wg-identity-authentication/blob/main/topics/icrc_49_call_canister.md
 
+const MethodSchema = z.string().trim().min(1);
+
+export type Method = z.infer<typeof MethodSchema>;
+
 export const IcrcCallCanisterRequestParamsSchema = z.object({
   canisterId: PrincipalTextSchema,
   sender: PrincipalTextSchema,
-  method: z.string().trim().min(1),
+  method: MethodSchema,
   arg: IcrcBlobSchema,
   nonce: IcrcBlobSchema.optional().refine(
     (blob) => {

--- a/src/utils/call.utils.spec.ts
+++ b/src/utils/call.utils.spec.ts
@@ -1,0 +1,48 @@
+import {uint8ArrayToBase64} from './base64.utils';
+import {assertCallArg, assertCallMethod} from './call.utils';
+
+describe('call.utils', () => {
+  describe('assertCallMethod', () => {
+    it('should not throw an error when methods match', () => {
+      const requestMethod = 'icrc1_transfer';
+      const responseMethod = 'icrc1_transfer';
+
+      expect(() => assertCallMethod({requestMethod, responseMethod})).not.toThrow();
+    });
+
+    it('should throw an error when methods do not match', () => {
+      const requestMethod = 'icrc1_transfer';
+      const responseMethod = 'test';
+
+      expect(() => assertCallMethod({requestMethod, responseMethod})).toThrow(
+        'The response method does not match the request method.'
+      );
+    });
+  });
+
+  describe('assertCallArg', () => {
+    it('should not throw an error when arguments match', () => {
+      const responseArg = new Uint8Array([1, 2, 3, 4, 5, 6, 7]);
+      const requestArgBlob = uint8ArrayToBase64(responseArg);
+
+      expect(() =>
+        assertCallArg({
+          requestArg: requestArgBlob,
+          responseArg
+        })
+      ).not.toThrow();
+    });
+
+    it('should throw an error when arguments do not match', () => {
+      const responseArg = new Uint8Array([1, 2, 3, 4, 5, 6, 7]);
+      const requestArgBlob = uint8ArrayToBase64(new Uint8Array([1, 2, 3]));
+
+      expect(() =>
+        assertCallArg({
+          requestArg: requestArgBlob,
+          responseArg
+        })
+      ).toThrow('The response does not contain the request arguments.');
+    });
+  });
+});

--- a/src/utils/call.utils.ts
+++ b/src/utils/call.utils.ts
@@ -1,0 +1,35 @@
+import {arrayBufferToUint8Array} from '@dfinity/utils';
+import {IcrcBlob} from '../types/blob';
+import {Method} from '../types/icrc-requests';
+import {base64ToUint8Array} from './base64.utils';
+
+export const assertCallMethod = ({
+  requestMethod,
+  responseMethod
+}: {
+  responseMethod: string;
+  requestMethod: Method;
+}) => {
+  if (responseMethod !== requestMethod) {
+    throw new Error('The response method does not match the request method.');
+  }
+};
+
+export const assertCallArg = ({
+  responseArg,
+  requestArg: requestArgBlob
+}: {
+  responseArg: ArrayBuffer;
+  requestArg: IcrcBlob;
+}) => {
+  const requestArg = base64ToUint8Array(requestArgBlob);
+  const callRequestArg = arrayBufferToUint8Array(responseArg);
+
+  const uint8ArrayEqual = ({first, second}: {first: Uint8Array; second: Uint8Array}): boolean =>
+    // eslint-disable-next-line local-rules/prefer-object-params
+    first.length === second.length && first.every((value, index) => value === second[index]);
+
+  if (!uint8ArrayEqual({first: requestArg, second: callRequestArg})) {
+    throw new Error('The response does not contain the request arguments.');
+  }
+};


### PR DESCRIPTION
# Motivation

When decoding a response we need to ensure the method and arguments of the call are the same as those requested. Therefore we need utilities.
