### PR TITLE
feat: assert response sender

### DIFF
--- a/src/utils/call.assert.utils.spec.ts
+++ b/src/utils/call.assert.utils.spec.ts
@@ -1,7 +1,12 @@
 import {Principal} from '@dfinity/principal';
 import {mockCanisterId, mockPrincipalText} from '../mocks/icrc-accounts.mocks';
 import {uint8ArrayToBase64} from './base64.utils';
-import {assertCallArg, assertCallCanisterId, assertCallMethod} from './call.assert.utils';
+import {
+  assertCallArg,
+  assertCallCanisterId,
+  assertCallMethod,
+  assertCallSender
+} from './call.assert.utils';
 
 describe('call.assert.utils', () => {
   describe('assertCallMethod', () => {
@@ -62,6 +67,27 @@ describe('call.assert.utils', () => {
 
       expect(() => assertCallCanisterId({requestCanisterId, responseCanisterId})).toThrow(
         'The response canister ID does not match the requested canister ID.'
+      );
+    });
+  });
+
+  describe('assertCallSender', () => {
+    const senders = [
+      Principal.fromText(mockPrincipalText),
+      Principal.fromText(mockPrincipalText).toUint8Array()
+    ];
+
+    it.each(senders)('should not throw an error when sender match', (responseSender) => {
+      const requestSender = mockPrincipalText;
+
+      expect(() => assertCallSender({requestSender, responseSender})).not.toThrow();
+    });
+
+    it.each(senders)('should throw an error when methods do not match', (responseSender) => {
+      const requestSender = mockCanisterId;
+
+      expect(() => assertCallSender({requestSender, responseSender})).toThrow(
+        'The response sender does not match the request sender.'
       );
     });
   });

--- a/src/utils/call.assert.utils.ts
+++ b/src/utils/call.assert.utils.ts
@@ -2,6 +2,7 @@ import {Principal} from '@dfinity/principal';
 import {arrayBufferToUint8Array} from '@dfinity/utils';
 import {IcrcBlob} from '../types/blob';
 import {Method} from '../types/icrc-requests';
+import {PrincipalText} from '../types/principal';
 import {base64ToUint8Array} from './base64.utils';
 
 export const assertCallMethod = ({
@@ -44,5 +45,22 @@ export const assertCallCanisterId = ({
 }) => {
   if (requestCanisterId.toText() !== responseCanisterId.toText()) {
     throw new Error('The response canister ID does not match the requested canister ID.');
+  }
+};
+
+export const assertCallSender = ({
+  requestSender,
+  responseSender
+}: {
+  responseSender: Uint8Array | Principal;
+  requestSender: PrincipalText;
+}) => {
+  const receivedSender =
+    responseSender instanceof Uint8Array
+      ? Principal.fromUint8Array(responseSender)
+      : responseSender;
+
+  if (receivedSender.toText() !== Principal.fromText(requestSender).toText()) {
+    throw new Error('The response sender does not match the request sender.');
   }
 };

--- a/src/utils/call.utils.spec.ts
+++ b/src/utils/call.utils.spec.ts
@@ -42,11 +42,13 @@ describe('call.utils', () => {
     let spyAssertCallMethod: MockInstance;
     let spyAssertCallCanisterId: MockInstance;
     let spyAssertCallArg: MockInstance;
+    let spyAssertCallSender: MockInstance;
 
     beforeEach(() => {
       spyAssertCallMethod = vi.spyOn(callUtils, 'assertCallMethod');
       spyAssertCallCanisterId = vi.spyOn(callUtils, 'assertCallCanisterId');
       spyAssertCallArg = vi.spyOn(callUtils, 'assertCallArg');
+      spyAssertCallSender = vi.spyOn(callUtils, 'assertCallSender');
     });
 
     it('should validate a valid response', () => {
@@ -97,6 +99,20 @@ describe('call.utils', () => {
       expect(spyAssertCallArg).toHaveBeenCalledWith({
         requestArg: mockLocalCallParams.arg,
         responseArg: callRequest.arg
+      });
+    });
+
+    it('should call assertCallSender with correct params', () => {
+      assertCallResponse({
+        params: mockLocalCallParams,
+        result: mockLocalCallResult
+      });
+
+      const callRequest = decodeCallRequest(mockLocalCallResult.contentMap);
+
+      expect(spyAssertCallSender).toHaveBeenCalledWith({
+        requestSender: mockLocalCallParams.sender,
+        responseSender: callRequest.sender
       });
     });
   });

--- a/src/utils/call.utils.ts
+++ b/src/utils/call.utils.ts
@@ -13,11 +13,16 @@ import {IcrcCallCanisterRequestParams} from '../types/icrc-requests';
 import type {IcrcCallCanisterResult} from '../types/icrc-responses';
 import {decodeCallRequest} from './agentjs-cbor-copy.utils';
 import {base64ToUint8Array} from './base64.utils';
-import {assertCallArg, assertCallCanisterId, assertCallMethod} from './call.assert.utils';
+import {
+  assertCallArg,
+  assertCallCanisterId,
+  assertCallMethod,
+  assertCallSender
+} from './call.assert.utils';
 import {decodeResult} from './idl.utils';
 
 export const assertCallResponse = ({
-  params: {method, arg, canisterId},
+  params: {method, arg, canisterId, sender},
   result: {contentMap}
 }: {
   params: IcrcCallCanisterRequestParams;
@@ -38,6 +43,11 @@ export const assertCallResponse = ({
   assertCallArg({
     requestArg: arg,
     responseArg: callRequest.arg
+  });
+
+  assertCallSender({
+    requestSender: sender,
+    responseSender: callRequest.sender
   });
 };
 


### PR DESCRIPTION
# Motivation

In addition to the existing assertions of the response of a call, we also want to ensure that the sender provided within the response matches the one use for calling.
