### PR TITLE
chore: add TODO for support i18n

### DIFF
--- a/src/builders/signer.builders.ts
+++ b/src/builders/signer.builders.ts
@@ -46,6 +46,7 @@ export const buildContentMessageIcrc1Transfer: SignerBuilderFn = async ({
       bytes: arg
     });
 
+    // TODO: support i18n
     // eslint-disable-next-line import/no-relative-parent-imports
     const {default: en} = await import('../i18n/en.json');
 

--- a/src/services/signer.service.ts
+++ b/src/services/signer.service.ts
@@ -176,6 +176,7 @@ export class SignerService {
         // TODO: consumer should be able to define user_preferences
         user_preferences: {
           metadata: {
+            // TODO: support i18n
             language: 'en',
             utc_offset_minutes: []
           },


### PR DESCRIPTION
# Motivation

Follow-up of [review](https://github.com/dfinity/oisy-wallet-signer/pull/371#discussion_r1895823009). We add `TODO` for the future, to extend the lib to support i18n.
