### PR TITLE
test: use toHaveBeenCalledOnce

### DIFF
--- a/src/agent/custom-http-agent.spec.ts
+++ b/src/agent/custom-http-agent.spec.ts
@@ -99,7 +99,7 @@ describe('CustomHttpAgent', () => {
     await CustomHttpAgent.create(agentOptions);
 
     // eslint-disable-next-line @typescript-eslint/unbound-method
-    expect(httpAgent.HttpAgent.create).toHaveBeenCalledTimes(1);
+    expect(httpAgent.HttpAgent.create).toHaveBeenCalledOnce();
     // eslint-disable-next-line @typescript-eslint/unbound-method
     expect(httpAgent.HttpAgent.create).toHaveBeenCalledWith(agentOptions);
   });
@@ -143,7 +143,7 @@ describe('CustomHttpAgent', () => {
         it('should call agent on request', async () => {
           await agent.request(mockRequestPayload);
 
-          expect(spyCall).toHaveBeenCalledTimes(1);
+          expect(spyCall).toHaveBeenCalledOnce();
           expect(spyCall).toHaveBeenCalledWith(mockCanisterId, {
             arg: base64ToUint8Array(mockRequestPayload.arg),
             effectiveCanisterId: mockCanisterId,
@@ -308,7 +308,7 @@ describe('CustomHttpAgent', () => {
           it('should call agent on request', async () => {
             await agent.request(mockRequestPayload);
 
-            expect(spyCall).toHaveBeenCalledTimes(1);
+            expect(spyCall).toHaveBeenCalledOnce();
             expect(spyCall).toHaveBeenCalledWith(mockCanisterId, {
               arg: base64ToUint8Array(mockRequestPayload.arg),
               effectiveCanisterId: mockCanisterId,
@@ -326,7 +326,7 @@ describe('CustomHttpAgent', () => {
           it('should poll for response when status is 202 and no certificate is returned by v3 call', async () => {
             await agent.request(mockRequestPayload);
 
-            expect(spyPollForResponse).toHaveBeenCalledTimes(1);
+            expect(spyPollForResponse).toHaveBeenCalledOnce();
           });
         });
 

--- a/src/api/agent.api.spec.ts
+++ b/src/api/agent.api.spec.ts
@@ -57,7 +57,7 @@ describe('AgentApi', () => {
       await agentApi.getAgentTest(signerOptions);
 
       // eslint-disable-next-line @typescript-eslint/unbound-method
-      expect(CustomHttpAgent.create).toHaveBeenCalledTimes(1);
+      expect(CustomHttpAgent.create).toHaveBeenCalledOnce();
     });
 
     it('should create and cache a new agent for a different identity', async () => {
@@ -82,7 +82,7 @@ describe('AgentApi', () => {
       await agentApi.getAgentTest(signerOptions);
 
       // eslint-disable-next-line @typescript-eslint/unbound-method
-      expect(CustomHttpAgent.create).toHaveBeenCalledTimes(1);
+      expect(CustomHttpAgent.create).toHaveBeenCalledOnce();
     });
   });
 

--- a/src/api/icrc21-canister.api.spec.ts
+++ b/src/api/icrc21-canister.api.spec.ts
@@ -184,11 +184,11 @@ describe('icrc-21.canister.api', () => {
 
       // Ensure that the `CustomHttpAgent.create` is only called once
       // eslint-disable-next-line @typescript-eslint/unbound-method
-      expect(CustomHttpAgent.create).toHaveBeenCalledTimes(1);
+      expect(CustomHttpAgent.create).toHaveBeenCalledOnce();
 
       // TODO: spyOn nor function does work with vitest and Actor.createActor. Not against a better idea than disabling eslint for next line.
       // eslint-disable-next-line @typescript-eslint/unbound-method
-      expect(Actor.createActor).toHaveBeenCalledTimes(1);
+      expect(Actor.createActor).toHaveBeenCalledOnce();
     });
 
     it('should create a new actor when canisterId changes', async () => {

--- a/src/handlers/relying-party.handlers.spec.ts
+++ b/src/handlers/relying-party.handlers.spec.ts
@@ -226,7 +226,7 @@ describe('Relying Party handlers', () => {
     it('should bring the popup in front with focus', () => {
       requestPermissions({id: testId, popup, origin: testOrigin, params});
 
-      expect(focusMock).toHaveBeenCalledTimes(1);
+      expect(focusMock).toHaveBeenCalledOnce();
     });
   });
 
@@ -247,7 +247,7 @@ describe('Relying Party handlers', () => {
     it('should bring the popup in front with focus', () => {
       requestAccounts({id: testId, popup, origin: testOrigin});
 
-      expect(focusMock).toHaveBeenCalledTimes(1);
+      expect(focusMock).toHaveBeenCalledOnce();
     });
   });
 
@@ -269,7 +269,7 @@ describe('Relying Party handlers', () => {
     it('should bring the popup in front with focus', () => {
       requestCallCanister({id: testId, popup, origin: testOrigin, params: mockCallCanisterParams});
 
-      expect(focusMock).toHaveBeenCalledTimes(1);
+      expect(focusMock).toHaveBeenCalledOnce();
     });
   });
 });

--- a/src/relying-party.spec.ts
+++ b/src/relying-party.spec.ts
@@ -170,7 +170,7 @@ describe('Relying Party', () => {
             'relyingPartyWindow',
             expectedOptions
           );
-          expect(window.open).toHaveBeenCalledTimes(1);
+          expect(window.open).toHaveBeenCalledOnce();
 
           expect(addEventListenerSpy).toHaveBeenCalledWith('message', expect.any(Function));
           expect(removeEventListenerSpy).toHaveBeenCalledWith('message', expect.any(Function));
@@ -182,7 +182,7 @@ describe('Relying Party', () => {
 
           const promise = RelyingParty.connect(mockParameters);
 
-          expect(spy).toHaveBeenCalledTimes(1);
+          expect(spy).toHaveBeenCalledOnce();
 
           expect(spyPostMessage).toHaveBeenCalledWith(
             expect.objectContaining({
@@ -239,7 +239,7 @@ describe('Relying Party', () => {
 
           expect(relyingParty).toBeInstanceOf(RelyingParty);
 
-          expect(window.open).toHaveBeenCalledTimes(1);
+          expect(window.open).toHaveBeenCalledOnce();
           expect(window.close).not.toHaveBeenCalled();
         });
 
@@ -251,8 +251,8 @@ describe('Relying Party', () => {
             RelyingParty.connect(mockParameters).catch((err: Error) => {
               expect(err.message).toBe('Connection timeout. Unable to connect to the signer.');
 
-              expect(window.open).toHaveBeenCalledTimes(1);
-              expect(window.close).toHaveBeenCalledTimes(1);
+              expect(window.open).toHaveBeenCalledOnce();
+              expect(window.close).toHaveBeenCalledOnce();
 
               vi.useRealTimers();
 
@@ -274,7 +274,7 @@ describe('Relying Party', () => {
 
           const {disconnect} = await promise;
 
-          expect(window.open).toHaveBeenCalledTimes(1);
+          expect(window.open).toHaveBeenCalledOnce();
           expect(window.close).not.toHaveBeenCalled();
 
           await disconnect();
@@ -291,7 +291,7 @@ describe('Relying Party', () => {
 
           await connectAndDisconnect();
 
-          expect(clearIntervalSpy).toHaveBeenCalledTimes(1);
+          expect(clearIntervalSpy).toHaveBeenCalledOnce();
 
           clearIntervalSpy.mockRestore();
         });
@@ -301,7 +301,7 @@ describe('Relying Party', () => {
 
           await connectAndDisconnect(spyOnDisconnect);
 
-          expect(spyOnDisconnect).toHaveBeenCalledTimes(1);
+          expect(spyOnDisconnect).toHaveBeenCalledOnce();
         });
       });
     });
@@ -382,7 +382,7 @@ describe('Relying Party', () => {
                 `Request to signer timed out after ${RELYING_PARTY_TIMEOUT_REQUEST_SUPPORTED_STANDARD} milliseconds.`
               );
 
-              expect(spy).toHaveBeenCalledTimes(1);
+              expect(spy).toHaveBeenCalledOnce();
 
               vi.useRealTimers();
 
@@ -505,8 +505,8 @@ describe('Relying Party', () => {
 
           await promise;
 
-          expect(spy).toHaveBeenCalledTimes(1);
-          expect(spyPostMessage).toHaveBeenCalledTimes(1);
+          expect(spy).toHaveBeenCalledOnce();
+          expect(spyPostMessage).toHaveBeenCalledOnce();
 
           expect(spyPostMessage).toHaveBeenCalledWith(
             expect.objectContaining({
@@ -620,7 +620,7 @@ describe('Relying Party', () => {
                   `Request to signer timed out after ${RELYING_PARTY_TIMEOUT_PERMISSIONS} milliseconds.`
                 );
 
-                expect(spy).toHaveBeenCalledTimes(1);
+                expect(spy).toHaveBeenCalledOnce();
 
                 vi.useRealTimers();
 
@@ -743,8 +743,8 @@ describe('Relying Party', () => {
 
             await promise;
 
-            expect(spy).toHaveBeenCalledTimes(1);
-            expect(spyPostMessage).toHaveBeenCalledTimes(1);
+            expect(spy).toHaveBeenCalledOnce();
+            expect(spyPostMessage).toHaveBeenCalledOnce();
 
             expect(spyPostMessage).toHaveBeenCalledWith(
               expect.objectContaining({
@@ -839,7 +839,7 @@ describe('Relying Party', () => {
                   `Request to signer timed out after ${RELYING_PARTY_TIMEOUT_REQUEST_PERMISSIONS} milliseconds.`
                 );
 
-                expect(spy).toHaveBeenCalledTimes(1);
+                expect(spy).toHaveBeenCalledOnce();
 
                 vi.useRealTimers();
 
@@ -962,8 +962,8 @@ describe('Relying Party', () => {
 
             await promise;
 
-            expect(spy).toHaveBeenCalledTimes(1);
-            expect(spyPostMessage).toHaveBeenCalledTimes(1);
+            expect(spy).toHaveBeenCalledOnce();
+            expect(spyPostMessage).toHaveBeenCalledOnce();
 
             expect(spyPostMessage).toHaveBeenCalledWith(
               expect.objectContaining({
@@ -990,8 +990,8 @@ describe('Relying Party', () => {
 
             await promise;
 
-            expect(spy).toHaveBeenCalledTimes(1);
-            expect(spyPostMessage).toHaveBeenCalledTimes(1);
+            expect(spy).toHaveBeenCalledOnce();
+            expect(spyPostMessage).toHaveBeenCalledOnce();
 
             expect(spyPostMessage).toHaveBeenCalledWith(
               expect.objectContaining({
@@ -1101,7 +1101,7 @@ describe('Relying Party', () => {
                 `Request to signer timed out after ${RELYING_PARTY_TIMEOUT_ACCOUNTS} milliseconds.`
               );
 
-              expect(spy).toHaveBeenCalledTimes(1);
+              expect(spy).toHaveBeenCalledOnce();
 
               vi.useRealTimers();
 
@@ -1224,8 +1224,8 @@ describe('Relying Party', () => {
 
           await promise;
 
-          expect(spy).toHaveBeenCalledTimes(1);
-          expect(spyPostMessage).toHaveBeenCalledTimes(1);
+          expect(spy).toHaveBeenCalledOnce();
+          expect(spyPostMessage).toHaveBeenCalledOnce();
 
           expect(spyPostMessage).toHaveBeenCalledWith(
             expect.objectContaining({
@@ -1361,7 +1361,7 @@ describe('Relying Party', () => {
                 `Request to signer timed out after ${RELYING_PARTY_TIMEOUT_CALL_CANISTER} milliseconds.`
               );
 
-              expect(spy).toHaveBeenCalledTimes(1);
+              expect(spy).toHaveBeenCalledOnce();
 
               vi.useRealTimers();
 
@@ -1494,8 +1494,8 @@ describe('Relying Party', () => {
 
           await promise;
 
-          expect(spy).toHaveBeenCalledTimes(1);
-          expect(spyPostMessage).toHaveBeenCalledTimes(1);
+          expect(spy).toHaveBeenCalledOnce();
+          expect(spyPostMessage).toHaveBeenCalledOnce();
 
           expect(spyPostMessage).toHaveBeenCalledWith(
             expect.objectContaining({
@@ -1530,7 +1530,7 @@ describe('Relying Party', () => {
 
           const callResult = await promise;
 
-          expect(spyAssertCallResponse).toHaveBeenCalledTimes(1);
+          expect(spyAssertCallResponse).toHaveBeenCalledOnce();
 
           expect(spyAssertCallResponse).toHaveBeenCalledWith({
             result: callResult,

--- a/src/services/signer.services.spec.ts
+++ b/src/services/signer.services.spec.ts
@@ -438,7 +438,7 @@ describe('Signer services', () => {
         prompt
       });
 
-      expect(spySignerApiCall).toHaveBeenCalledTimes(1);
+      expect(spySignerApiCall).toHaveBeenCalledOnce();
 
       expect(spySignerApiCall).toHaveBeenCalledWith({
         ...signerOptions,

--- a/src/signer.spec.ts
+++ b/src/signer.spec.ts
@@ -800,7 +800,7 @@ describe('Signer', () => {
             const messageEvent = new MessageEvent('message', requestPermissionsMsg);
             window.dispatchEvent(messageEvent);
 
-            expect(postMessageMock).toHaveBeenCalledTimes(1);
+            expect(postMessageMock).toHaveBeenCalledOnce();
 
             expect(postMessageMock).toHaveBeenCalledWith(
               {
@@ -825,7 +825,7 @@ describe('Signer', () => {
             const messageEvent = new MessageEvent('message', requestPermissionsMsg);
             window.dispatchEvent(messageEvent);
 
-            expect(promptSpy).toHaveBeenCalledTimes(1);
+            expect(promptSpy).toHaveBeenCalledOnce();
 
             expect(promptSpy).toHaveBeenCalledWith({
               requestedScopes: requestPermissionsDataSortedScopes.map((scope) => ({
@@ -850,7 +850,7 @@ describe('Signer', () => {
             const messageEvent = new MessageEvent('message', requestPermissionsMsg);
             window.dispatchEvent(messageEvent);
 
-            expect(promptSpy).toHaveBeenCalledTimes(1);
+            expect(promptSpy).toHaveBeenCalledOnce();
 
             expect(promptSpy).toHaveBeenCalledWith({
               requestedScopes: requestPermissionsDataSortedScopes.map((scope) => ({
@@ -889,7 +889,7 @@ describe('Signer', () => {
             const messageEvent = new MessageEvent('message', requestPermissionsMsg);
             window.dispatchEvent(messageEvent);
 
-            expect(promptSpy).toHaveBeenCalledTimes(1);
+            expect(promptSpy).toHaveBeenCalledOnce();
 
             expect(promptSpy).toHaveBeenCalledWith({
               requestedScopes: requestPermissionsDataSortedScopes.map((scope) => ({
@@ -1107,7 +1107,7 @@ describe('Signer', () => {
               }
             ]);
 
-            await vi.waitFor(() => expect(spy).toHaveBeenCalledTimes(1));
+            await vi.waitFor(() => expect(spy).toHaveBeenCalledOnce());
           });
         });
       });
@@ -1650,7 +1650,7 @@ describe('Signer', () => {
 
               approve?.(mockAccounts);
 
-              await vi.waitFor(() => expect(spy).toHaveBeenCalledTimes(1));
+              await vi.waitFor(() => expect(spy).toHaveBeenCalledOnce());
             });
           });
         });
@@ -1886,7 +1886,7 @@ describe('Signer', () => {
                     });
                   });
 
-                  expect(promptSpy).not.toHaveBeenCalledTimes(1);
+                  expect(promptSpy).not.toHaveBeenCalledOnce();
                 });
               });
             });
@@ -2085,7 +2085,7 @@ describe('Signer', () => {
                   });
 
                   it('should call canister and notify success', () => {
-                    expect(spyCanisterCall).toHaveBeenCalledTimes(1);
+                    expect(spyCanisterCall).toHaveBeenCalledOnce();
 
                     expect(spyCanisterCall).toHaveBeenCalledWith({
                       ...signerOptions,
@@ -2123,7 +2123,7 @@ describe('Signer', () => {
                   });
 
                   it('should call canister and notify error', () => {
-                    expect(spyCanisterCall).toHaveBeenCalledTimes(1);
+                    expect(spyCanisterCall).toHaveBeenCalledOnce();
 
                     expect(spyCanisterCall).toHaveBeenCalledWith({
                       ...signerOptions,

--- a/src/utils/timeout.utils.spec.ts
+++ b/src/utils/timeout.utils.spec.ts
@@ -36,7 +36,7 @@ describe('retryUntilReady', () => {
     const result = await retryUntilReady({retries: 3, isReady, fn});
 
     expect(result).toBe('ready');
-    expect(isReady).toHaveBeenCalledTimes(1);
+    expect(isReady).toHaveBeenCalledOnce();
     expect(fn).not.toHaveBeenCalled();
   });
 
@@ -49,7 +49,7 @@ describe('retryUntilReady', () => {
     const result = await retryUntilReady({retries: 3, isReady, fn});
 
     expect(result).toBe('error');
-    expect(isReady).toHaveBeenCalledTimes(1);
+    expect(isReady).toHaveBeenCalledOnce();
     expect(fn).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
# Motivation

Suggested by @AntonioVentilii in https://github.com/dfinity/oisy-wallet-signer/pull/325#pullrequestreview-2447681710

We can use the shorthand `toHaveBeenCalledOnce`.
