### PR TITLE
feat: assert call canister id

### DIFF
--- a/src/utils/call.utils.spec.ts
+++ b/src/utils/call.utils.spec.ts
@@ -1,5 +1,7 @@
+import {Principal} from '@dfinity/principal';
+import {mockCanisterId, mockPrincipalText} from '../mocks/icrc-accounts.mocks';
 import {uint8ArrayToBase64} from './base64.utils';
-import {assertCallArg, assertCallMethod} from './call.utils';
+import {assertCallArg, assertCallCanisterId, assertCallMethod} from './call.utils';
 
 describe('call.utils', () => {
   describe('assertCallMethod', () => {
@@ -43,6 +45,24 @@ describe('call.utils', () => {
           responseArg
         })
       ).toThrow('The response does not contain the request arguments.');
+    });
+  });
+
+  describe('assertCallCanisterId', () => {
+    it('should not throw an error when canister ID match', () => {
+      const requestCanisterId = Principal.fromText(mockCanisterId);
+      const responseCanisterId = Principal.fromText(mockCanisterId);
+
+      expect(() => assertCallCanisterId({requestCanisterId, responseCanisterId})).not.toThrow();
+    });
+
+    it('should throw an error when methods do not match', () => {
+      const requestCanisterId = Principal.fromText(mockCanisterId);
+      const responseCanisterId = Principal.fromText(mockPrincipalText);
+
+      expect(() => assertCallCanisterId({requestCanisterId, responseCanisterId})).toThrow(
+        'The response canister ID does not match the requested canister ID.'
+      );
     });
   });
 });

--- a/src/utils/call.utils.ts
+++ b/src/utils/call.utils.ts
@@ -1,3 +1,4 @@
+import {Principal} from '@dfinity/principal';
 import {arrayBufferToUint8Array} from '@dfinity/utils';
 import {IcrcBlob} from '../types/blob';
 import {Method} from '../types/icrc-requests';
@@ -31,5 +32,17 @@ export const assertCallArg = ({
 
   if (!uint8ArrayEqual({first: requestArg, second: callRequestArg})) {
     throw new Error('The response does not contain the request arguments.');
+  }
+};
+
+export const assertCallCanisterId = ({
+  requestCanisterId,
+  responseCanisterId
+}: {
+  responseCanisterId: Principal;
+  requestCanisterId: Principal;
+}) => {
+  if (requestCanisterId.toText() !== responseCanisterId.toText()) {
+    throw new Error('The response canister ID does not match the requested canister ID.');
   }
 };


### PR DESCRIPTION
# Motivation

We need to ensure that the request and response contains the same targetted canister ID when decoding a response. Therefore this utility.
