### PR TITLE
refactor: rename icrc2 mock

### DIFF
--- a/src/icp-wallet.spec.ts
+++ b/src/icp-wallet.spec.ts
@@ -16,9 +16,9 @@ import {
   mockIcrc2ApproveLocalCallParams,
   mockIcrc2ApproveLocalCallResult,
   mockIcrc2ApproveLocalCallTime,
-  mockIcrc2ApproveLocalIcRootKey,
-  mockIcrc2ApproveLocalRelyingPartyPrincipal
-} from './mocks/icrc2-approve-call-utils.mocks';
+  mockIcrc2LocalIcRootKey,
+  mockIcrc2LocalRelyingPartyPrincipal
+} from './mocks/icrc2-call-utils.mocks';
 import {RelyingPartyOptions} from './types/relying-party-options';
 import {JSON_RPC_VERSION_2} from './types/rpc';
 import * as callUtils from './utils/call.utils';
@@ -224,7 +224,7 @@ describe('icp-wallet', () => {
   describe('icrc2Approve', () => {
     const request: Icrc2ApproveRequest = {
       spender: {
-        owner: mockIcrc2ApproveLocalRelyingPartyPrincipal,
+        owner: mockIcrc2LocalRelyingPartyPrincipal,
         subaccount: toNullable()
       },
       amount: 50000000n,
@@ -236,7 +236,7 @@ describe('icp-wallet', () => {
     beforeEach(() => {
       vi.setSystemTime(mockIcrc2ApproveLocalCallTime);
 
-      mocks.getRootKey.mockReturnValue(mockIcrc2ApproveLocalIcRootKey);
+      mocks.getRootKey.mockReturnValue(mockIcrc2LocalIcRootKey);
     });
 
     it('should call `call` with the correct parameters when icrc1Approve is invoked', async () => {

--- a/src/icrc-wallet.spec.ts
+++ b/src/icrc-wallet.spec.ts
@@ -15,9 +15,9 @@ import {
   mockIcrc2ApproveLocalCallParams,
   mockIcrc2ApproveLocalCallResult,
   mockIcrc2ApproveLocalCallTime,
-  mockIcrc2ApproveLocalIcRootKey,
-  mockIcrc2ApproveLocalRelyingPartyPrincipal
-} from './mocks/icrc2-approve-call-utils.mocks';
+  mockIcrc2LocalIcRootKey,
+  mockIcrc2LocalRelyingPartyPrincipal
+} from './mocks/icrc2-call-utils.mocks';
 import {RelyingPartyOptions} from './types/relying-party-options';
 import {JSON_RPC_VERSION_2} from './types/rpc';
 import * as callUtils from './utils/call.utils';
@@ -216,7 +216,7 @@ describe('icrc-wallet', () => {
   describe('approve', () => {
     const params: ApproveParams = {
       spender: {
-        owner: mockIcrc2ApproveLocalRelyingPartyPrincipal,
+        owner: mockIcrc2LocalRelyingPartyPrincipal,
         subaccount: toNullable()
       },
       amount: 50000000n,
@@ -228,7 +228,7 @@ describe('icrc-wallet', () => {
     beforeEach(() => {
       vi.setSystemTime(mockIcrc2ApproveLocalCallTime);
 
-      mocks.getRootKey.mockReturnValue(mockIcrc2ApproveLocalIcRootKey);
+      mocks.getRootKey.mockReturnValue(mockIcrc2LocalIcRootKey);
     });
 
     it('should call `call` with the correct parameters when approve is invoked', async () => {

--- a/src/mocks/icrc2-call-utils.mocks.ts
+++ b/src/mocks/icrc2-call-utils.mocks.ts
@@ -2,7 +2,7 @@ import {Principal} from '@dfinity/principal';
 import {IcrcCallCanisterResult} from '../types/icrc-responses';
 import {mockLedgerCanisterId} from './icrc-call-utils.mocks';
 
-export const mockIcrc2ApproveLocalIcRootKey = new Uint8Array([
+export const mockIcrc2LocalIcRootKey = new Uint8Array([
   48, 129, 130, 48, 29, 6, 13, 43, 6, 1, 4, 1, 130, 220, 124, 5, 3, 1, 2, 1, 6, 12, 43, 6, 1, 4, 1,
   130, 220, 124, 5, 3, 2, 1, 3, 97, 0, 129, 6, 102, 63, 3, 53, 55, 129, 51, 203, 97, 190, 30, 2, 63,
   141, 246, 99, 241, 69, 17, 4, 47, 59, 149, 227, 251, 110, 34, 153, 69, 131, 245, 236, 6, 182, 218,
@@ -11,7 +11,7 @@ export const mockIcrc2ApproveLocalIcRootKey = new Uint8Array([
   34, 211, 123, 123, 177, 221, 227, 169, 81, 74, 250, 113, 141, 109, 138, 176
 ]);
 
-export const mockIcrc2ApproveLocalRelyingPartyPrincipal = Principal.fromText(
+export const mockIcrc2LocalRelyingPartyPrincipal = Principal.fromText(
   '6ngla-7dqvy-l73ju-54jt5-a4gvm-itu47-4dpih-e2h55-vtbzn-24yem-sae'
 );
 


### PR DESCRIPTION
# Motivation

We will reuse few of the mocks of ICRC2 approve for ICRC2 transfer from therefore it makes sense to rename variable and modules.
