### PR TITLE
e2e: skipped test for build consent message

### DIFF
--- a/e2e/build-consent-message.spec.ts
+++ b/e2e/build-consent-message.spec.ts
@@ -1,0 +1,15 @@
+import {testWithII} from '@dfinity/internet-identity-playwright';
+import {initTestSuite} from './utils/init.utils';
+
+const getPartyPage = initTestSuite();
+
+testWithII.skip(
+  'should requests permissions and present consent message build by the library',
+  async () => {
+    const partyPage = getPartyPage();
+
+    await partyPage.approvePermissionsAccounts();
+
+    await partyPage.approvePermissionsBuildConsentMessage();
+  }
+);

--- a/e2e/mocks/consent-message.mocks.ts
+++ b/e2e/mocks/consent-message.mocks.ts
@@ -1,13 +1,15 @@
 export const mockConsentMessage = ({
   walletUserId,
-  partyUserId
+  partyUserId,
+  tokenSymbol
 }: {
   walletUserId: string;
   partyUserId: string;
+  tokenSymbol: 'ICP' | 'TKN';
 }): string => `# Approve the transfer of funds
 
 **Amount:**
-0.5 ICP
+0.5 ${tokenSymbol}
 
 **From:**
 ${walletUserId}
@@ -16,4 +18,4 @@ ${walletUserId}
 ${partyUserId}
 
 **Fee:**
-0.0001 ICP`;
+0.0001 ${tokenSymbol}`;

--- a/e2e/page-objects/party.page.ts
+++ b/e2e/page-objects/party.page.ts
@@ -164,7 +164,21 @@ export class PartyPage extends IdentityPage {
 
     await this.#walletPage?.assertConsentMessageLoading();
 
-    await this.#walletPage?.assertConsentMessage(partyUserId);
+    await this.#walletPage?.assertConsentMessage({partyUserId, tokenSymbol: 'ICP'});
+  }
+
+  async approvePermissionsBuildConsentMessage(): Promise<void> {
+    const partyUserId = await this.getUserId();
+
+    await expect(this.page.getByTestId('build-consent-message-button')).toBeVisible();
+
+    await this.page.getByTestId('build-consent-message-button').click();
+
+    await this.#walletPage?.approveCallCanisterPermission();
+
+    await this.#walletPage?.assertConsentMessageLoading();
+
+    await this.#walletPage?.assertConsentMessage({partyUserId, tokenSymbol: 'TKN'});
   }
 
   async callCanister(): Promise<void> {

--- a/e2e/page-objects/wallet.page.ts
+++ b/e2e/page-objects/wallet.page.ts
@@ -61,7 +61,10 @@ export class WalletPage extends IdentityPage {
     await expect(this.page.getByTestId('loading-consent-message')).toBeVisible();
   }
 
-  async assertConsentMessage(partyUserId: string): Promise<void> {
+  async assertConsentMessage(params: {
+    partyUserId: string;
+    tokenSymbol: 'ICP' | 'TKN';
+  }): Promise<void> {
     const walletUserId = await this.getUserId();
 
     await expect(this.page.getByTestId('consent-message')).toBeVisible();
@@ -70,8 +73,8 @@ export class WalletPage extends IdentityPage {
 
     await expect(p).toContainText(
       mockConsentMessage({
-        partyUserId,
-        walletUserId
+        walletUserId,
+        ...params
       })
     );
   }


### PR DESCRIPTION
# Motivation

I don't really want to automate the test of the "Build consent message" in the CI because it would requires building the canister of #382 in the pipeline which would require some tooling and time but, it's still handy to have a test to run locally. That's why this PR add such an E2E test.

# Changes

- New E2E test to assert the consent message that is generated from the library.
