### PR TITLE
build: downgrade agent-js v2.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@dfinity/eslint-config-oisy-wallet": "^0.0.6",
-        "@dfinity/identity": "^2.1.2",
+        "@dfinity/identity": "^2.0.0",
         "@dfinity/internet-identity-playwright": "^0.0.3",
         "@playwright/test": "^1.48.0",
         "@types/jest": "^29.5.13",
@@ -26,11 +26,11 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "@dfinity/agent": "^2.1.2",
-        "@dfinity/candid": "^2.1.2",
+        "@dfinity/agent": "^2.0.0",
+        "@dfinity/candid": "^2.0.0",
         "@dfinity/ledger-icp": "^2.6.1",
         "@dfinity/ledger-icrc": "^2.6.1",
-        "@dfinity/principal": "^2.1.2",
+        "@dfinity/principal": "^2.0.0",
         "@dfinity/utils": "^2.5.2",
         "borc": "^2.1.1",
         "simple-cbor": "^0.4.1",
@@ -156,9 +156,9 @@
       }
     },
     "node_modules/@dfinity/agent": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-2.1.2.tgz",
-      "integrity": "sha512-UAXf6uXovhBlSp245RWlA21zcCavy+vVUvKVQUpesk1gLJpJlvsCE6hYOwTeFZAP+bjmPi0Tl7cx8DT2KM4eDQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-2.0.0.tgz",
+      "integrity": "sha512-Cc2VDAMfxCNIQoaEeKPf0rbS/Y21HAF+eEFj6GfijNnUxS42i4zwUF2PUvEJZqaB2FQwA9SC7MDyuwL8BR2oJA==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
@@ -170,18 +170,18 @@
         "simple-cbor": "^0.4.1"
       },
       "peerDependencies": {
-        "@dfinity/candid": "^2.1.2",
-        "@dfinity/principal": "^2.1.2"
+        "@dfinity/candid": "^2.0.0",
+        "@dfinity/principal": "^2.0.0"
       }
     },
     "node_modules/@dfinity/candid": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-2.1.2.tgz",
-      "integrity": "sha512-do69J9iahW2tlmbPdbmc8MDhi5cfIQyTcAlYqaSOOAyg+Kp8beCnW7mletXVfx30dyVlpkyCrYOXhbpQuSCKtw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-2.0.0.tgz",
+      "integrity": "sha512-poxIEnzErcKBM5yroabQ3VqQpiYZnqYZdLJWFuIQZzioGdP1mlnVLHx7IbgHN4HBlqVXYPFmEzMU02FnyYUA1Q==",
       "license": "Apache-2.0",
       "peer": true,
       "peerDependencies": {
-        "@dfinity/principal": "^2.1.2"
+        "@dfinity/principal": "^2.0.0"
       }
     },
     "node_modules/@dfinity/eslint-config-oisy-wallet": {
@@ -207,9 +207,9 @@
       }
     },
     "node_modules/@dfinity/identity": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/identity/-/identity-2.1.2.tgz",
-      "integrity": "sha512-LgskXJzyqm1UVsobAkF8bL1/SdLKFYW2kTIsKw7UOhuBy/COpnf3HZYmKeFCnxvharyIyq23W3WBhIpu9FeAvw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/identity/-/identity-2.0.0.tgz",
+      "integrity": "sha512-6NBdqG/Z2H6zEwBlpwWcWKsffgisIVzy2AMY7fXu5Jq31niFAoxv//oRsejeW45ChahVJlhvP/UYrNMJur8GpQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -218,8 +218,8 @@
         "borc": "^2.1.1"
       },
       "peerDependencies": {
-        "@dfinity/agent": "^2.1.2",
-        "@dfinity/principal": "^2.1.2",
+        "@dfinity/agent": "^2.0.0",
+        "@dfinity/principal": "^2.0.0",
         "@peculiar/webcrypto": "^1.4.0"
       }
     },
@@ -263,9 +263,9 @@
       }
     },
     "node_modules/@dfinity/principal": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-2.1.2.tgz",
-      "integrity": "sha512-L3Y0nDjquqNFseM2Gx5fI4GOUKjjezFr9/6ZjSwAFeDeb4Ubqld4ZKL3FEzv4QKNbfZgCx19b7UXi+OdmLhi4w==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-2.0.0.tgz",
+      "integrity": "sha512-cqJ5kOrPpxco+wvJC4TFBhdr4lkw9mnwKGAYunesyqdzSYi8lnFB4dShNqlHFWdwoxNAw6OZkt/B+0nLa+7Yqw==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   },
   "devDependencies": {
     "@dfinity/eslint-config-oisy-wallet": "^0.0.6",
-    "@dfinity/identity": "^2.1.2",
+    "@dfinity/identity": "^2.0.0",
     "@dfinity/internet-identity-playwright": "^0.0.3",
     "@playwright/test": "^1.48.0",
     "@types/jest": "^29.5.13",
@@ -91,11 +91,11 @@
     "node": ">=20"
   },
   "peerDependencies": {
-    "@dfinity/agent": "^2.1.2",
-    "@dfinity/candid": "^2.1.2",
+    "@dfinity/agent": "^2.0.0",
+    "@dfinity/candid": "^2.0.0",
     "@dfinity/ledger-icp": "^2.6.1",
     "@dfinity/ledger-icrc": "^2.6.1",
-    "@dfinity/principal": "^2.1.2",
+    "@dfinity/principal": "^2.0.0",
     "@dfinity/utils": "^2.5.2",
     "borc": "^2.1.1",
     "simple-cbor": "^0.4.1",


### PR DESCRIPTION
# Motivation

Simiarly to what we have done with all ic-js we downgrade Agent-js to v2.0.0. This is particularly useful for consumer that also uses `@dfinity/ic-management` which is broken with new version of Agent-js (SDK team is looking at the issue).
