### PR TITLE
build: bump demo dependencies and audit fix

### DIFF
--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -19,18 +19,18 @@
 				"@dfinity/principal": "^2.1.3",
 				"@dfinity/utils": "^2.6.0",
 				"buffer": "^6.0.3",
-				"zod": "^3.23.8"
+				"zod": "^3.24.1"
 			},
 			"devDependencies": {
 				"@junobuild/config": "^0.0.17",
 				"@junobuild/vite-plugin": "^0.0.19",
-				"@playwright/test": "^1.49.0",
+				"@playwright/test": "^1.49.1",
 				"@rollup/plugin-inject": "^5.0.5",
 				"@sveltejs/adapter-static": "^3.0.6",
-				"@sveltejs/kit": "^2.8.3",
+				"@sveltejs/kit": "^2.10.1",
 				"@sveltejs/vite-plugin-svelte": "^4.0.2",
 				"@types/eslint": "^8.56.0",
-				"@types/node": "^22.9.1",
+				"@types/node": "^22.10.2",
 				"@typescript-eslint/eslint-plugin": "^7.0.0",
 				"@typescript-eslint/parser": "^7.0.0",
 				"autoprefixer": "^10.4.20",
@@ -38,15 +38,15 @@
 				"eslint-config-prettier": "^9.1.0",
 				"eslint-plugin-svelte": "^2.46.0",
 				"postcss": "^8.4.49",
-				"prettier": "^3.4.0",
+				"prettier": "^3.4.2",
 				"prettier-plugin-organize-imports": "^4.1.0",
 				"prettier-plugin-svelte": "^3.3.2",
-				"sass": "^1.81.0",
-				"svelte": "^5.2.4",
+				"sass": "^1.82.0",
+				"svelte": "^5.11.2",
 				"svelte-check": "^4.1.1",
-				"tailwindcss": "^3.4.15",
+				"tailwindcss": "^3.4.16",
 				"tslib": "^2.8.1",
-				"typescript": "^5.6.3",
+				"typescript": "^5.7.2",
 				"vite": "^5.4.11",
 				"vitest": "^2.1.5"
 			}
@@ -1889,13 +1889,13 @@
 			}
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.49.0",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.49.0.tgz",
-			"integrity": "sha512-DMulbwQURa8rNIQrf94+jPJQ4FmOVdpE5ZppRNvWVjvhC+6sOeo28r8MgIpQRYouXRtt/FCCXU7zn20jnHR4Qw==",
+			"version": "1.49.1",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.49.1.tgz",
+			"integrity": "sha512-Ky+BVzPz8pL6PQxHqNRW1k3mIyv933LML7HktS8uik0bUXNCdPhoS/kLihiO1tMf/egaJb4IutXd7UywvXEW+g==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"playwright": "1.49.0"
+				"playwright": "1.49.1"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -2190,16 +2190,17 @@
 			}
 		},
 		"node_modules/@sveltejs/kit": {
-			"version": "2.8.3",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.8.3.tgz",
-			"integrity": "sha512-DVBVwugfzzn0SxKA+eAmKqcZ7aHZROCHxH7/pyrOi+HLtQ721eEsctGb9MkhEuqj6q/9S/OFYdn37vdxzFPdvw==",
+			"version": "2.10.1",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.10.1.tgz",
+			"integrity": "sha512-2aormKTn94aU8Lfxj4gcbRGh1Dyw0hCFlNo51+njdRDn9P2ERuWC4bOtTuoy5HJpPYR3AH8oaaEjKDWUHbi1OA==",
 			"dev": true,
 			"hasInstallScript": true,
+			"license": "MIT",
 			"dependencies": {
 				"@types/cookie": "^0.6.0",
 				"cookie": "^0.6.0",
 				"devalue": "^5.1.0",
-				"esm-env": "^1.0.0",
+				"esm-env": "^1.2.1",
 				"import-meta-resolve": "^4.1.0",
 				"kleur": "^4.1.5",
 				"magic-string": "^0.30.5",
@@ -2216,9 +2217,9 @@
 				"node": ">=18.13"
 			},
 			"peerDependencies": {
-				"@sveltejs/vite-plugin-svelte": "^3.0.0 || ^4.0.0-next.1",
+				"@sveltejs/vite-plugin-svelte": "^3.0.0 || ^4.0.0-next.1 || ^5.0.0",
 				"svelte": "^4.0.0 || ^5.0.0-next.0",
-				"vite": "^5.0.3"
+				"vite": "^5.0.3 || ^6.0.0"
 			}
 		},
 		"node_modules/@sveltejs/vite-plugin-svelte": {
@@ -2294,13 +2295,13 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "22.9.1",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.9.1.tgz",
-			"integrity": "sha512-p8Yy/8sw1caA8CdRIQBG5tiLHmxtQKObCijiAa9Ez+d4+PRffM4054xbju0msf+cvhJpnFEeNjxmVT/0ipktrg==",
+			"version": "22.10.2",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.2.tgz",
+			"integrity": "sha512-Xxr6BBRCAOQixvonOye19wnzyDiUtTeqldOOmj3CkeblonbccA12PFwlufvRdrpjXxqnmUaeiU5EOA+7s5diUQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"undici-types": "~6.19.8"
+				"undici-types": "~6.20.0"
 			}
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
@@ -3173,9 +3174,9 @@
 			"license": "MIT"
 		},
 		"node_modules/cookie": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-			"integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+			"integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -3183,9 +3184,9 @@
 			}
 		},
 		"node_modules/cross-spawn": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-			"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3586,9 +3587,9 @@
 			}
 		},
 		"node_modules/esm-env": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.0.0.tgz",
