### PR TITLE
build: bump agent-js in demo

### DIFF
--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -12,12 +12,12 @@
 				"src/wallet_frontend"
 			],
 			"dependencies": {
-				"@dfinity/agent": "^2.1.1",
-				"@dfinity/auth-client": "^2.1.1",
-				"@dfinity/candid": "^2.1.1",
-				"@dfinity/ledger-icp": "^2.5.0-next-2024-09-17",
-				"@dfinity/principal": "^2.1.1",
-				"@dfinity/utils": "^2.5.0-next-2024-09-17",
+				"@dfinity/agent": "^2.1.2",
+				"@dfinity/auth-client": "^2.1.2",
+				"@dfinity/candid": "^2.1.2",
+				"@dfinity/ledger-icp": "^2.6.0",
+				"@dfinity/principal": "^2.1.2",
+				"@dfinity/utils": "^2.5.1",
 				"buffer": "^6.0.3",
 				"zod": "^3.23.8"
 			},
@@ -661,9 +661,9 @@
 			}
 		},
 		"node_modules/@dfinity/agent": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-2.1.1.tgz",
-			"integrity": "sha512-9+XPFc9PrXM0kmaqZOOVW3eXBGaWzOjnnbEa55J1NBuDA6+X2jAyE51I62zXr1oFwMeKj7ykOEFd5MOmnMEijA==",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-2.1.2.tgz",
+			"integrity": "sha512-UAXf6uXovhBlSp245RWlA21zcCavy+vVUvKVQUpesk1gLJpJlvsCE6hYOwTeFZAP+bjmPi0Tl7cx8DT2KM4eDQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@noble/curves": "^1.4.0",
@@ -674,37 +674,37 @@
 				"simple-cbor": "^0.4.1"
 			},
 			"peerDependencies": {
-				"@dfinity/candid": "^2.1.1",
-				"@dfinity/principal": "^2.1.1"
+				"@dfinity/candid": "^2.1.2",
+				"@dfinity/principal": "^2.1.2"
 			}
 		},
 		"node_modules/@dfinity/auth-client": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/@dfinity/auth-client/-/auth-client-2.1.1.tgz",
-			"integrity": "sha512-yvP3g9Y4ZnBw7GVy37ICFKt+2pZ3BAtOqbia5OSnaMRXgpgmfIvvyxFbMIrIDzLQJM+EuEmm1ZomXCyeFWDqyw==",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/@dfinity/auth-client/-/auth-client-2.1.2.tgz",
+			"integrity": "sha512-3wIbap6NQi+6z/o+kEFfOQmWuIz94/j1efVlkBtLO0IWqC5NZqoMppwANZZCkENeMvI0krhqH3asQvediWKIsg==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"idb": "^7.0.2"
 			},
 			"peerDependencies": {
-				"@dfinity/agent": "^2.1.1",
-				"@dfinity/identity": "^2.1.1",
-				"@dfinity/principal": "^2.1.1"
+				"@dfinity/agent": "^2.1.2",
+				"@dfinity/identity": "^2.1.2",
+				"@dfinity/principal": "^2.1.2"
 			}
 		},
 		"node_modules/@dfinity/candid": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-2.1.1.tgz",
-			"integrity": "sha512-RVcTKko8wLys2yW84e9Fu/AcJkZOdH7U/Rlm3Pgcx81fnfm74hxKCoecTYD+awbD2HSlVJRB/Uo7NoAoE/N+gQ==",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-2.1.2.tgz",
+			"integrity": "sha512-do69J9iahW2tlmbPdbmc8MDhi5cfIQyTcAlYqaSOOAyg+Kp8beCnW7mletXVfx30dyVlpkyCrYOXhbpQuSCKtw==",
 			"license": "Apache-2.0",
 			"peerDependencies": {
-				"@dfinity/principal": "^2.1.1"
+				"@dfinity/principal": "^2.1.2"
 			}
 		},
 		"node_modules/@dfinity/identity": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/@dfinity/identity/-/identity-2.1.1.tgz",
