### PR TITLE
feat: read invalid session scopes

### DIFF
--- a/src/sessions/signer.sessions.ts
+++ b/src/sessions/signer.sessions.ts
@@ -84,6 +84,22 @@ export const readSessionValidScopes = (params: SessionIdentifier): IcrcScopesArr
     .map(({updatedAt: _, createdAt: __, ...rest}) => ({...rest}));
 };
 
+export const readSessionInvalidScopes = (
+  params: SessionIdentifier
+): IcrcScopesArray | undefined => {
+  const permissions = get<SessionPermissions>({key: key(params)});
+
+  if (isNullish(permissions)) {
+    return undefined;
+  }
+
+  return permissions.scopes
+    .filter(
+      ({updatedAt}) => updatedAt < Date.now() - SIGNER_PERMISSION_VALIDITY_PERIOD_IN_MILLISECONDS
+    )
+    .map(({updatedAt: _, createdAt: __, ...rest}) => ({...rest}));
+};
+
 export const sessionScopeState = ({
   method,
   ...rest


### PR DESCRIPTION
# Motivation

We want to change the list of permissions we provide to request permissions by providing only those that still need to be granted. That's why we need a util to read the permissions that are outdated or "invalid".