-			"integrity": "sha512-Cf6VksWPsTuW01vU9Mk/3vRue91Zevka5SjyNf3nEpokFRuqt/KjUQoGAwq9qMmhpLTHmXzSIrFRw8zxWzmFBA==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.1.tgz",
+			"integrity": "sha512-U9JedYYjCnadUlXk7e1Kr+aENQhtUaoaV9+gZm1T8LC/YBAPJx3NSPIAurFOC0U5vrdSevnUJS2/wUVxGwPhng==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -3624,9 +3625,9 @@
 			}
 		},
 		"node_modules/esrap": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/esrap/-/esrap-1.2.2.tgz",
-			"integrity": "sha512-F2pSJklxx1BlQIQgooczXCPHmcWpn6EsP5oo73LQfonG9fIlIENQ8vMmfGXeojP9MrkzUNAfyU5vdFlR9shHAw==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/esrap/-/esrap-1.2.3.tgz",
+			"integrity": "sha512-ZlQmCCK+n7SGoqo7DnfKaP1sJZa49P01/dXzmjCASSo04p72w8EksT2NMK8CEX8DhKsfJXANioIw8VyHNsBfvQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4543,9 +4544,9 @@
 			}
 		},
 		"node_modules/nanoid": {
-			"version": "3.3.7",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-			"integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+			"version": "3.3.8",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+			"integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
 			"dev": true,
 			"funding": [
 				{
@@ -4825,13 +4826,13 @@
 			}
 		},
 		"node_modules/playwright": {
-			"version": "1.49.0",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.49.0.tgz",
-			"integrity": "sha512-eKpmys0UFDnfNb3vfsf8Vx2LEOtflgRebl0Im2eQQnYMA4Aqd+Zw8bEOB+7ZKvN76901mRnqdsiOGKxzVTbi7A==",
+			"version": "1.49.1",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.49.1.tgz",
+			"integrity": "sha512-VYL8zLoNTBxVOrJBbDuRgDWa3i+mfQgDTrL8Ah9QXZ7ax4Dsj0MSq5bYgytRnDVVe+njoKnfsYkH3HzqVj5UZA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"playwright-core": "1.49.0"
+				"playwright-core": "1.49.1"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -4844,9 +4845,9 @@
 			}
 		},
 		"node_modules/playwright-core": {
-			"version": "1.49.0",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.49.0.tgz",
-			"integrity": "sha512-R+3KKTQF3npy5GTiKH/T+kdhoJfJojjHESR1YEWhYuEKRVfVaxH3+4+GvXE5xyCngCxhxnykk0Vlah9v8fs3jA==",
+			"version": "1.49.1",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.49.1.tgz",
+			"integrity": "sha512-BzmpVcs4kE2CH15rWfzpjzVGhWERJfmnXmniSyKeRZUs9Ws65m+RGIi7mjJK/euCegfn3i7jvqWeWyHe9y3Vgg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
@@ -5055,9 +5056,9 @@
 			}
 		},
 		"node_modules/prettier": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.0.tgz",
