### PR TITLE
build: fix ci next

### DIFF
--- a/.github/workflows/lib-next.yml
+++ b/.github/workflows/lib-next.yml
@@ -18,14 +18,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Build next version
-        run: ./scripts/build-next
-
       - name: Prepare
         uses: ./.github/actions/prepare
 
-      - name: Build
-        run: npm run build
+      - name: Build next version
+        run: ./scripts/build-next
 
       - run: npm publish --provenance --access public --tag next
         working-directory: ${{env.dist-directory}}


### PR DESCRIPTION
# Motivation

The order of building the next was inverted in the action. As a result a next version cannot be published.

Example: https://github.com/dfinity/oisy-wallet-signer/actions/runs/11532355284