-			"integrity": "sha512-Imls2yplJG8KUM4WRW3PHHaC1zJR/xGy6usXpkwJSV3zQVWuxTL0+myM20pTa3qO9RFawPDBtnu1/e14KJZ7Kw==",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/@dfinity/identity/-/identity-2.1.2.tgz",
+			"integrity": "sha512-LgskXJzyqm1UVsobAkF8bL1/SdLKFYW2kTIsKw7UOhuBy/COpnf3HZYmKeFCnxvharyIyq23W3WBhIpu9FeAvw==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
@@ -713,21 +713,21 @@
 				"borc": "^2.1.1"
 			},
 			"peerDependencies": {
-				"@dfinity/agent": "^2.1.1",
-				"@dfinity/principal": "^2.1.1",
+				"@dfinity/agent": "^2.1.2",
+				"@dfinity/principal": "^2.1.2",
 				"@peculiar/webcrypto": "^1.4.0"
 			}
 		},
 		"node_modules/@dfinity/ledger-icp": {
-			"version": "2.5.0-next-2024-09-17",
-			"resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.5.0-next-2024-09-17.tgz",
-			"integrity": "sha512-xA38uJ4b5XuqnCWMAmZh+3dJhDnbdqBabWxZ0JT7htZ3Pnb/9+AZTGOxV65fsMFW4S4HvJIzonUi/zKcv/ABKQ==",
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.6.0.tgz",
+			"integrity": "sha512-EXYYtZe+hCyjkIczG6ONlThElrnX0IOxOr/1ahCkvMJ9mnMpS+2zfkzOe+1MBawhLidDAtOwXaCVHMOIbxJ6TQ==",
 			"license": "Apache-2.0",
 			"peerDependencies": {
-				"@dfinity/agent": "*",
-				"@dfinity/candid": "*",
-				"@dfinity/principal": "*",
-				"@dfinity/utils": "*"
+				"@dfinity/agent": "^2.1.2",
+				"@dfinity/candid": "^2.1.2",
+				"@dfinity/principal": "^2.1.2",
+				"@dfinity/utils": "^2.5.1"
 			}
 		},
 		"node_modules/@dfinity/oisy-wallet-signer-demo-relying-party-frontend": {
@@ -739,23 +739,23 @@
 			"link": true
 		},
 		"node_modules/@dfinity/principal": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-2.1.1.tgz",
-			"integrity": "sha512-XKoQRgL7S7MRPwabY6z2wJ1Mn0WQqe9ZQIMK2wtRq48f5nL1m0rZejf8kR9JsZCNCYK6ss4b09FCRNGC20J8Bg==",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-2.1.2.tgz",
+			"integrity": "sha512-L3Y0nDjquqNFseM2Gx5fI4GOUKjjezFr9/6ZjSwAFeDeb4Ubqld4ZKL3FEzv4QKNbfZgCx19b7UXi+OdmLhi4w==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@noble/hashes": "^1.3.1"
 			}
 		},
 		"node_modules/@dfinity/utils": {
-			"version": "2.5.0-next-2024-09-17",
-			"resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.5.0-next-2024-09-17.tgz",
-			"integrity": "sha512-Dem4YFkbo1JkmudtKL9ho50/PO+zPQ1npdDEz6JeyaqedpKwM28Cp3+L+62B5SxGxS5BfjJBMgmVmnar48ivQQ==",
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.5.1.tgz",
+			"integrity": "sha512-ypu63xSX/7f79rVVe/T/2eiEwwi2+XvPNEuHz+isj8zf4jvEoG8DDDBZF9hedDgYC5uxuBDm1UJqHGYUcaCmRg==",
 			"license": "Apache-2.0",
 			"peerDependencies": {
-				"@dfinity/agent": "*",
-				"@dfinity/candid": "*",
-				"@dfinity/principal": "*"
+				"@dfinity/agent": "^2.1.2",
+				"@dfinity/candid": "^2.1.2",
+				"@dfinity/principal": "^2.1.2"
 			}
 		},
 		"node_modules/@esbuild/aix-ppc64": {

--- a/demo/package.json
+++ b/demo/package.json
@@ -55,12 +55,12 @@
 	},
 	"type": "module",
 	"dependencies": {
-		"@dfinity/agent": "^2.1.1",
-		"@dfinity/auth-client": "^2.1.1",
-		"@dfinity/candid": "^2.1.1",
-		"@dfinity/ledger-icp": "^2.5.0-next-2024-09-17",
-		"@dfinity/principal": "^2.1.1",
-		"@dfinity/utils": "^2.5.0-next-2024-09-17",
+		"@dfinity/agent": "^2.1.2",
+		"@dfinity/auth-client": "^2.1.2",
+		"@dfinity/candid": "^2.1.2",
+		"@dfinity/ledger-icp": "^2.6.0",
+		"@dfinity/principal": "^2.1.2",
+		"@dfinity/utils": "^2.5.1",
 		"buffer": "^6.0.3",
 		"zod": "^3.23.8"
 	}


### PR DESCRIPTION
# Motivation

We need to bump agent-js to v2.1.2. An issue of v2.1.1 was reverted.