-			"integrity": "sha512-/OXNZcLyWkfo13ofOW5M7SLh+k5pnIs07owXK2teFpnfaOEcycnSy7HQxldaVX1ZP/7Q8oO1eDuQJNwbomQq5Q==",
+			"version": "3.4.2",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.2.tgz",
+			"integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
@@ -5335,9 +5336,9 @@
 			"license": "MIT"
 		},
 		"node_modules/sass": {
-			"version": "1.81.0",
-			"resolved": "https://registry.npmjs.org/sass/-/sass-1.81.0.tgz",
-			"integrity": "sha512-Q4fOxRfhmv3sqCLoGfvrC9pRV8btc0UtqL9mN6Yrv6Qi9ScL55CVH1vlPP863ISLEEMNLLuu9P+enCeGHlnzhA==",
+			"version": "1.82.0",
+			"resolved": "https://registry.npmjs.org/sass/-/sass-1.82.0.tgz",
+			"integrity": "sha512-j4GMCTa8elGyN9A7x7bEglx0VgSpNUG4W4wNedQ33wSMdnkqQCT8HTwOaVSV4e6yQovcu/3Oc4coJP/l0xhL2Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5703,9 +5704,9 @@
 			}
 		},
 		"node_modules/svelte": {
-			"version": "5.2.4",
-			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.2.4.tgz",
-			"integrity": "sha512-hsab3Inx/HKV6Y/FUwtX8yCkt+nl6n46zC7Z6y7VWoDFhJWEQ453vP0KmDL42cLm9Q92nZyOE+izANqjss61/A==",
+			"version": "5.11.2",
+			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.11.2.tgz",
+			"integrity": "sha512-kGWswlBaohYxZHML9jp8ZYXkwjKd+WTpyAK1CCDmNzsefZHQjvsa7kbrKUckcFloNmdzwQwaZq+NyunuNOE6lw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5716,8 +5717,8 @@
 				"acorn-typescript": "^1.4.13",
 				"aria-query": "^5.3.1",
 				"axobject-query": "^4.1.0",
-				"esm-env": "^1.0.0",
-				"esrap": "^1.2.2",
+				"esm-env": "^1.2.1",
+				"esrap": "^1.2.3",
 				"is-reference": "^3.0.3",
 				"locate-character": "^3.0.0",
 				"magic-string": "^0.30.11",
@@ -5839,9 +5840,9 @@
 			}
 		},
 		"node_modules/tailwindcss": {
-			"version": "3.4.15",
-			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.15.tgz",
-			"integrity": "sha512-r4MeXnfBmSOuKUWmXe6h2CcyfzJCEk4F0pptO5jlnYSIViUkVmsawj80N5h2lO3gwcmSb4n3PuN+e+GC1Guylw==",
+			"version": "3.4.16",
+			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.16.tgz",
+			"integrity": "sha512-TI4Cyx7gDiZ6r44ewaJmt0o6BrMCT5aK5e0rmJ/G9Xq3w7CX/5VXl/zIPEJZFUK5VEqwByyhqNPycPlvcK4ZNw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5854,7 +5855,7 @@
 				"glob-parent": "^6.0.2",
 				"is-glob": "^4.0.3",
 				"jiti": "^1.21.6",
-				"lilconfig": "^2.1.0",
+				"lilconfig": "^3.1.3",
 				"micromatch": "^4.0.8",
 				"normalize-path": "^3.0.0",
 				"object-hash": "^3.0.0",
@@ -5874,6 +5875,19 @@
 			},
 			"engines": {
 				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/tailwindcss/node_modules/lilconfig": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+			"integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/antonk52"
 			}
 		},
 		"node_modules/tailwindcss/node_modules/postcss-load-config": {
@@ -5910,19 +5924,6 @@
 				"ts-node": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/tailwindcss/node_modules/postcss-load-config/node_modules/lilconfig": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.2.tgz",
-			"integrity": "sha512-eop+wDAvpItUys0FWkHIKeC9ybYrTGbU41U5K7+bttZZeohvnY7M9dZ5kB21GNWiFT2q1OoPTvncPCgSOVO5ow==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=14"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/antonk52"
 			}
 		},
 		"node_modules/tailwindcss/node_modules/yaml": {
@@ -6109,9 +6110,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "5.6.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
-			"integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
+			"version": "5.7.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
+			"integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
@@ -6123,9 +6124,9 @@
 			}
 		},
 		"node_modules/undici-types": {
-			"version": "6.19.8",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-			"integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+			"version": "6.20.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+			"integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -6562,9 +6563,9 @@
 			"license": "MIT"
 		},
 		"node_modules/zod": {
-			"version": "3.23.8",
-			"resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
-			"integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+			"version": "3.24.1",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-3.24.1.tgz",
+			"integrity": "sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==",
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"

--- a/demo/package.json
+++ b/demo/package.json
@@ -25,13 +25,13 @@
 	"devDependencies": {
 		"@junobuild/config": "^0.0.17",
 		"@junobuild/vite-plugin": "^0.0.19",
-		"@playwright/test": "^1.49.0",
+		"@playwright/test": "^1.49.1",
 		"@rollup/plugin-inject": "^5.0.5",
 		"@sveltejs/adapter-static": "^3.0.6",
-		"@sveltejs/kit": "^2.8.3",
+		"@sveltejs/kit": "^2.10.1",
 		"@sveltejs/vite-plugin-svelte": "^4.0.2",
 		"@types/eslint": "^8.56.0",
-		"@types/node": "^22.9.1",
+		"@types/node": "^22.10.2",
 		"@typescript-eslint/eslint-plugin": "^7.0.0",
 		"@typescript-eslint/parser": "^7.0.0",
 		"autoprefixer": "^10.4.20",
@@ -39,15 +39,15 @@
 		"eslint-config-prettier": "^9.1.0",
 		"eslint-plugin-svelte": "^2.46.0",
 		"postcss": "^8.4.49",
-		"prettier": "^3.4.0",
+		"prettier": "^3.4.2",
 		"prettier-plugin-organize-imports": "^4.1.0",
 		"prettier-plugin-svelte": "^3.3.2",
-		"sass": "^1.81.0",
-		"svelte": "^5.2.4",
+		"sass": "^1.82.0",
+		"svelte": "^5.11.2",
 		"svelte-check": "^4.1.1",
-		"tailwindcss": "^3.4.15",
+		"tailwindcss": "^3.4.16",
 		"tslib": "^2.8.1",
-		"typescript": "^5.6.3",
+		"typescript": "^5.7.2",
 		"vite": "^5.4.11",
 		"vitest": "^2.1.5"
 	},
@@ -60,6 +60,9 @@
 		"@dfinity/principal": "^2.1.3",
 		"@dfinity/utils": "^2.6.0",
 		"buffer": "^6.0.3",
-		"zod": "^3.23.8"
+		"zod": "^3.24.1"
+	},
+	"overrides": {
+		"cookie": "^0.7.0"
 	}
 }


### PR DESCRIPTION
# Motivation

Bump recent dependencies in the demo (except eslint) and audit fix at the same time.

