### PR TITLE
build: upgrade agent-js v2.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@dfinity/eslint-config-oisy-wallet": "^0.0.6",
-        "@dfinity/identity": "^2.1.1",
+        "@dfinity/identity": "^2.1.2",
         "@dfinity/internet-identity-playwright": "^0.0.3",
         "@playwright/test": "^1.47.1",
         "@types/jest": "^29.5.13",
@@ -26,12 +26,12 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "@dfinity/agent": "^2.1.1",
-        "@dfinity/candid": "^2.1.1",
-        "@dfinity/ledger-icp": "^2.6.0",
-        "@dfinity/ledger-icrc": "^2.6.0",
-        "@dfinity/principal": "^2.1.1",
-        "@dfinity/utils": "^2.5.0-next-2024-09-17",
+        "@dfinity/agent": "^2.1.2",
+        "@dfinity/candid": "^2.1.2",
+        "@dfinity/ledger-icp": "^2.6.1",
+        "@dfinity/ledger-icrc": "^2.6.1",
+        "@dfinity/principal": "^2.1.2",
+        "@dfinity/utils": "^2.5.2",
         "borc": "^2.1.1",
         "simple-cbor": "^0.4.1",
         "zod": "^3.23.8"
@@ -207,9 +207,9 @@
       }
     },
     "node_modules/@dfinity/identity": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/identity/-/identity-2.1.1.tgz",
-      "integrity": "sha512-Imls2yplJG8KUM4WRW3PHHaC1zJR/xGy6usXpkwJSV3zQVWuxTL0+myM20pTa3qO9RFawPDBtnu1/e14KJZ7Kw==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/identity/-/identity-2.1.2.tgz",
+      "integrity": "sha512-LgskXJzyqm1UVsobAkF8bL1/SdLKFYW2kTIsKw7UOhuBy/COpnf3HZYmKeFCnxvharyIyq23W3WBhIpu9FeAvw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -218,8 +218,8 @@
         "borc": "^2.1.1"
       },
       "peerDependencies": {
-        "@dfinity/agent": "^2.1.1",
-        "@dfinity/principal": "^2.1.1",
+        "@dfinity/agent": "^2.1.2",
+        "@dfinity/principal": "^2.1.2",
         "@peculiar/webcrypto": "^1.4.0"
       }
     },
@@ -237,29 +237,29 @@
       }
     },
     "node_modules/@dfinity/ledger-icp": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.6.0.tgz",
-      "integrity": "sha512-EXYYtZe+hCyjkIczG6ONlThElrnX0IOxOr/1ahCkvMJ9mnMpS+2zfkzOe+1MBawhLidDAtOwXaCVHMOIbxJ6TQ==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.6.1.tgz",
+      "integrity": "sha512-GKfG/53C9IXkiPNbsWa9/r68wTCnW68GSm795SRDNa0YwLe0Y+FVEYDl6yz2tRFHwDWo+MTHhY07FfS4P4kJFw==",
       "license": "Apache-2.0",
       "peer": true,
       "peerDependencies": {
-        "@dfinity/agent": "^2.1.2",
-        "@dfinity/candid": "^2.1.2",
-        "@dfinity/principal": "^2.1.2",
-        "@dfinity/utils": "^2.5.1"
+        "@dfinity/agent": "^2.0.0",
+        "@dfinity/candid": "^2.0.0",
+        "@dfinity/principal": "^2.0.0",
+        "@dfinity/utils": "^2.5.2"
       }
     },
     "node_modules/@dfinity/ledger-icrc": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.6.0.tgz",
