### PR TITLE
build: bump demo dev dependencies

### DIFF
--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -27,7 +27,7 @@
 				"@playwright/test": "^1.49.1",
 				"@rollup/plugin-inject": "^5.0.5",
 				"@sveltejs/adapter-static": "^3.0.6",
-				"@sveltejs/kit": "^2.10.1",
+				"@sveltejs/kit": "^2.13.0",
 				"@sveltejs/vite-plugin-svelte": "^4.0.2",
 				"@types/eslint": "^8.56.0",
 				"@types/node": "^22.10.2",
@@ -41,14 +41,14 @@
 				"prettier": "^3.4.2",
 				"prettier-plugin-organize-imports": "^4.1.0",
 				"prettier-plugin-svelte": "^3.3.2",
-				"sass": "^1.82.0",
-				"svelte": "^5.11.2",
+				"sass": "^1.83.0",
+				"svelte": "^5.15.0",
 				"svelte-check": "^4.1.1",
-				"tailwindcss": "^3.4.16",
+				"tailwindcss": "^3.4.17",
 				"tslib": "^2.8.1",
 				"typescript": "^5.7.2",
 				"vite": "^5.4.11",
-				"vitest": "^2.1.5"
+				"vitest": "^2.1.8"
 			}
 		},
 		"node_modules/@alloc/quick-lru": {
@@ -1314,9 +1314,9 @@
 			}
 		},
 		"node_modules/@isaacs/cliui/node_modules/ansi-regex": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-			"integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+			"integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -2190,9 +2190,9 @@
 			}
 		},
 		"node_modules/@sveltejs/kit": {
-			"version": "2.10.1",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.10.1.tgz",
-			"integrity": "sha512-2aormKTn94aU8Lfxj4gcbRGh1Dyw0hCFlNo51+njdRDn9P2ERuWC4bOtTuoy5HJpPYR3AH8oaaEjKDWUHbi1OA==",
+			"version": "2.13.0",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.13.0.tgz",
+			"integrity": "sha512-6t6ne00vZx/TjD6s0Jvwt8wRLKBwbSAN1nhlOzcLUSTYX1hTp4eCBaTPB5Yz/lu+tYcvz4YPEEuPv3yfsNp2gw==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -2505,14 +2505,14 @@
 			"license": "ISC"
 		},
 		"node_modules/@vitest/expect": {
-			"version": "2.1.5",
-			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.5.tgz",
-			"integrity": "sha512-nZSBTW1XIdpZvEJyoP/Sy8fUg0b8od7ZpGDkTUcfJ7wz/VoZAFzFfLyxVxGFhUjJzhYqSbIpfMtl/+k/dpWa3Q==",
+			"version": "2.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.8.tgz",
+			"integrity": "sha512-8ytZ/fFHq2g4PJVAtDX57mayemKgDR6X3Oa2Foro+EygiOJHUXhCqBAAKQYYajZpFoIfvBCF1j6R6IYRSIUFuw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/spy": "2.1.5",
-				"@vitest/utils": "2.1.5",
+				"@vitest/spy": "2.1.8",
+				"@vitest/utils": "2.1.8",
 				"chai": "^5.1.2",
 				"tinyrainbow": "^1.2.0"
 			},
@@ -2521,13 +2521,13 @@
 			}
 		},
 		"node_modules/@vitest/mocker": {
-			"version": "2.1.5",
-			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.5.tgz",
-			"integrity": "sha512-XYW6l3UuBmitWqSUXTNXcVBUCRytDogBsWuNXQijc00dtnU/9OqpXWp4OJroVrad/gLIomAq9aW8yWDBtMthhQ==",
+			"version": "2.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.8.tgz",
+			"integrity": "sha512-7guJ/47I6uqfttp33mgo6ga5Gr1VnL58rcqYKyShoRK9ebu8T5Rs6HN3s1NABiBeVTdWNrwUMcHH54uXZBN4zA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/spy": "2.1.5",
+				"@vitest/spy": "2.1.8",
 				"estree-walker": "^3.0.3",
 				"magic-string": "^0.30.12"
 			},
