### PR TITLE
feat: expose request status handler

### DIFF
--- a/src/handlers/relying-party.handlers.spec.ts
+++ b/src/handlers/relying-party.handlers.spec.ts
@@ -4,6 +4,7 @@ import {
   ICRC25_REQUEST_PERMISSIONS,
   ICRC25_SUPPORTED_STANDARDS,
   ICRC27_ACCOUNTS,
+  ICRC29_STATUS,
   ICRC49_CALL_CANISTER
 } from '../constants/icrc.constants';
 import {mockCallCanisterParams} from '../mocks/call-canister.mocks';
@@ -15,6 +16,7 @@ import {
   requestAccounts,
   requestCallCanister,
   requestPermissions,
+  requestStatus,
   requestSupportedStandards,
   retryRequestStatus
 } from './relying-party.handlers';
@@ -133,6 +135,27 @@ describe('Relying Party handlers', () => {
 
         await vi.advanceTimersByTimeAsync(retries * DEFAULT_POLLING_INTERVAL_IN_MILLISECONDS);
       }));
+  });
+
+  describe('Request status', () => {
+    it('should send the correct message to the popup', () => {
+      requestStatus({id: testId, popup, origin: testOrigin});
+
+      expect(postMessageMock).toHaveBeenCalledWith(
+        {
+          jsonrpc: JSON_RPC_VERSION_2,
+          id: testId,
+          method: ICRC29_STATUS
+        },
+        testOrigin
+      );
+    });
+
+    it('should not bring the popup in front with focus', () => {
+      requestStatus({id: testId, popup, origin: testOrigin});
+
+      expect(focusMock).not.toHaveBeenCalled();
+    });
   });
 
   describe('Supported standards', () => {

--- a/src/handlers/relying-party.handlers.ts
+++ b/src/handlers/relying-party.handlers.ts
@@ -40,7 +40,7 @@ export const retryRequestStatus = async ({
   timeoutInMilliseconds: number;
   intervalInMilliseconds?: number;
 }): Promise<ReadyOrError | 'timeout'> => {
-  const requestStatus = (): void => {
+  const requestInitialStatus = (): void => {
     const msg: IcrcStatusRequest = {
       jsonrpc: JSON_RPC_VERSION_2,
       id,
@@ -56,8 +56,19 @@ export const retryRequestStatus = async ({
       timeoutInMilliseconds / (intervalInMilliseconds ?? DEFAULT_POLLING_INTERVAL_IN_MILLISECONDS),
     intervalInMilliseconds,
     isReady,
-    fn: requestStatus
+    fn: requestInitialStatus
   });
+};
+
+export const requestStatus = ({id, ...rest}: Request): void => {
+  const msg: IcrcStatusRequest = {
+    jsonrpc: JSON_RPC_VERSION_2,
+    id,
+    method: ICRC29_STATUS
+  };
+
+  // Requesting status does not require user interaction therefore it can be queried without focusing the popup.
+  postMsg({msg, ...rest});
 };
 
 export const requestSupportedStandards = ({id, ...rest}: Request): void => {


### PR DESCRIPTION
# Motivation

The relying party will start polling to check if the connection with the wallet is alive. We will start implementing this #276 and therefore we need to expose the related post message handler.
