### PR TITLE
refactor: rename IDL encoder and decoder utils

### DIFF
--- a/src/icp-wallet.ts
+++ b/src/icp-wallet.ts
@@ -14,7 +14,7 @@ import type {PrincipalText} from './types/principal';
 import {RelyingPartyOptions} from './types/relying-party-options';
 import type {RelyingPartyRequestOptions} from './types/relying-party-requests';
 import {decodeResponse} from './utils/call.utils';
-import {encodeArg} from './utils/idl.utils';
+import {encodeIdl} from './utils/idl.utils';
 
 const ICP_LEDGER_CANISTER_ID = 'ryjl3-tyaaa-aaaaa-aaaba-cai';
 
@@ -63,7 +63,7 @@ export class IcpWallet extends RelyingParty {
     // TODO: should we convert ic-js to zod? or should we map Icrc1TransferRequest to zod?
     const rawArgs = toIcrc1TransferRawRequest(request);
 
-    const arg = encodeArg({
+    const arg = encodeIdl({
       recordClass: TransferArgs,
       rawArgs
     });

--- a/src/icrc-wallet.ts
+++ b/src/icrc-wallet.ts
@@ -16,7 +16,7 @@ import type {
 } from './index';
 import {RelyingParty} from './relying-party';
 import {decodeResponse} from './utils/call.utils';
-import {encodeArg} from './utils/idl.utils';
+import {encodeIdl} from './utils/idl.utils';
 
 export class IcrcWallet extends RelyingParty {
   /**
@@ -62,7 +62,7 @@ export class IcrcWallet extends RelyingParty {
   } & Pick<IcrcAccount, 'owner'>): Promise<IcrcBlockIndex> => {
     const rawArgs = toTransferArg(params);
 
-    const arg = encodeArg({
+    const arg = encodeIdl({
       recordClass: TransferArgs,
       rawArgs
     });

--- a/src/utils/call.utils.ts
+++ b/src/utils/call.utils.ts
@@ -20,7 +20,7 @@ import {
   assertCallMethod,
   assertCallSender
 } from './call.assert.utils';
-import {decodeResult} from './idl.utils';
+import {decodeIdl} from './idl.utils';
 
 export const assertCallResponse = ({
   params: {method, arg, canisterId, sender},
@@ -97,8 +97,8 @@ export const decodeResponse = async <T>({
     'A reply cannot be resolved within the provided certificate. This is unexpected; it should have been known at this point.'
   );
 
-  return decodeResult<T>({
+  return decodeIdl<T>({
     recordClass: resultRecordClass,
-    reply
+    bytes: reply
   });
 };

--- a/src/utils/idl.utils.spec.ts
+++ b/src/utils/idl.utils.spec.ts
@@ -2,7 +2,7 @@ import {IDL} from '@dfinity/candid';
 import {Principal} from '@dfinity/principal';
 import {TransferArgs} from '../constants/icrc.idl.constants';
 import {TransferArgs as TransferArgsType} from '../declarations/icrc-1';
-import {decodeResult, encodeArg} from './idl.utils';
+import {decodeIdl, encodeIdl} from './idl.utils';
 
 describe('idl.utils', () => {
   beforeEach(() => {
@@ -25,7 +25,7 @@ describe('idl.utils', () => {
         }
       };
 
-      const arg = encodeArg({
+      const arg = encodeIdl({
         recordClass: TransferArgs,
         rawArgs
       });
@@ -39,13 +39,13 @@ describe('idl.utils', () => {
   describe('decodeResult', () => {
     const mockRecordClass = IDL.Record({someField: IDL.Text});
 
-    it('should decode the reply and return the result', () => {
+    it('should decode the bytes and return the result', () => {
       const mockExpectedObject = {someField: 'test value'};
       const mockReply = IDL.encode([mockRecordClass], [mockExpectedObject]);
 
-      const result = decodeResult<{someField: string}>({
+      const result = decodeIdl<{someField: string}>({
         recordClass: mockRecordClass,
-        reply: mockReply
+        bytes: mockReply
       });
 
       expect(result).toEqual(mockExpectedObject);
@@ -55,9 +55,9 @@ describe('idl.utils', () => {
       const invalidReply = new ArrayBuffer(10);
 
       expect(() =>
-        decodeResult({
+        decodeIdl({
           recordClass: mockRecordClass,
-          reply: invalidReply
+          bytes: invalidReply
         })
       ).toThrowError(/Wrong magic number/);
     });
@@ -71,9 +71,9 @@ describe('idl.utils', () => {
       vi.spyOn(IDL, 'decode').mockReturnValue([{someField: 'value1'}, {someField: 'value2'}]);
 
       expect(() =>
-        decodeResult({
+        decodeIdl({
           recordClass: mockRecordClass,
-          reply: mockReply
+          bytes: mockReply
         })
       ).toThrow('More than one object returned. This is unexpected.');
     });

--- a/src/utils/idl.utils.ts
+++ b/src/utils/idl.utils.ts
@@ -3,7 +3,7 @@ import {RecordClass, VariantClass} from '@dfinity/candid/lib/cjs/idl';
 import {IcrcBlob} from '../types/blob';
 import {uint8ArrayToBase64} from './base64.utils';
 
-export const encodeArg = <T>({
+export const encodeIdl = <T>({
   recordClass,
   rawArgs
 }: {
@@ -11,14 +11,14 @@ export const encodeArg = <T>({
   rawArgs: T;
 }): IcrcBlob => uint8ArrayToBase64(new Uint8Array(IDL.encode([recordClass], [rawArgs])));
 
-export const decodeResult = <T>({
+export const decodeIdl = <T>({
   recordClass,
-  reply
+  bytes
 }: {
   recordClass: RecordClass | VariantClass;
-  reply: ArrayBuffer;
+  bytes: ArrayBuffer;
 }): T => {
-  const result = IDL.decode([recordClass], reply);
+  const result = IDL.decode([recordClass], bytes);
 
   if (result.length !== 1) {
     throw new Error('More than one object returned. This is unexpected.');


### PR DESCRIPTION
# Motivation

We want to reuse the IDL decoder utility for other features than only results, notably decoding args in  #360, that's why this PR renames the functions for a more generic purpose related to IDL.

# Changes

No code changes functional wise.

# Tests

No tests changes.