@@ -2548,9 +2548,9 @@
 			}
 		},
 		"node_modules/@vitest/pretty-format": {
-			"version": "2.1.5",
-			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.5.tgz",
-			"integrity": "sha512-4ZOwtk2bqG5Y6xRGHcveZVr+6txkH7M2e+nPFd6guSoN638v/1XQ0K06eOpi0ptVU/2tW/pIU4IoPotY/GZ9fw==",
+			"version": "2.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.8.tgz",
+			"integrity": "sha512-9HiSZ9zpqNLKlbIDRWOnAWqgcA7xu+8YxXSekhr0Ykab7PAYFkhkwoqVArPOtJhPmYeE2YHgKZlj3CP36z2AJQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2561,13 +2561,13 @@
 			}
 		},
 		"node_modules/@vitest/runner": {
-			"version": "2.1.5",
-			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.5.tgz",
-			"integrity": "sha512-pKHKy3uaUdh7X6p1pxOkgkVAFW7r2I818vHDthYLvUyjRfkKOU6P45PztOch4DZarWQne+VOaIMwA/erSSpB9g==",
+			"version": "2.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.8.tgz",
+			"integrity": "sha512-17ub8vQstRnRlIU5k50bG+QOMLHRhYPAna5tw8tYbj+jzjcspnwnwtPtiOlkuKC4+ixDPTuLZiqiWWQ2PSXHVg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/utils": "2.1.5",
+				"@vitest/utils": "2.1.8",
 				"pathe": "^1.1.2"
 			},
 			"funding": {
@@ -2575,13 +2575,13 @@
 			}
 		},
 		"node_modules/@vitest/snapshot": {
-			"version": "2.1.5",
-			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.5.tgz",
-			"integrity": "sha512-zmYw47mhfdfnYbuhkQvkkzYroXUumrwWDGlMjpdUr4jBd3HZiV2w7CQHj+z7AAS4VOtWxI4Zt4bWt4/sKcoIjg==",
+			"version": "2.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.8.tgz",
+			"integrity": "sha512-20T7xRFbmnkfcmgVEz+z3AU/3b0cEzZOt/zmnvZEctg64/QZbSDJEVm9fLnnlSi74KibmRsO9/Qabi+t0vCRPg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/pretty-format": "2.1.5",
+				"@vitest/pretty-format": "2.1.8",
 				"magic-string": "^0.30.12",
 				"pathe": "^1.1.2"
 			},
@@ -2590,9 +2590,9 @@
 			}
 		},
 		"node_modules/@vitest/spy": {
-			"version": "2.1.5",
-			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.5.tgz",
-			"integrity": "sha512-aWZF3P0r3w6DiYTVskOYuhBc7EMc3jvn1TkBg8ttylFFRqNN2XGD7V5a4aQdk6QiUzZQ4klNBSpCLJgWNdIiNw==",
+			"version": "2.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.8.tgz",
+			"integrity": "sha512-5swjf2q95gXeYPevtW0BLk6H8+bPlMb4Vw/9Em4hFxDcaOxS+e0LOX4yqNxoHzMR2akEB2xfpnWUzkZokmgWDg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2603,13 +2603,13 @@
 			}
 		},
 		"node_modules/@vitest/utils": {
-			"version": "2.1.5",
-			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.5.tgz",
-			"integrity": "sha512-yfj6Yrp0Vesw2cwJbP+cl04OC+IHFsuQsrsJBL9pyGeQXE56v1UAOQco+SR55Vf1nQzfV0QJg1Qum7AaWUwwYg==",
+			"version": "2.1.8",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.8.tgz",
+			"integrity": "sha512-dwSoui6djdwbfFmIgbIjX2ZhIoG7Ex/+xpxyiEgIGzjliY8xGkcpITKTlp6B4MgtGkF2ilvm97cPM96XZaAgcA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/pretty-format": "2.1.5",
+				"@vitest/pretty-format": "2.1.8",
 				"loupe": "^3.1.2",
 				"tinyrainbow": "^1.2.0"
 			},
