### PR TITLE
ci: add format check

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,7 +20,7 @@ updates:
     schedule:
       interval: weekly
     ignore:
-      - dependency-name: "@types/*"
+      - dependency-name: '@types/*'
       - dependency-name: '@typescript-eslint/*'
       - dependency-name: 'eslint'
       - dependency-name: 'eslint-*'


### PR DESCRIPTION
# Motivation

We include the format among the `lib_checks`

# Tests

In this same PR, I injected a bad formatting (that didn't pass the CI tests) and then removed (and it passed them).
