### PR TITLE
feat: rename call canister status from loading to executing

### DIFF
--- a/demo/src/wallet_frontend/src/lib/CallCanister.svelte
+++ b/demo/src/wallet_frontend/src/lib/CallCanister.svelte
@@ -3,7 +3,7 @@
 	import {
 		type CallCanisterPromptPayload,
 		ICRC49_CALL_CANISTER,
-		type Status
+		type CallCanisterStatus
 	} from '@dfinity/oisy-wallet-signer';
 	import { isNullish, nonNullish } from '@dfinity/utils';
 	import { fade } from 'svelte/transition';
@@ -15,7 +15,7 @@
 
 	let { signer }: Props = $props();
 
-	let status = $state<Status | undefined>(undefined);
+	let status = $state<CallCanisterStatus | undefined>(undefined);
 
 	$effect(() => {
 		if (isNullish(signer)) {
@@ -42,7 +42,7 @@
 	<div class="dark:text-white" in:fade>
 		<p class="font-bold mt-6">Call canister:</p>
 		<p class="mb-2 break-words">
-			{#if status === 'loading'}
+			{#if status === 'executing'}
 				<output data-tid="loading-call-canister">Loading call canister...</output>
 			{:else if status === 'result'}
 				<output data-tid="result-call-canister">Canister call successful.</output>

--- a/src/services/signer.service.ts
+++ b/src/services/signer.service.ts
@@ -125,7 +125,7 @@ export class SignerService {
   }): Promise<{result: 'success' | 'error'}> {
     const {origin} = notify;
 
-    prompt?.({origin, status: 'loading'});
+    prompt?.({origin, status: 'executing'});
 
     try {
       const result = await this.#signerApi.call({

--- a/src/services/signer.services.spec.ts
+++ b/src/services/signer.services.spec.ts
@@ -492,7 +492,7 @@ describe('Signer services', () => {
       });
     });
 
-    it('should trigger prompt "loading" before the call canister if a prompt is provided', async () => {
+    it('should trigger prompt "executing" before the call canister if a prompt is provided', async () => {
       spySignerApiCall.mockResolvedValue(mockCanisterCallSuccess);
 
       await signerService.callCanister({
@@ -504,7 +504,7 @@ describe('Signer services', () => {
 
       expect(prompt).toHaveBeenCalledWith({
         origin: testOrigin,
-        status: 'loading'
+        status: 'executing'
       });
     });
 

--- a/src/types/signer-prompts.spec.ts
+++ b/src/types/signer-prompts.spec.ts
@@ -145,7 +145,7 @@ describe('SignerPrompts', () => {
   describe('CallCanister prompt', () => {
     it('should validate a CallCanisterPrompt with status "loading"', () => {
       const prompt = (payload: CallCanisterPromptPayload): void => {
-        if (payload.status === 'loading') {
+        if (payload.status === 'executing') {
           // Do nothing
         }
       };

--- a/src/types/signer-prompts.ts
+++ b/src/types/signer-prompts.ts
@@ -40,13 +40,7 @@ const RejectionSchema = z.function().returns(z.void());
 
 export type Rejection = z.infer<typeof RejectionSchema>;
 
-export const StatusSchema = z.enum(['loading', 'result', 'error']);
-
-export type Status = z.infer<typeof StatusSchema>;
-
-const LoadingSchema = PayloadOriginSchema.extend({
-  status: z.literal(StatusSchema.enum.loading)
-});
+const StatusSchema = z.enum(['result', 'error']);
 
 const ErrorSchema = PayloadOriginSchema.extend({
   status: z.literal(StatusSchema.enum.error),
@@ -116,6 +110,16 @@ const ConsentMessageApprovalSchema = z.function().returns(z.void());
 
 export type ConsentMessageApproval = z.infer<typeof ConsentMessageApprovalSchema>;
 
+const LoadingConsentMessageStatusSchema = z.enum(['loading']);
+
+const ConsentMessageStatusSchema = LoadingConsentMessageStatusSchema.or(StatusSchema);
+
+export type ConsentMessageStatus = z.infer<typeof ConsentMessageStatusSchema>;
+
+const LoadingConsentMessageSchema = PayloadOriginSchema.extend({
+  status: z.literal(LoadingConsentMessageStatusSchema.enum.loading)
+});
+
 const ResultConsentMessageSchema = PayloadOriginSchema.extend({
   status: z.literal(StatusSchema.enum.result),
   consentInfo: z.custom<icrc21_consent_info>(),
@@ -126,7 +130,7 @@ const ResultConsentMessageSchema = PayloadOriginSchema.extend({
 export type ResultConsentMessage = z.infer<typeof ResultConsentMessageSchema>;
 
 const ConsentMessagePromptPayloadSchema = z.union([
-  LoadingSchema,
+  LoadingConsentMessageSchema,
   ResultConsentMessageSchema,
   ErrorSchema
 ]);
@@ -150,6 +154,16 @@ export type ConsentMessagePrompt = z.infer<typeof ConsentMessagePromptSchema>;
 
 // Prompt for call canister
 
+const ExecutingCallCanisterStatusSchema = z.enum(['executing']);
+
+const CallCanisterStatusSchema = ExecutingCallCanisterStatusSchema.or(StatusSchema);
+
+export type CallCanisterStatus = z.infer<typeof CallCanisterStatusSchema>;
+
+const ExecutingCallCanisterSchema = PayloadOriginSchema.extend({
+  status: z.literal(ExecutingCallCanisterStatusSchema.enum.executing)
+});
+
 const ResultCallCanisterSchema = z.intersection(
   PayloadOriginSchema.extend({
     status: z.literal(StatusSchema.enum.result)
@@ -158,7 +172,7 @@ const ResultCallCanisterSchema = z.intersection(
 );
 
 const CallCanisterPromptPayloadSchema = z.union([
-  LoadingSchema,
+  ExecutingCallCanisterSchema,
   ResultCallCanisterSchema,
   ErrorSchema
 ]);


### PR DESCRIPTION
# Motivation

In the [review](https://github.com/dfinity/oisy-wallet/pull/2960#pullrequestreview-2374165221) of the integration of the library into OISY, we discussed the fact that a status "loading" for the effective execution of the call canister was not the best naming. That is why this PR renamed "loading" to "executing".

Note that we keep "loading" for "loading the consent message".
