### PR TITLE
chore: set version to v0.0.1-rc.1 for usage in OISY

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dfinity/oisy-wallet-signer",
-  "version": "0.0.1",
+  "version": "0.0.1-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dfinity/oisy-wallet-signer",
-      "version": "0.0.1",
+      "version": "0.0.1-rc.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@dfinity/eslint-config-oisy-wallet": "^0.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/oisy-wallet-signer",
-  "version": "0.0.1",
+  "version": "0.0.1-rc.1",
   "description": "A library designed to facilitate communication between a dApp and the OISY Wallet on the Internet Computer. ",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
# Motivation

Set version to `v0.0.1-rc.1` for usage in OISY as we aim to use the lib before open sourcing or while we get all the signatures that approve open sourcing the library.