@@ -3625,14 +3625,13 @@
 			}
 		},
 		"node_modules/esrap": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/esrap/-/esrap-1.2.3.tgz",
-			"integrity": "sha512-ZlQmCCK+n7SGoqo7DnfKaP1sJZa49P01/dXzmjCASSo04p72w8EksT2NMK8CEX8DhKsfJXANioIw8VyHNsBfvQ==",
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/esrap/-/esrap-1.3.2.tgz",
+			"integrity": "sha512-C4PXusxYhFT98GjLSmb20k9PREuUdporer50dhzGuJu9IJXktbMddVCMLAERl5dAHyAi73GWWCE4FVHGP1794g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jridgewell/sourcemap-codec": "^1.4.15",
-				"@types/estree": "^1.0.1"
+				"@jridgewell/sourcemap-codec": "^1.4.15"
 			}
 		},
 		"node_modules/esrecurse": {
@@ -3815,9 +3814,9 @@
 			"license": "ISC"
 		},
 		"node_modules/foreground-child": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.2.1.tgz",
-			"integrity": "sha512-PXUUyLqrR2XCWICfv6ukppP96sdFwWbNEnfEMt7jNsISjMsvaLNinAHNDYyvkyU+SZG2BTSbT5NjG+vZslfGTA==",
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
+			"integrity": "sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -4140,9 +4139,9 @@
 			}
 		},
 		"node_modules/is-core-module": {
-			"version": "2.15.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.0.tgz",
-			"integrity": "sha512-Dd+Lb2/zvk9SKy1TGCt1wFJFo/MWBPMX5x7KcvLajWTGuomczdQX61PvY5yK6SVACwpoexWo81IfFyoKY2QnTA==",
+			"version": "2.16.0",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.0.tgz",
+			"integrity": "sha512-urTSINYfAYgcbLb0yDQ6egFm6h3Mo1DcF9EkyXSRjjzdHbsulg01qhwWuXdOoUBuTkbQ80KDboXa0vFJ+BDH+g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4258,9 +4257,9 @@
 			}
 		},
 		"node_modules/jiti": {
-			"version": "1.21.6",
-			"resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.6.tgz",
-			"integrity": "sha512-2yTgeWTWzMWkHu6Jp9NKgePDaYHbntiwvYuuJLbbN9vl7DC9DvXKOB2BC3ZZ92D3cvV/aflH0osDfwpHepQ53w==",
+			"version": "1.21.7",
+			"resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
+			"integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
@@ -4685,9 +4684,9 @@
 			}
 		},
 		"node_modules/package-json-from-dist": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.0.tgz",
-			"integrity": "sha512-dATvCeZN/8wQsGywez1mzHtTlP22H8OEfPrVMLNr4/eGa+ijtLn/6M5f0dY8UKNrC2O9UCU6SSoG3qRKnt7STw==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+			"integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
 			"dev": true,
 			"license": "BlueOak-1.0.0"
 		},
