### PR TITLE
feat: revert read invalid scope and add todo

### DIFF
--- a/src/sessions/signer.sessions.ts
+++ b/src/sessions/signer.sessions.ts
@@ -84,22 +84,6 @@ export const readSessionValidScopes = (params: SessionIdentifier): IcrcScopesArr
     .map(({updatedAt: _, createdAt: __, ...rest}) => ({...rest}));
 };
 
-export const readSessionInvalidScopes = (
-  params: SessionIdentifier
-): IcrcScopesArray | undefined => {
-  const permissions = get<SessionPermissions>({key: key(params)});
-
-  if (isNullish(permissions)) {
-    return undefined;
-  }
-
-  return permissions.scopes
-    .filter(
-      ({updatedAt}) => updatedAt < Date.now() - SIGNER_PERMISSION_VALIDITY_PERIOD_IN_MILLISECONDS
-    )
-    .map(({updatedAt: _, createdAt: __, ...rest}) => ({...rest}));
-};
-
 export const sessionScopeState = ({
   method,
   ...rest

--- a/src/signer.ts
+++ b/src/signer.ts
@@ -401,6 +401,7 @@ export class Signer {
         return {handled: true};
       }
 
+      // TODO: In the future, we might want to prompt only if the requested permissions are not already granted. We should prevent the case where the relying party requests permissions without first checking if those permissions have already been granted. Let's see how the signer is used by the community first.
       // TODO: Can the newer version of TypeScript infer "as IcrcScope"?
       const supportedRequestedScopes = requestedScopes
         .filter(


### PR DESCRIPTION
# Motivation

We can revert #270 because this can be addressed by the relying party as for example in #272. We do add a TODO for the future in case we notice most do not implement such a pattern "list permissions - ask permissions only if needed".
