### PR TITLE
chore: workaround for Jetbrains IDE issue not resolving vi

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,3 +2,5 @@ dist
 
 # Never-ending story: It's easier to just exclude did files from the lint checks.
 src/declarations
+
+src/tsconfig.json

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -1,3 +1,3 @@
 {
-	"extends": "../tsconfig.spec.json"
+  "extends": "../tsconfig.spec.json"
 }

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -1,0 +1,3 @@
+{
+	"extends": "../tsconfig.spec.json"
+}


### PR DESCRIPTION
# Motivation

We aim to have separate `tsconfig` files: a main `tsconfig.json` for library rules, a `tsconfig.eslint.json` extending it for ESLint, and a `tsconfig.spec.json` for testing. While this setup works well with command-line tools, JetBrains IDE version 2024.2.x has issues resolving the test configuration. Consequently, the `vi` global type isn’t recognized, which causes the editor to display errors.

I reported this issue to JetBrains, who opened a tracking ticket: [https://youtrack.jetbrains.com/issue/WEB-69571](https://youtrack.jetbrains.com/issue/WEB-69571). It may be resolved eventually—or not.

In the meantime, a workaround is to add a `tsconfig.json` file in the `src` directory that extends the root `tsconfig.spec.json`.