@@ -5188,18 +5187,21 @@
 			}
 		},
 		"node_modules/resolve": {
-			"version": "1.22.8",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
-			"integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
+			"version": "1.22.10",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
+			"integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"is-core-module": "^2.13.0",
+				"is-core-module": "^2.16.0",
 				"path-parse": "^1.0.7",
 				"supports-preserve-symlinks-flag": "^1.0.0"
 			},
 			"bin": {
 				"resolve": "bin/resolve"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -5336,9 +5338,9 @@
 			"license": "MIT"
 		},
 		"node_modules/sass": {
-			"version": "1.82.0",
-			"resolved": "https://registry.npmjs.org/sass/-/sass-1.82.0.tgz",
-			"integrity": "sha512-j4GMCTa8elGyN9A7x7bEglx0VgSpNUG4W4wNedQ33wSMdnkqQCT8HTwOaVSV4e6yQovcu/3Oc4coJP/l0xhL2Q==",
+			"version": "1.83.0",
+			"resolved": "https://registry.npmjs.org/sass/-/sass-1.83.0.tgz",
+			"integrity": "sha512-qsSxlayzoOjdvXMVLkzF84DJFc2HZEL/rFyGIKbbilYtAvlCxyuzUeff9LawTn4btVnLKg75Z8MMr1lxU1lfGw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5555,9 +5557,9 @@
 			"license": "MIT"
 		},
 		"node_modules/string-width/node_modules/ansi-regex": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-			"integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+			"integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -5704,9 +5706,9 @@
 			}
 		},
 		"node_modules/svelte": {
-			"version": "5.11.2",
-			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.11.2.tgz",
-			"integrity": "sha512-kGWswlBaohYxZHML9jp8ZYXkwjKd+WTpyAK1CCDmNzsefZHQjvsa7kbrKUckcFloNmdzwQwaZq+NyunuNOE6lw==",
+			"version": "5.15.0",
+			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.15.0.tgz",
+			"integrity": "sha512-YWl8rAd4hSjERLtLvP6h2pflGtmrJwv+L12BgrOtHYJCpvLS9WKp/YNAdyolw3FymXtcYZqhSWvWlu5O1X7tgQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5718,7 +5720,7 @@
 				"aria-query": "^5.3.1",
 				"axobject-query": "^4.1.0",
 				"esm-env": "^1.2.1",
-				"esrap": "^1.2.3",
+				"esrap": "^1.3.2",
 				"is-reference": "^3.0.3",
 				"locate-character": "^3.0.0",
 				"magic-string": "^0.30.11",
@@ -5840,9 +5842,9 @@
 			}
 		},
 		"node_modules/tailwindcss": {
-			"version": "3.4.16",
-			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.16.tgz",
-			"integrity": "sha512-TI4Cyx7gDiZ6r44ewaJmt0o6BrMCT5aK5e0rmJ/G9Xq3w7CX/5VXl/zIPEJZFUK5VEqwByyhqNPycPlvcK4ZNw==",
+			"version": "3.4.17",
+			"resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
+			"integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5927,9 +5929,9 @@
 			}
 		},
 		"node_modules/tailwindcss/node_modules/yaml": {
-			"version": "2.4.5",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.4.5.tgz",
-			"integrity": "sha512-aBx2bnqDzVOyNKfsysjA2ms5ZlnjSAW2eG3/L5G/CSujfjLJTJsEw1bGw8kCf04KodQWk1pxlGnZ56CRxiawmg==",
+			"version": "2.6.1",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.1.tgz",
+			"integrity": "sha512-7r0XPzioN/Q9kXBro/XPnA6kznR73DHq+GXh5ON7ZozRO6aMjbmiBuKste2wslTFkC5d1dw0GooOCepZXJ2SAg==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -6238,9 +6240,9 @@
 			}
 		},
 		"node_modules/vite-node": {
-			"version": "2.1.5",
-			"resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.5.tgz",
-			"integrity": "sha512-rd0QIgx74q4S1Rd56XIiL2cYEdyWn13cunYBIuqh9mpmQr7gGS0IxXoP8R6OaZtNQQLyXSWbd4rXKYUbhFpK5w==",
+			"version": "2.1.8",
+			"resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.8.tgz",
+			"integrity": "sha512-uPAwSr57kYjAUux+8E2j0q0Fxpn8M9VoyfGiRI8Kfktz9NcYMCenwY5RnZxnF1WTu3TGiYipirIzacLL3VVGFg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6295,19 +6297,19 @@
 			}
 		},
 		"node_modules/vitest": {
-			"version": "2.1.5",
-			"resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.5.tgz",
-			"integrity": "sha512-P4ljsdpuzRTPI/kbND2sDZ4VmieerR2c9szEZpjc+98Z9ebvnXmM5+0tHEKqYZumXqlvnmfWsjeFOjXVriDG7A==",
+			"version": "2.1.8",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.8.tgz",
+			"integrity": "sha512-1vBKTZskHw/aosXqQUlVWWlGUxSJR8YtiyZDJAFeW2kPAeX6S3Sool0mjspO+kXLuxVWlEDDowBAeqeAQefqLQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/expect": "2.1.5",
-				"@vitest/mocker": "2.1.5",
-				"@vitest/pretty-format": "^2.1.5",
-				"@vitest/runner": "2.1.5",
-				"@vitest/snapshot": "2.1.5",
-				"@vitest/spy": "2.1.5",
-				"@vitest/utils": "2.1.5",
+				"@vitest/expect": "2.1.8",
+				"@vitest/mocker": "2.1.8",
+				"@vitest/pretty-format": "^2.1.8",
+				"@vitest/runner": "2.1.8",
+				"@vitest/snapshot": "2.1.8",
+				"@vitest/spy": "2.1.8",
+				"@vitest/utils": "2.1.8",
 				"chai": "^5.1.2",
 				"debug": "^4.3.7",
 				"expect-type": "^1.1.0",
@@ -6319,7 +6321,7 @@
 				"tinypool": "^1.0.1",
 				"tinyrainbow": "^1.2.0",
 				"vite": "^5.0.0",
-				"vite-node": "2.1.5",
+				"vite-node": "2.1.8",
 				"why-is-node-running": "^2.3.0"
 			},
 			"bin": {
@@ -6334,8 +6336,8 @@
 			"peerDependencies": {
 				"@edge-runtime/vm": "*",
 				"@types/node": "^18.0.0 || >=20.0.0",
-				"@vitest/browser": "2.1.5",
-				"@vitest/ui": "2.1.5",
+				"@vitest/browser": "2.1.8",
+				"@vitest/ui": "2.1.8",
 				"happy-dom": "*",
 				"jsdom": "*"
 			},
@@ -6477,9 +6479,9 @@
 			}
 		},
 		"node_modules/wrap-ansi/node_modules/ansi-regex": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-			"integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+			"integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {

--- a/demo/package.json
+++ b/demo/package.json
@@ -28,7 +28,7 @@
 		"@playwright/test": "^1.49.1",
 		"@rollup/plugin-inject": "^5.0.5",
 		"@sveltejs/adapter-static": "^3.0.6",
-		"@sveltejs/kit": "^2.10.1",
+		"@sveltejs/kit": "^2.13.0",
 		"@sveltejs/vite-plugin-svelte": "^4.0.2",
 		"@types/eslint": "^8.56.0",
 		"@types/node": "^22.10.2",
@@ -42,14 +42,14 @@
 		"prettier": "^3.4.2",
 		"prettier-plugin-organize-imports": "^4.1.0",
 		"prettier-plugin-svelte": "^3.3.2",
-		"sass": "^1.82.0",
-		"svelte": "^5.11.2",
+		"sass": "^1.83.0",
+		"svelte": "^5.15.0",
 		"svelte-check": "^4.1.1",
-		"tailwindcss": "^3.4.16",
+		"tailwindcss": "^3.4.17",
 		"tslib": "^2.8.1",
 		"typescript": "^5.7.2",
 		"vite": "^5.4.11",
-		"vitest": "^2.1.5"
+		"vitest": "^2.1.8"
 	},
 	"type": "module",
 	"dependencies": {


### PR DESCRIPTION
# Motivation

Vitest currently does not support vite v6, therefore not all dev dependencies related to Svelte in the demo can be upgraded.

# Changes

- Update @sveltejs/kit svelte sass tailwindcss vitest in demo