### PR TITLE
refactor: extract a constant for mainnet

### DIFF
--- a/src/api/agent.api.ts
+++ b/src/api/agent.api.ts
@@ -1,5 +1,6 @@
 import {isNullish} from '@dfinity/utils';
 import {CustomHttpAgent} from '../agent/custom-http-agent';
+import {MAINNET_REPLICA_URL} from '../constants/core.constants';
 import type {SignerOptions} from '../types/signer-options';
 
 export abstract class AgentApi {
@@ -23,15 +24,13 @@ export abstract class AgentApi {
   }
 
   private async createAgent({owner: identity, host}: SignerOptions): Promise<CustomHttpAgent> {
-    const mainnetHost = 'https://icp-api.io';
-
-    const {hostname} = new URL(host ?? mainnetHost);
+    const {hostname} = new URL(host ?? MAINNET_REPLICA_URL);
 
     const shouldFetchRootKey = ['localhost', '127.0.0.1'].includes(hostname);
 
     return await CustomHttpAgent.create({
       identity,
-      host: host ?? mainnetHost,
+      host: host ?? MAINNET_REPLICA_URL,
       shouldFetchRootKey
     });
   }

--- a/src/constants/core.constants.ts
+++ b/src/constants/core.constants.ts
@@ -1,1 +1,2 @@
 export const DEFAULT_POLLING_INTERVAL_IN_MILLISECONDS = 500;
+export const MAINNET_REPLICA_URL = 'https://icp-api.io';


### PR DESCRIPTION
# Motivation

A constant for `icp-api.io` is useful as we need to create on the relying party side as well when decoding response.
