### PR TITLE
fix: use token fee in approve builder

### DIFF
--- a/src/builders/signer.builders.spec.ts
+++ b/src/builders/signer.builders.spec.ts
@@ -459,6 +459,47 @@ ${encodeIcrcAccount({owner: owner.getPrincipal()})}
       expect((err as Error).message).toContain('Wrong magic number');
     });
 
+    it('should build a consent message with token fee if no fee as arg', async () => {
+      const arg = encodeIdl({
+        recordClass: ApproveArgs,
+        rawArgs: {
+          ...mockIcrcApproveRawArgs,
+          fee: []
+        }
+      });
+
+      const result = await buildContentMessageIcrc2Approve({
+        arg: base64ToUint8Array(arg),
+        owner: owner.getPrincipal(),
+        token
+      });
+
+      expectMessage({
+        result,
+        expectedMessage: `# Authorize another address to withdraw from your account
+
+**The following address is allowed to withdraw from your account:**
+${encodeIcrcAccount({owner: mockIcrcApproveRawArgs.spender.owner, subaccount: fromNullable(mockIcrcApproveRawArgs.spender.subaccount)})}
+
+**Your account:**
+${encodeIcrcAccount({owner: owner.getPrincipal()})}
+
+**Requested withdrawal allowance:**
+3,200.00000001 TKN
+
+⚠ The allowance will be set to 3,200.00000001 TKN independently of any previous allowance. Until this transaction has been executed the spender can still exercise the previous allowance (if any) to it's full amount.
+
+**Expiration date:**
+No expiration.
+
+**Approval fee:**
+0.0001 TKN
+
+**Transaction fees to be paid by:**
+${encodeIcrcAccount({owner: owner.getPrincipal()})}`
+      });
+    });
+
     it('should build a consent message with expected allowance', async () => {
       const expectedAllowance = 1234567n;
 

--- a/src/builders/signer.builders.ts
+++ b/src/builders/signer.builders.ts
@@ -120,7 +120,7 @@ export const buildContentMessageIcrc1Transfer: SignerBuilderFn = async ({
 export const buildContentMessageIcrc2Approve: SignerBuilderFn = async ({
   arg,
   owner,
-  token: {symbol: tokenSymbol, decimals: tokenDecimals}
+  token: {symbol: tokenSymbol, decimals: tokenDecimals, fee: tokenFee}
 }): Promise<SignerBuildersResult> => {
   const build = (en: I18n): {message: string[]} => {
     const {
@@ -145,7 +145,7 @@ export const buildContentMessageIcrc2Approve: SignerBuilderFn = async ({
         requested_withdrawal_allowance,
         withdrawal_allowance: {none: withdrawalAllowanceNone, some: withdrawalAllowanceSome},
         expiration_date: {title: expirationDateTitle, none: noExpirationDate},
-        approval_fee,
+        approval_fee: approvalFeeLabel,
         approver_account_transaction_fees: {
           subaccount: approverFeeSubaccount,
           owner: approverFeeOwner
@@ -199,12 +199,9 @@ export const buildContentMessageIcrc2Approve: SignerBuilderFn = async ({
     );
 
     // - Fee
-    const fee = fromNullable(approveFee);
-    if (nonNullish(fee)) {
-      message.push(
-        `${section(approval_fee)}\n${formatAmount({amount: fee, decimals: tokenDecimals})} ${tokenSymbol}`
-      );
-    }
+    message.push(
+      `${section(approvalFeeLabel)}\n${formatAmount({amount: fromNullable(approveFee) ?? tokenFee, decimals: tokenDecimals})} ${tokenSymbol}`
+    );
 
     // - Fee paid by
     message.push(


### PR DESCRIPTION
# Motivation

Similarly as for ICRC1 transfer, we should use the token default fee as fallback if no fee is provided in the ICRC2 approve because the fee are given by the ledger.
