### PR TITLE
build: bump II playwright plugin for no captcha

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@dfinity/eslint-config-oisy-wallet": "^0.0.6",
         "@dfinity/identity": "^2.1.2",
-        "@dfinity/internet-identity-playwright": "^0.0.3",
+        "@dfinity/internet-identity-playwright": "^0.0.4",
         "@playwright/test": "^1.48.0",
         "@types/jest": "^29.5.13",
         "@types/node": "^20.12.7",
@@ -224,9 +224,9 @@
       }
     },
     "node_modules/@dfinity/internet-identity-playwright": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/@dfinity/internet-identity-playwright/-/internet-identity-playwright-0.0.3.tgz",
-      "integrity": "sha512-zGb3uLEL82tHs2MR3HL4IWa04AnhIZep6I0CuiWTQw76Bo1XnKTxYKGohQMJbziTQrSqEjswygOqm3LU3nBK3A==",
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@dfinity/internet-identity-playwright/-/internet-identity-playwright-0.0.4.tgz",
+      "integrity": "sha512-yOYHPSgB2rGVERVd6XkHnIvKT9OBysPzgXBjZDGBLWPdN4LN4sGLwhCD/yo6R12QU9l7YBm7UsjyZH0mvQ36JA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
   "devDependencies": {
     "@dfinity/eslint-config-oisy-wallet": "^0.0.6",
     "@dfinity/identity": "^2.1.2",
-    "@dfinity/internet-identity-playwright": "^0.0.3",
+    "@dfinity/internet-identity-playwright": "^0.0.4",
     "@playwright/test": "^1.48.0",
     "@types/jest": "^29.5.13",
     "@types/node": "^20.12.7",


### PR DESCRIPTION
# Motivation

The latest version of Internet Identity included in the Juno Docker image no longer requires a captcha for new user sign-ins. Therefore, to ensure the E2E test suite for this library succeeds with the updated Docker container, we need to bump the Playwright plugin, which has been updated accordingly.

