### PR TITLE
refactor: extract common reusable code for builders

### DIFF
--- a/src/builders/signer.builders.ts
+++ b/src/builders/signer.builders.ts
@@ -3,11 +3,11 @@ import {
   arrayOfNumberToUint8Array,
   fromNullable,
   isNullish,
-  nonNullish,
   uint8ArrayToHexString
 } from '@dfinity/utils';
 import {TransferArgs} from '../constants/icrc.idl.constants';
 import type {icrc21_consent_info} from '../declarations/icrc-21';
+import type {I18n} from '../types/i18n';
 import type {SignerBuilderFn, SignerBuildersResult} from '../types/signer-builders';
 import {formatAmount} from '../utils/format.utils';
 import {decodeIdl} from '../utils/idl.utils';
@@ -34,7 +34,7 @@ export const buildContentMessageIcrc1Transfer: SignerBuilderFn = async ({
   owner,
   token: {symbol: tokenSymbol, decimals: tokenDecimals, fee: tokenFee}
 }): Promise<SignerBuildersResult> => {
-  try {
+  const build = (en: I18n): {message: string[]} => {
     const {
       amount,
       from_subaccount: fromSubaccount,
@@ -46,19 +46,13 @@ export const buildContentMessageIcrc1Transfer: SignerBuilderFn = async ({
       bytes: arg
     });
 
-    // TODO: support i18n
-    // eslint-disable-next-line import/no-relative-parent-imports
-    const {default: en} = await import('../i18n/en.json');
-
     const {
-      core: {amount: amountLabel, from, to, fee: feeLabel, memo: memoLabel},
+      core: {amount: amountLabel, from, to, fee: feeLabel},
       icrc1_transfer: {title, from_subaccount: fromSubaccountLabel}
     } = en;
 
     // Title
     const message = [`# ${title}`];
-
-    const section = (text: string): string => `**${text}:**`;
 
     // - Amount
     message.push(
@@ -88,12 +82,44 @@ export const buildContentMessageIcrc1Transfer: SignerBuilderFn = async ({
     );
 
     // - Memo
-    const nullishMemo = fromNullable(memo);
-    if (nonNullish(nullishMemo)) {
-      message.push(
-        `${section(memoLabel)}\n0x${uint8ArrayToHexString(nullishMemo instanceof Uint8Array ? nullishMemo : arrayOfNumberToUint8Array(nullishMemo))}`
-      );
-    }
+    const memoMessage = buildMemo({
+      memo,
+      en
+    });
+
+    return {message: [...message, ...memoMessage]};
+  };
+
+  return await buildContentMessage(build);
+};
+
+const section = (text: string): string => `**${text}:**`;
+
+const buildMemo = ({memo, en}: {memo: [] | [Uint8Array | number[]]; en: I18n}): [] | [string] => {
+  const nullishMemo = fromNullable(memo);
+
+  if (isNullish(nullishMemo)) {
+    return [];
+  }
+
+  const {
+    core: {memo: memoLabel}
+  } = en;
+
+  return [
+    `${section(memoLabel)}\n0x${uint8ArrayToHexString(nullishMemo instanceof Uint8Array ? nullishMemo : arrayOfNumberToUint8Array(nullishMemo))}`
+  ];
+};
+
+const buildContentMessage = async (
+  fn: (en: I18n) => {message: string[]}
+): Promise<SignerBuildersResult> => {
+  try {
+    // TODO: support i18n
+    // eslint-disable-next-line import/no-relative-parent-imports
+    const {default: en} = await import('../i18n/en.json');
+
+    const {message} = fn(en);
 
     const consentMessage: icrc21_consent_info = {
       metadata: {


### PR DESCRIPTION
# Motivation

In #383, to implement ICRC2 approve builder, we will have to reuse few common patterns and code of the current ICRC1 transfer builder implementation. This PR refactor the code to make few functions reusable.