### PR TITLE
feat: integrate ledger metadata in the API

### DIFF
--- a/src/api/signer.api.ts
+++ b/src/api/signer.api.ts
@@ -1,3 +1,6 @@
+import {IcrcLedgerCanister} from '@dfinity/ledger-icrc';
+import type {IcrcTokenMetadataResponse} from '@dfinity/ledger-icrc/dist/types/types/ledger.responses';
+import {Principal} from '@dfinity/principal';
 import {arrayBufferToUint8Array} from '@dfinity/utils';
 import {encode} from '../agent/agentjs-cbor-copy';
 import type {CustomHttpAgentResponse} from '../agent/custom-http-agent';
@@ -24,6 +27,23 @@ export class SignerApi extends Icrc21Canister {
     });
 
     return this.encodeResult(result);
+  }
+
+  async ledgerMetadata({
+    host,
+    owner,
+    params: {canisterId}
+  }: {
+    params: Pick<IcrcCallCanisterRequestParams, 'canisterId'>;
+  } & SignerOptions): Promise<IcrcTokenMetadataResponse> {
+    const agent = await this.getAgent({host, owner});
+
+    const {metadata} = IcrcLedgerCanister.create({
+      agent: agent.agent,
+      canisterId: Principal.fromText(canisterId)
+    });
+
+    return await metadata({certified: true});
   }
 
   private encodeResult({

--- a/src/api/signer.api.ts
+++ b/src/api/signer.api.ts
@@ -36,10 +36,11 @@ export class SignerApi extends Icrc21Canister {
   }: {
     params: Pick<IcrcCallCanisterRequestParams, 'canisterId'>;
   } & SignerOptions): Promise<IcrcTokenMetadataResponse> {
-    const agent = await this.getAgent({host, owner});
+    const {agent} = await this.getAgent({host, owner});
 
+    // TODO: improve performance by caching the IcrcLedgerCanister?
     const {metadata} = IcrcLedgerCanister.create({
-      agent: agent.agent,
+      agent,
       canisterId: Principal.fromText(canisterId)
     });
 


### PR DESCRIPTION
# Motivation  

To generate custom Markdown for a consent message #360, we need the tokens' decimals and symbols. That's why we fetch this information through the ledger canister and add support for the `metadata` call to the `signer.api`.  

# Notes  

- The call will always be executed using an **update** call.  
- The `signer.api` is named as a layer rather than as a canister. From an architectural perspective, this is why we can add the call there.  
- In this library, we generally cache agents and actors for optimal performance. In this particular implementation, however, I skipped the overhead and added a TODO for it.  

# Changes

- Add function that create an ICRC ledger from `@dfinity/ledger-icrc` and exposes `metadata`