### PR TITLE
feat: relying party call protected

### DIFF
--- a/src/icp-wallet.spec.ts
+++ b/src/icp-wallet.spec.ts
@@ -99,6 +99,7 @@ describe('icp-wallet', () => {
     it('should call `call` with the correct parameters when icrc1Transfer is invoked', async () => {
       const mockCall = vi.fn().mockResolvedValue(mockLocalCallResult);
 
+      // @ts-expect-error we mock call for testing purposes
       icpWallet.call = mockCall;
 
       const result = await icpWallet.icrc1Transfer({request, owner: sender});
@@ -113,6 +114,7 @@ describe('icp-wallet', () => {
     it('should call `call` with the specific canister ID', async () => {
       const mockCall = vi.fn().mockResolvedValue({});
 
+      // @ts-expect-error we mock call for testing purposes
       icpWallet.call = mockCall;
 
       vi.spyOn(callUtils, 'decodeResponse').mockResolvedValue({Ok: mockLocalBlockHeight});
@@ -130,6 +132,7 @@ describe('icp-wallet', () => {
     it('should call `call` with the specific sender', async () => {
       const mockCall = vi.fn().mockResolvedValue({});
 
+      // @ts-expect-error we mock call for testing purposes
       icpWallet.call = mockCall;
 
       vi.spyOn(callUtils, 'decodeResponse').mockResolvedValue({Ok: mockLocalBlockHeight});
@@ -149,6 +152,7 @@ describe('icp-wallet', () => {
     it('should call `call` with the specific options', async () => {
       const mockCall = vi.fn().mockResolvedValue({});
 
+      // @ts-expect-error we mock call for testing purposes
       icpWallet.call = mockCall;
 
       vi.spyOn(callUtils, 'decodeResponse').mockResolvedValue({Ok: mockLocalBlockHeight});

--- a/src/icrc-wallet.spec.ts
+++ b/src/icrc-wallet.spec.ts
@@ -76,6 +76,7 @@ describe('icrc-wallet', () => {
     it('should call `call` with the correct parameters when transfer is invoked', async () => {
       const mockCall = vi.fn().mockResolvedValue({});
 
+      // @ts-expect-error we mock call for testing purposes
       icrcWallet.call = mockCall;
 
       const owner = Ed25519KeyIdentity.generate().getPrincipal().toText();
@@ -95,6 +96,7 @@ describe('icrc-wallet', () => {
     it('should call `call` with the specific options', async () => {
       const mockCall = vi.fn().mockResolvedValue({});
 
+      // @ts-expect-error we mock call for testing purposes
       icrcWallet.call = mockCall;
 
       const owner = Ed25519KeyIdentity.generate().getPrincipal().toText();

--- a/src/relying-party.ts
+++ b/src/relying-party.ts
@@ -625,6 +625,9 @@ export class RelyingParty {
     });
   };
 
+  // TODO: This method is marked as `protected` because it lacks response validation.
+  // Validation is deferred to opinionated implementations like `IcpWallet` or `IcrcWallet`.
+  // If you wish to make this method public, ensure that proper validation is implemented first.
   /**
    * Call a canister method via the signer.
    *
@@ -636,7 +639,7 @@ export class RelyingParty {
    * @returns {Promise<IcrcCallCanisterResult>} A promise that resolves to the result of the canister call.
    * @see [ICRC49 Call Canister](https://github.com/dfinity/wg-identity-authentication/blob/main/topics/icrc_49_call_canister.md)
    */
-  call = async ({
+  protected call = async ({
     options: {timeoutInMilliseconds, ...rest} = {},
     params
   }: {


### PR DESCRIPTION
# Motivation

The `RelyingParty.call`  function does not validate responses. The consumer might assume it does, which poses a security issue that needs to be addressed or documented. Therefore, we have made it protected for now. Additionally, the client used for Oisy is opinionated and does validate the responses.
