### PR TITLE
test: E2E approve fee

### DIFF
--- a/demo/src/relying_party_frontend/src/lib/components/BuildConsentMessage.svelte
+++ b/demo/src/relying_party_frontend/src/lib/components/BuildConsentMessage.svelte
@@ -61,7 +61,8 @@
 				owner: $authStore.identity.getPrincipal(),
 				subaccount: []
 			},
-			amount: 1n * (E8S_PER_ICP / 2n)
+			amount: 1n * (E8S_PER_ICP / 2n),
+			fee: 12_000n
 		};
 
 		await wallet?.approve({

--- a/demo/src/relying_party_frontend/src/lib/components/Icrc2Approve.svelte
+++ b/demo/src/relying_party_frontend/src/lib/components/Icrc2Approve.svelte
@@ -32,7 +32,8 @@
 				owner: $authStore.identity.getPrincipal(),
 				subaccount: []
 			},
-			amount: 1n * (E8S_PER_ICP / 2n)
+			amount: 1n * (E8S_PER_ICP / 2n),
+			fee: 12_000n
 		};
 
 		result = await wallet?.approve({

--- a/e2e/mocks/consent-message.mocks.ts
+++ b/e2e/mocks/consent-message.mocks.ts
@@ -45,7 +45,7 @@ ${walletUserId}
 No expiration.
 
 **Approval fee:**
-0.0001 ${tokenSymbol}
- 
+0.00012 ${tokenSymbol}
+
 **Transaction fees to be paid by:**
 ${walletUserId}`;


### PR DESCRIPTION
# Motivation

When I ran the builder test locally it failed because the fee in the approve message was not displayed. To ensure we have a fee in all scenario, I set a value in the call and in the mock data.