-      "integrity": "sha512-gFnD50gzWq+N6P+A9yBiSXc0oaMdmh6W84x5GZOG5i58/p0xeGX4JPwUOrxFCKk0DRdWeH1muO4nknmWFhAZxA==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.6.1.tgz",
+      "integrity": "sha512-fsCC01JHDIA+2l7CRll44yB5/OF2qj3Gz7xE10SW7V80elYULfa98w9ks12dqxGh62+62btxujU7ylluTgugyg==",
       "license": "Apache-2.0",
       "peer": true,
       "peerDependencies": {
-        "@dfinity/agent": "^2.1.2",
-        "@dfinity/candid": "^2.1.2",
-        "@dfinity/principal": "^2.1.2",
-        "@dfinity/utils": "^2.5.1"
+        "@dfinity/agent": "^2.0.0",
+        "@dfinity/candid": "^2.0.0",
+        "@dfinity/principal": "^2.0.0",
+        "@dfinity/utils": "^2.5.2"
       }
     },
     "node_modules/@dfinity/principal": {
@@ -273,15 +273,15 @@
       }
     },
     "node_modules/@dfinity/utils": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.5.1.tgz",
-      "integrity": "sha512-ypu63xSX/7f79rVVe/T/2eiEwwi2+XvPNEuHz+isj8zf4jvEoG8DDDBZF9hedDgYC5uxuBDm1UJqHGYUcaCmRg==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.5.2.tgz",
+      "integrity": "sha512-QSW7t8kcLj0s/gL4NbYqr+Pqr3e2QhFn2JriwcghuflhwrYet1y23ANyM4EwSUeDAUR/OQXR86e4MfWkGMttAg==",
       "license": "Apache-2.0",
       "peer": true,
       "peerDependencies": {
-        "@dfinity/agent": "^2.1.2",
-        "@dfinity/candid": "^2.1.2",
-        "@dfinity/principal": "^2.1.2"
+        "@dfinity/agent": "^2.0.0",
+        "@dfinity/candid": "^2.0.0",
+        "@dfinity/principal": "^2.0.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -6149,9 +6149,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
       "dev": true,
       "license": "0BSD",
       "peer": true
@@ -7189,18 +7189,18 @@
       }
     },
     "node_modules/webcrypto-core": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.8.0.tgz",
-      "integrity": "sha512-kR1UQNH8MD42CYuLzvibfakG5Ew5seG85dMMoAM/1LqvckxaF6pUiidLuraIu4V+YCIFabYecUZAW0TuxAoaqw==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.8.1.tgz",
+      "integrity": "sha512-P+x1MvlNCXlKbLSOY4cYrdreqPG5hbzkmawbcXLKN/mf6DZW0SdNNkZ+sjwsqVkI4A4Ko2sPZmkZtCKY58w83A==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@peculiar/asn1-schema": "^2.3.8",
+        "@peculiar/asn1-schema": "^2.3.13",
         "@peculiar/json-schema": "^1.1.12",
-        "asn1js": "^3.0.1",
+        "asn1js": "^3.0.5",
         "pvtsutils": "^1.3.5",
-        "tslib": "^2.6.2"
+        "tslib": "^2.7.0"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   },
   "devDependencies": {
     "@dfinity/eslint-config-oisy-wallet": "^0.0.6",
-    "@dfinity/identity": "^2.1.1",
+    "@dfinity/identity": "^2.1.2",
     "@dfinity/internet-identity-playwright": "^0.0.3",
     "@playwright/test": "^1.47.1",
     "@types/jest": "^29.5.13",
@@ -91,12 +91,12 @@
     "node": ">=20"
   },
   "peerDependencies": {
-    "@dfinity/agent": "^2.1.1",
-    "@dfinity/candid": "^2.1.1",
-    "@dfinity/ledger-icp": "^2.6.0",
-    "@dfinity/ledger-icrc": "^2.6.0",
-    "@dfinity/principal": "^2.1.1",
-    "@dfinity/utils": "^2.5.0-next-2024-09-17",
+    "@dfinity/agent": "^2.1.2",
+    "@dfinity/candid": "^2.1.2",
+    "@dfinity/ledger-icp": "^2.6.1",
+    "@dfinity/ledger-icrc": "^2.6.1",
+    "@dfinity/principal": "^2.1.2",
+    "@dfinity/utils": "^2.5.2",
     "borc": "^2.1.1",
     "simple-cbor": "^0.4.1",
     "zod": "^3.23.8"


### PR DESCRIPTION
# Motivation

There is a bug in agent-js v2.1.1. So we set v2.1.2 as minimum version.
