### PR TITLE
feat: format amount with min one decimal

### DIFF
--- a/src/utils/format.utils.spec.ts
+++ b/src/utils/format.utils.spec.ts
@@ -3,14 +3,14 @@ import {formatAmount} from './format.utils';
 describe('formatAmount', () => {
   it('formats amounts with the specified decimals', () => {
     expect(formatAmount({amount: 123456n, decimals: 2})).toBe('1,234.56');
-    expect(formatAmount({amount: 1000000n, decimals: 6})).toBe('1.00');
+    expect(formatAmount({amount: 1000000n, decimals: 6})).toBe('1.0');
     expect(formatAmount({amount: 123456n, decimals: 1})).toBe('12,345.6');
     expect(formatAmount({amount: 123456n, decimals: 0})).toBe('123,456');
   });
 
   it('formats zero amount with decimals', () => {
-    expect(formatAmount({amount: 0n, decimals: 2})).toBe('0.00');
-    expect(formatAmount({amount: 0n, decimals: 6})).toBe('0.00');
+    expect(formatAmount({amount: 0n, decimals: 2})).toBe('0.0');
+    expect(formatAmount({amount: 0n, decimals: 6})).toBe('0.0');
   });
 
   it('handles large amounts properly', () => {
@@ -21,14 +21,14 @@ describe('formatAmount', () => {
     expect(formatAmount({amount: 1n, decimals: 8})).toBe('0.00000001');
     expect(formatAmount({amount: 10n, decimals: 8})).toBe('0.0000001');
     expect(formatAmount({amount: 100n, decimals: 8})).toBe('0.000001');
-    expect(formatAmount({amount: 100_000_000n, decimals: 8})).toBe('1.00');
-    expect(formatAmount({amount: 1_000_000_000n, decimals: 8})).toBe('10.00');
-    expect(formatAmount({amount: 1_010_000_000n, decimals: 8})).toBe('10.10');
+    expect(formatAmount({amount: 100_000_000n, decimals: 8})).toBe('1.0');
+    expect(formatAmount({amount: 1_000_000_000n, decimals: 8})).toBe('10.0');
+    expect(formatAmount({amount: 1_010_000_000n, decimals: 8})).toBe('10.1');
     expect(formatAmount({amount: 1_012_300_000n, decimals: 8})).toBe('10.123');
-    expect(formatAmount({amount: 20_000_000_000n, decimals: 8})).toBe('200.00');
+    expect(formatAmount({amount: 20_000_000_000n, decimals: 8})).toBe('200.0');
     expect(formatAmount({amount: 20_000_000_001n, decimals: 8})).toBe('200.00000001');
-    expect(formatAmount({amount: 200_000_000_000n, decimals: 8})).toBe(`2,000.00`);
-    expect(formatAmount({amount: 200_000_000_000_000n, decimals: 8})).toBe(`2,000,000.00`);
+    expect(formatAmount({amount: 200_000_000_000n, decimals: 8})).toBe(`2,000.0`);
+    expect(formatAmount({amount: 200_000_000_000_000n, decimals: 8})).toBe(`2,000,000.0`);
   });
 
   it('throws an error for invalid decimals', () => {

--- a/src/utils/format.utils.ts
+++ b/src/utils/format.utils.ts
@@ -2,7 +2,7 @@ export const formatAmount = ({amount, decimals}: {amount: bigint; decimals: numb
   const converted = Number(amount) / 10 ** decimals;
 
   // For ease of readability we want to display two decimals at least but, handle edge case where ledgers have none or 1 decimal set.
-  const minimumFractionDigits = decimals >= 2 ? 2 : decimals;
+  const minimumFractionDigits = decimals >= 1 ? 1 : decimals;
 
   return new Intl.NumberFormat('en-US', {
     minimumFractionDigits,


### PR DESCRIPTION
# Motivation

While developing an E2E tests I noticed that actually the ICP ledger enforce one minimal decimal. Therefore I think it makes sense to align the formatter to their implementation.

# Source

See `convert_tokens_to_string_representation` in https://github.com/dfinity/ic/blob/master/packages/icrc-ledger-types/src/icrc21/lib.rs#L577

# Changes

- Set min decimals to one
