### PR TITLE
feat: always display label "Account" in generate consent message

### DIFF
--- a/src/builders/signer.builders.spec.ts
+++ b/src/builders/signer.builders.spec.ts
@@ -133,7 +133,7 @@ s3oqv-3j7id-xjhbm-3owbe-fvwly-oso6u-vej6n-bexck-koyu2-bxb6y-wae
       expect(fromNullable(Ok.metadata.utc_offset_minutes)).toBeUndefined();
     });
 
-    it('should build a consent message with a from subaccount', async () => {
+    it('should build a consent message with a from label even if a subaccount is used', async () => {
       const subaccount = [1, 2, 3];
 
       const arg = encodeIdl({
@@ -157,7 +157,7 @@ s3oqv-3j7id-xjhbm-3owbe-fvwly-oso6u-vej6n-bexck-koyu2-bxb6y-wae
 **Amount:**
 3,200.00000001 TKN
 
-**From subaccount:**
+**From:**
 ${encodeIcrcAccount({owner: owner.getPrincipal(), subaccount: subaccount})}
 
 **To:**
@@ -379,7 +379,7 @@ ${encodeIcrcAccount({owner: owner.getPrincipal()})}`
 **The following address is allowed to withdraw from your account:**
 ${encodeIcrcAccount({owner: mockIcrcApproveRawArgs.spender.owner, subaccount: fromNullable(mockIcrcApproveRawArgs.spender.subaccount)})}
 
-**Your subaccount:**
+**Your account:**
 ${encodeIcrcAccount({owner: owner.getPrincipal(), subaccount: subaccount})}
 
 **Requested withdrawal allowance:**
@@ -393,7 +393,7 @@ No expiration.
 **Approval fee:**
 0.0010033 TKN
 
-**Transaction fees to be paid by your subaccount:**
+**Transaction fees to be paid by:**
 ${encodeIcrcAccount({owner: owner.getPrincipal(), subaccount: subaccount})}`
       });
     });
@@ -669,7 +669,7 @@ ${encodeIcrcAccount({owner: mockIcrcTransferFromRawArgs.to.owner, subaccount: fr
 **Withdrawal account:**
 ${encodeIcrcAccount({owner: mockIcrcTransferFromRawArgs.from.owner, subaccount: fromNullable(mockIcrcTransferFromRawArgs.from.subaccount)})}
 
-**Subaccount sending the transfer request:**
+**Account sending the transfer request:**
 ${encodeIcrcAccount({owner: owner.getPrincipal(), subaccount})}
 
 **Amount to withdraw:**

--- a/src/builders/signer.builders.ts
+++ b/src/builders/signer.builders.ts
@@ -55,7 +55,7 @@ export const buildContentMessageIcrc1Transfer: SignerBuilderFn = async ({
 
     const {
       core: {amount: amountLabel, from, to, fee: feeLabel},
-      icrc1_transfer: {title, from_subaccount: fromSubaccountLabel}
+      icrc1_transfer: {title}
     } = en;
 
     // Title
@@ -72,9 +72,7 @@ export const buildContentMessageIcrc1Transfer: SignerBuilderFn = async ({
       owner,
       subaccount: fromNullishSubaccount
     });
-    message.push(
-      `${section(isNullish(fromNullishSubaccount) ? from : fromSubaccountLabel)}\n${fromAccount}`
-    );
+    message.push(`${section(from)}\n${fromAccount}`);
 
     // - To
     const toAccount = encodeIcrcAccount({
@@ -141,15 +139,11 @@ export const buildContentMessageIcrc2Approve: SignerBuilderFn = async ({
         title,
         address_is_allowed,
         your_account,
-        your_subaccount,
         requested_withdrawal_allowance,
         withdrawal_allowance: {none: withdrawalAllowanceNone, some: withdrawalAllowanceSome},
         expiration_date: {title: expirationDateTitle, none: noExpirationDate},
         approval_fee: approvalFeeLabel,
-        approver_account_transaction_fees: {
-          subaccount: approverFeeSubaccount,
-          owner: approverFeeOwner
-        }
+        approver_account_transaction_fees
       }
     } = en;
 
@@ -169,9 +163,7 @@ export const buildContentMessageIcrc2Approve: SignerBuilderFn = async ({
       owner,
       subaccount: fromNullishSubaccount
     });
-    message.push(
-      `${section(isNullish(fromNullishSubaccount) ? your_account : your_subaccount)}\n${fromAccount}`
-    );
+    message.push(`${section(your_account)}\n${fromAccount}`);
 
     // - Amount
     message.push(
@@ -204,9 +196,7 @@ export const buildContentMessageIcrc2Approve: SignerBuilderFn = async ({
     );
 
     // - Fee paid by
-    message.push(
-      `${section(isNullish(fromNullishSubaccount) ? approverFeeOwner : approverFeeSubaccount)}\n${fromAccount}`
-    );
+    message.push(`${section(approver_account_transaction_fees)}\n${fromAccount}`);
 
     // - Memo
     const memoMessage = buildMemo({
@@ -260,10 +250,7 @@ export const buildContentMessageIcrc2TransferFrom: SignerBuilderFn = async ({
       icrc2_transfer_from: {
         title,
         withdrawal_account,
-        sending_the_transfer_request: {
-          subaccount: subaccountSendingTransferRequest,
-          account: accountSendingTransferRequest
-        },
+        sending_the_transfer_request,
         amount_to_withdraw,
         fee_paid_by_withdrawal_account
       }
@@ -285,9 +272,7 @@ export const buildContentMessageIcrc2TransferFrom: SignerBuilderFn = async ({
       owner,
       subaccount: spenderNullishSubaccount
     });
-    message.push(
-      `${section(isNullish(spenderNullishSubaccount) ? accountSendingTransferRequest : subaccountSendingTransferRequest)}\n${spenderAccount}`
-    );
+    message.push(`${section(sending_the_transfer_request)}\n${spenderAccount}`);
 
     // - Amount
     message.push(

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -7,13 +7,11 @@
     "memo": "Memo"
   },
   "icrc1_transfer": {
-    "title": "Approve the transfer of funds",
-    "from_subaccount": "From subaccount"
+    "title": "Approve the transfer of funds"
   },
   "icrc2_approve": {
     "title": "Authorize another address to withdraw from your account",
     "address_is_allowed": "The following address is allowed to withdraw from your account",
-    "your_subaccount": "Your subaccount",
     "your_account": "Your account",
     "requested_withdrawal_allowance": "Requested withdrawal allowance",
     "withdrawal_allowance": {
@@ -25,18 +23,12 @@
       "none": "No expiration."
     },
     "approval_fee": "Approval fee",
-    "approver_account_transaction_fees": {
-      "subaccount": "Transaction fees to be paid by your subaccount",
-      "owner": "Transaction fees to be paid by"
-    }
+    "approver_account_transaction_fees": "Transaction fees to be paid by"
   },
   "icrc2_transfer_from": {
     "title": "Transfer from a withdrawal account",
     "withdrawal_account": "Withdrawal account",
-    "sending_the_transfer_request": {
-      "subaccount": "Subaccount sending the transfer request",
-      "account": "Account sending the transfer request"
-    },
+    "sending_the_transfer_request": "Account sending the transfer request",
     "amount_to_withdraw": "Amount to withdraw",
     "fee_paid_by_withdrawal_account": "Fee paid by withdrawal account"
   }

--- a/src/types/i18n.ts
+++ b/src/types/i18n.ts
@@ -13,8 +13,7 @@ export const i18nCoreSchema = z
 
 export const i18nIcrc1_transferSchema = z
   .object({
-    title: z.string(),
-    from_subaccount: z.string()
+    title: z.string()
   })
   .strict();
 
@@ -22,13 +21,12 @@ export const i18nIcrc2_approveSchema = z
   .object({
     title: z.string(),
     address_is_allowed: z.string(),
-    your_subaccount: z.string(),
     your_account: z.string(),
     requested_withdrawal_allowance: z.string(),
     withdrawal_allowance: z.object({some: z.string(), none: z.string()}),
     expiration_date: z.object({title: z.string(), none: z.string()}),
     approval_fee: z.string(),
-    approver_account_transaction_fees: z.object({subaccount: z.string(), owner: z.string()})
+    approver_account_transaction_fees: z.string()
   })
   .strict();
 
@@ -36,7 +34,7 @@ export const i18nIcrc2_transfer_fromSchema = z
   .object({
     title: z.string(),
     withdrawal_account: z.string(),
-    sending_the_transfer_request: z.object({subaccount: z.string(), account: z.string()}),
+    sending_the_transfer_request: z.string(),
     amount_to_withdraw: z.string(),
     fee_paid_by_withdrawal_account: z.string()
   })


### PR DESCRIPTION
# Motivation

To avoid confusion, Prodsec suggest to avoid the use of the term "Subaccount" in the generated consent message of the library and always use the term "Account" even if the account contains a subaccount. This because the library does not trim the account but, always prints the textual representation defined by the ICRC standard.

# Changes

- Remove labels "subaccount"
- Adapt builder and related tests
