### PR TITLE
refactor: use ICRC-25 constants

### DIFF
--- a/src/handlers/signer-success.handlers.spec.ts
+++ b/src/handlers/signer-success.handlers.spec.ts
@@ -1,5 +1,5 @@
 import type {Mock} from 'vitest';
-import {ICRC27_ACCOUNTS} from '../constants/icrc.constants';
+import {ICRC25_PERMISSION_GRANTED, ICRC27_ACCOUNTS} from '../constants/icrc.constants';
 import {SIGNER_SUPPORTED_STANDARDS} from '../constants/signer.constants';
 import {mockCallCanisterSuccess} from '../mocks/call-canister.mocks';
 import {mockAccounts} from '../mocks/icrc-accounts.mocks';
@@ -78,7 +78,7 @@ describe('Signer-success.handlers', () => {
           scope: {
             method: ICRC27_ACCOUNTS
           },
-          state: 'granted'
+          state: ICRC25_PERMISSION_GRANTED
         }
       ];
 

--- a/src/relying-party.spec.ts
+++ b/src/relying-party.spec.ts
@@ -1,5 +1,7 @@
 import {MockInstance} from 'vitest';
 import {
+  ICRC25_PERMISSION_DENIED,
+  ICRC25_PERMISSION_GRANTED,
   ICRC25_PERMISSIONS,
   ICRC25_REQUEST_PERMISSIONS,
   ICRC25_SUPPORTED_STANDARDS,
@@ -548,8 +550,8 @@ describe('Relying Party', () => {
       let relyingParty: RelyingParty;
 
       const scopes = [
-        {scope: {method: ICRC27_ACCOUNTS}, state: 'granted'},
-        {scope: {method: ICRC49_CALL_CANISTER}, state: 'denied'}
+        {scope: {method: ICRC27_ACCOUNTS}, state: ICRC25_PERMISSION_GRANTED},
+        {scope: {method: ICRC49_CALL_CANISTER}, state: ICRC25_PERMISSION_DENIED}
       ];
 
       beforeEach(async () => {

--- a/src/signer.spec.ts
+++ b/src/signer.spec.ts
@@ -5,6 +5,7 @@ import {SignerApi} from './api/signer.api';
 import {
   ICRC21_CALL_CONSENT_MESSAGE,
   ICRC25_PERMISSION_ASK_ON_USE,
+  ICRC25_PERMISSION_DENIED,
   ICRC25_PERMISSION_GRANTED,
   ICRC25_PERMISSIONS,
   ICRC25_REQUEST_PERMISSIONS,
@@ -2209,13 +2210,13 @@ describe('Signer', () => {
             scope: {
               method: ICRC27_ACCOUNTS
             },
-            state: 'granted'
+            state: ICRC25_PERMISSION_GRANTED
           },
           {
             scope: {
               method: ICRC49_CALL_CANISTER
             },
-            state: 'denied'
+            state: ICRC25_PERMISSION_DENIED
           }
         ];
 

--- a/src/signer.ts
+++ b/src/signer.ts
@@ -1,6 +1,9 @@
 import {assertNonNullish, isNullish, nonNullish} from '@dfinity/utils';
 import {
   ICRC21_CALL_CONSENT_MESSAGE,
+  ICRC25_PERMISSION_ASK_ON_USE,
+  ICRC25_PERMISSION_DENIED,
+  ICRC25_PERMISSION_GRANTED,
   ICRC25_REQUEST_PERMISSIONS,
   ICRC27_ACCOUNTS,
   ICRC49_CALL_CANISTER
@@ -618,14 +621,14 @@ export class Signer {
       });
 
       switch (permission) {
-        case 'denied': {
+        case ICRC25_PERMISSION_DENIED: {
           notifyErrorPermissionNotGranted({
             id: requestId ?? null,
             origin
           });
           break;
         }
-        case 'granted': {
+        case ICRC25_PERMISSION_GRANTED: {
           await notifyAccounts();
           break;
         }
@@ -711,7 +714,7 @@ export class Signer {
         origin
       });
 
-      if (permission === 'denied') {
+      if (permission === ICRC25_PERMISSION_DENIED) {
         notifyErrorPermissionNotGranted({
           id: requestId ?? null,
           origin
@@ -783,7 +786,7 @@ export class Signer {
     });
 
     switch (currentPermission) {
-      case 'ask_on_use': {
+      case ICRC25_PERMISSION_ASK_ON_USE: {
         const promise = new Promise<Omit<IcrcPermissionState, 'ask_on_use'>>((resolve, reject) => {
           const promptFn = async (): Promise<void> => {
             const requestedScopes: IcrcScopesArray = [
@@ -791,7 +794,7 @@ export class Signer {
                 scope: {
                   method
                 },
-                state: 'denied'
+                state: ICRC25_PERMISSION_DENIED
               }
             ];
 
@@ -804,15 +807,15 @@ export class Signer {
 
             const approved =
               confirmedScopes.find(
-                ({scope: {method: m}, state}) => m === method && state === 'granted'
+                ({scope: {method: m}, state}) => m === method && state === ICRC25_PERMISSION_GRANTED
               ) !== undefined;
 
             if (approved) {
-              resolve('granted');
+              resolve(ICRC25_PERMISSION_GRANTED);
               return;
             }
 
-            resolve('denied');
+            resolve(ICRC25_PERMISSION_DENIED);
           };
 
           this.prompt({

--- a/src/types/signer-prompts.spec.ts
+++ b/src/types/signer-prompts.spec.ts
@@ -1,5 +1,6 @@
 import {
   ICRC21_CALL_CONSENT_MESSAGE,
+  ICRC25_PERMISSION_DENIED,
   ICRC25_PERMISSIONS,
   ICRC25_REQUEST_PERMISSIONS,
   ICRC25_SUPPORTED_STANDARDS,
@@ -75,7 +76,7 @@ describe('SignerPrompts', () => {
         scope: {
           method: ICRC27_ACCOUNTS
         },
-        state: 'denied'
+        state: ICRC25_PERMISSION_DENIED
       }
     ];
 


### PR DESCRIPTION
# Motivation

We've got constants for the permissions, so let's use them instead of duplicating their value.
