### PR TITLE
feat: amount formatter

### DIFF
--- a/src/utils/format.utils.spec.ts
+++ b/src/utils/format.utils.spec.ts
@@ -1,0 +1,35 @@
+import {formatAmount} from './format.utils';
+
+describe('formatAmount', () => {
+  it('formats amounts with the specified decimals', () => {
+    expect(formatAmount({amount: 123456n, decimals: 2})).toBe('1,234.56');
+    expect(formatAmount({amount: 1000000n, decimals: 6})).toBe('1.00');
+  });
+
+  it('formats zero amount with decimals', () => {
+    expect(formatAmount({amount: 0n, decimals: 2})).toBe('0.00');
+    expect(formatAmount({amount: 0n, decimals: 6})).toBe('0.00');
+  });
+
+  it('handles large amounts properly', () => {
+    expect(formatAmount({amount: 123456789012345n, decimals: 8})).toBe('1,234,567.89012345');
+  });
+
+  it('handles small decimals without rounding errors', () => {
+    expect(formatAmount({amount: 1n, decimals: 8})).toBe('0.00000001');
+    expect(formatAmount({amount: 10n, decimals: 8})).toBe('0.0000001');
+    expect(formatAmount({amount: 100n, decimals: 8})).toBe('0.000001');
+    expect(formatAmount({amount: 100_000_000n, decimals: 8})).toBe('1.00');
+    expect(formatAmount({amount: 1_000_000_000n, decimals: 8})).toBe('10.00');
+    expect(formatAmount({amount: 1_010_000_000n, decimals: 8})).toBe('10.10');
+    expect(formatAmount({amount: 1_012_300_000n, decimals: 8})).toBe('10.123');
+    expect(formatAmount({amount: 20_000_000_000n, decimals: 8})).toBe('200.00');
+    expect(formatAmount({amount: 20_000_000_001n, decimals: 8})).toBe('200.00000001');
+    expect(formatAmount({amount: 200_000_000_000n, decimals: 8})).toBe(`2,000.00`);
+    expect(formatAmount({amount: 200_000_000_000_000n, decimals: 8})).toBe(`2,000,000.00`);
+  });
+
+  it('throws an error for invalid decimals', () => {
+    expect(() => formatAmount({amount: 100n, decimals: -1})).toThrow();
+  });
+});

--- a/src/utils/format.utils.ts
+++ b/src/utils/format.utils.ts
@@ -1,0 +1,8 @@
+export const formatAmount = ({amount, decimals}: {amount: bigint; decimals: number}): string => {
+  const converted = Number(amount) / 10 ** decimals;
+
+  return new Intl.NumberFormat('en-US', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: decimals
+  }).format(converted);
+};


### PR DESCRIPTION
# Motivation

For the consent message custom builders of #360, we will need a formatter to present amounts in a readable way to users.  
This PR implements such utilities.

# Notes

The formatter isn't as fancy as in OISY or the NNS dapp, given the timeframe and the fact that the amount is included within markdown content. On the other hand, it is also closer to standard as it does not add too many customization at the top. Long story short, that will do for now when it comes to me.

# Changes

- Add a formatter which receive an amount in bigint and the number of decimals.
