### PR TITLE
feat: assert arg size when building consent message

### DIFF
--- a/src/builders/signer.builders.ts
+++ b/src/builders/signer.builders.ts
@@ -8,6 +8,7 @@ import {
 } from '@dfinity/utils';
 import {TransferArgs} from '../constants/icrc-1.idl.constants';
 import {ApproveArgs, TransferFromArgs} from '../constants/icrc-2.idl.constants';
+import {MAX_CONSENT_MESSAGE_ARG_SIZE_BYTES} from '../constants/signer.builders.constants';
 import {TransferArgs as IcrcTransferArg} from '../declarations/icrc-1';
 import {
   ApproveArgs as IcrcApproveArgs,
@@ -15,7 +16,7 @@ import {
 } from '../declarations/icrc-2';
 import type {icrc21_consent_info} from '../declarations/icrc-21';
 import {I18n} from '../types/i18n';
-import {SignerBuilderFn, SignerBuildersResult} from '../types/signer-builders';
+import {SignerBuilderFn, SignerBuilderParams, SignerBuildersResult} from '../types/signer-builders';
 import {formatAmount, formatDate} from '../utils/format.utils';
 import {decodeIdl} from '../utils/idl.utils';
 
@@ -95,7 +96,7 @@ export const buildContentMessageIcrc1Transfer: SignerBuilderFn = async ({
     return {message: [...message, ...memoMessage]};
   };
 
-  return await buildContentMessage(build);
+  return await buildContentMessage({arg, fn: build});
 };
 
 /**
@@ -207,7 +208,7 @@ export const buildContentMessageIcrc2Approve: SignerBuilderFn = async ({
     return {message: [...message, ...memoMessage]};
   };
 
-  return await buildContentMessage(build);
+  return await buildContentMessage({arg, fn: build});
 };
 
 /**
@@ -300,7 +301,7 @@ export const buildContentMessageIcrc2TransferFrom: SignerBuilderFn = async ({
     return {message: [...message, ...memoMessage]};
   };
 
-  return await buildContentMessage(build);
+  return await buildContentMessage({arg, fn: build});
 };
 
 const section = (text: string): string => `**${text}:**`;
@@ -321,10 +322,15 @@ const buildMemo = ({memo, en}: {memo: [] | [Uint8Array | number[]]; en: I18n}): 
   ];
 };
 
-const buildContentMessage = async (
-  fn: (en: I18n) => {message: string[]}
-): Promise<SignerBuildersResult> => {
+const buildContentMessage = async ({
+  fn,
+  arg
+}: Pick<SignerBuilderParams, 'arg'> & {
+  fn: (en: I18n) => {message: string[]};
+}): Promise<SignerBuildersResult> => {
   try {
+    assertArgSize({arg});
+
     // TODO: support i18n
     // eslint-disable-next-line import/no-relative-parent-imports
     const {default: en} = await import('../i18n/en.json');
@@ -344,5 +350,26 @@ const buildContentMessage = async (
     return {Ok: consentMessage};
   } catch (err: unknown) {
     return {Err: err};
+  }
+};
+
+export class ArgSizeError extends Error {}
+
+/**
+ * Validates the size of the argument to prevent issues with the Candid parser.
+ *
+ * A similar assertion is implemented in the ICP ledger for building the consent message.
+ *
+ * @see {@link https://github.com/dfinity/ic/blob/master/packages/icrc-ledger-types/src/icrc21/lib.rs#L426}
+ *
+ * @param {object} params - The parameters for the function.
+ * @param {ArrayBuffer} params.arg - The argument to validate, represented as an ArrayBuffer.
+ * @throws {Error} Throws an error if the argument size exceeds the maximum allowed size.
+ */
+const assertArgSize = ({arg}: Pick<SignerBuilderParams, 'arg'>) => {
+  if (arg.byteLength > MAX_CONSENT_MESSAGE_ARG_SIZE_BYTES) {
+    throw new ArgSizeError(
+      `The argument size is too large. The maximum allowed size is ${MAX_CONSENT_MESSAGE_ARG_SIZE_BYTES} bytes.`
+    );
   }
 };

--- a/src/constants/signer.builders.constants.ts
+++ b/src/constants/signer.builders.constants.ts
@@ -5,6 +5,9 @@ import {
 } from '../builders/signer.builders';
 import {SignerBuilderFn, SignerBuilderMethods} from '../types/signer-builders';
 
+// @see {@link https://github.com/dfinity/ic/blob/master/packages/icrc-ledger-types/src/icrc21/lib.rs#L20}
+export const MAX_CONSENT_MESSAGE_ARG_SIZE_BYTES = 500;
+
 export const SIGNER_BUILDERS: Record<SignerBuilderMethods, SignerBuilderFn> = {
   icrc1_transfer: buildContentMessageIcrc1Transfer,
   icrc2_approve: buildContentMessageIcrc2Approve,


### PR DESCRIPTION
# Motivation

ProdSec recommends asserting the size of arguments when building a consent message within the library, similar to how the ICP ledger does this, to prevent the Candid parser from crashing.

See https://github.com/dfinity/ic/blob/master/packages/icrc-ledger-types/src/icrc21/lib.rs#L426

# Changes

- Implement assertion
- Refactor function `buildContentMessage` to pass down arguments for each builder
