### PR TITLE
build: bump ic-js peer to include token metadata mapper

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,10 +28,10 @@
       "peerDependencies": {
         "@dfinity/agent": "^2.1.3",
         "@dfinity/candid": "^2.1.3",
-        "@dfinity/ledger-icp": "^2.6.4",
-        "@dfinity/ledger-icrc": "^2.6.4",
+        "@dfinity/ledger-icp": "^2.6.5",
+        "@dfinity/ledger-icrc": "^2.7.0",
         "@dfinity/principal": "^2.1.3",
-        "@dfinity/utils": "^2.7.1",
+        "@dfinity/utils": "^2.8.0",
         "borc": "^2.1.1",
         "simple-cbor": "^0.4.1",
         "zod": "^3.23.8"
@@ -237,29 +237,29 @@
       }
     },
     "node_modules/@dfinity/ledger-icp": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.6.4.tgz",
-      "integrity": "sha512-RbvDiMcMRCok4c3s4xoHg8nwatsFFZgQcZkV/TTn7MpfnLgmMWtTGx97astv0fpj5cCLOl/NXbJhJd+Z+g8eEg==",
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-2.6.5.tgz",
+      "integrity": "sha512-3Ya9LoCSeVUjqQ3+JBfzFf3XVRR4of2frko0ZimJ3MykTQCM8lEihLro6rr6a7tKeHSW2ceQaZwD5864UkrV2Q==",
       "license": "Apache-2.0",
       "peer": true,
       "peerDependencies": {
         "@dfinity/agent": "^2.0.0",
         "@dfinity/candid": "^2.0.0",
         "@dfinity/principal": "^2.0.0",
-        "@dfinity/utils": "^2.7.1"
+        "@dfinity/utils": "^2.8.0"
       }
     },
     "node_modules/@dfinity/ledger-icrc": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.6.4.tgz",
-      "integrity": "sha512-Q7B/D6NhmWQW4qFWZVaV8B6efuRto7hDa0GmT1hxeeUPcyXt42AtfNgyqByDu82Wsank90AW4hgBS0UhKGEB9Q==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-2.7.0.tgz",
+      "integrity": "sha512-WDqCFHaPE55Vn2aYgZQ0/Jdyp56zqhQKUk2dgphraG8F7MU6rgCan4IwiA8ksqXX9XSsvuS3UMWWYV5FcrRVoQ==",
       "license": "Apache-2.0",
       "peer": true,
       "peerDependencies": {
         "@dfinity/agent": "^2.0.0",
         "@dfinity/candid": "^2.0.0",
         "@dfinity/principal": "^2.0.0",
-        "@dfinity/utils": "^2.7.1"
+        "@dfinity/utils": "^2.8.0"
       }
     },
     "node_modules/@dfinity/principal": {
@@ -273,9 +273,9 @@
       }
     },
     "node_modules/@dfinity/utils": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.7.1.tgz",
-      "integrity": "sha512-61DFOBmRomKLQUqBYuiUaqE+bFeGs31bjCQjOlWMQghJAEC7gxOlapasZFGBMVGEYITGy48hFczWaVGtYRfTjw==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.8.0.tgz",
+      "integrity": "sha512-Iqqc3svXMoWEB55S8kCy+y2bwdjwTDFfZ9zmNY9Lf5kKtJ+7smlo/BlB1hz4xfocTPVzhDjuovKV5AYur5PfRg==",
       "license": "Apache-2.0",
       "peer": true,
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -94,10 +94,10 @@
   "peerDependencies": {
     "@dfinity/agent": "^2.1.3",
     "@dfinity/candid": "^2.1.3",
-    "@dfinity/ledger-icp": "^2.6.4",
-    "@dfinity/ledger-icrc": "^2.6.4",
+    "@dfinity/ledger-icp": "^2.6.5",
+    "@dfinity/ledger-icrc": "^2.7.0",
     "@dfinity/principal": "^2.1.3",
-    "@dfinity/utils": "^2.7.1",
+    "@dfinity/utils": "^2.8.0",
     "borc": "^2.1.1",
     "simple-cbor": "^0.4.1",
     "zod": "^3.23.8"


### PR DESCRIPTION
# Motivation

We released a new version of the ledger-icrc which contains a mapper for token metadata which we need in #360.
So this PR bumps the ic-js peer dependencies.