### PR TITLE
feat: notify busy error

### DIFF
--- a/src/constants/signer.constants.ts
+++ b/src/constants/signer.constants.ts
@@ -19,6 +19,11 @@ export enum SignerErrorCode {
   SENDER_NOT_ALLOWED = 502,
 
   /**
+   * The signer is currently processing a request and cannot handle new requests.
+   */
+  BUSY = 503,
+
+  /**
    * A generic error.
    * @see https://github.com/dfinity/wg-identity-authentication/blob/main/topics/icrc_25_signer_interaction_standard.md#errors
    */

--- a/src/handlers/signer-errors.handlers.spec.ts
+++ b/src/handlers/signer-errors.handlers.spec.ts
@@ -3,6 +3,7 @@ import {SignerErrorCode} from '../constants/signer.constants';
 import {mockErrorNotify} from '../mocks/signer-error.mocks';
 import {JSON_RPC_VERSION_2, type RpcId, type RpcResponseWithError} from '../types/rpc';
 import {
+  notifyBusyError,
   notifyErrorActionAborted,
   notifyErrorPermissionNotGranted,
   notifyErrorRequestNotSupported,
@@ -155,6 +156,26 @@ describe('Signer-errors.handlers', () => {
       };
 
       notifySenderNotAllowedError({id: requestId, origin: testOrigin});
+
+      const expectedMessage: RpcResponseWithError = {
+        jsonrpc: JSON_RPC_VERSION_2,
+        id: requestId,
+        error
+      };
+
+      expect(postMessageMock).toHaveBeenCalledWith(expectedMessage, testOrigin);
+    });
+  });
+
+  describe('notifyBusyError', () => {
+    it('should post an error message indicating the signer is busy', () => {
+      const error = {
+        code: SignerErrorCode.BUSY,
+        message:
+          'The signer is currently processing a request and cannot handle new requests at this time.'
+      };
+
+      notifyBusyError({id: requestId, origin: testOrigin});
 
       const expectedMessage: RpcResponseWithError = {
         jsonrpc: JSON_RPC_VERSION_2,

--- a/src/handlers/signer-errors.handlers.ts
+++ b/src/handlers/signer-errors.handlers.ts
@@ -65,3 +65,14 @@ export const notifySenderNotAllowedError = (notify: Notify): void => {
     }
   });
 };
+
+export const notifyBusyError = (notify: Notify): void => {
+  notifyError({
+    ...notify,
+    error: {
+      code: SignerErrorCode.BUSY,
+      message:
+        'The signer is currently processing a request and cannot handle new requests at this time.'
+    }
+  });
+};


### PR DESCRIPTION
# Motivation

The signer will have to keep track of it's state and reject requests if busy. Therefore we need an error and notifier for this.
