### PR TITLE
feat: build memo consent message utf-8

### DIFF
--- a/src/builders/signer.builders.spec.ts
+++ b/src/builders/signer.builders.spec.ts
@@ -240,7 +240,7 @@ ${encodeIcrcAccount({owner: rawArgs.to.owner, subaccount: fromNullable(rawArgs.t
 0.0010033 TKN
 
 **Memo:**
-0x50555054`
+PUPT`
       });
     });
 
@@ -440,7 +440,7 @@ No expiration.
 ${encodeIcrcAccount({owner: owner.getPrincipal()})}
 
 **Memo:**
-0x50555054`
+PUPT`
       });
     });
 
@@ -802,7 +802,7 @@ ${encodeIcrcAccount({owner: mockIcrcTransferFromRawArgs.to.owner, subaccount: fr
 0.0010044 TKN
 
 **Memo:**
-0x50555054`
+PUPT`
       });
     });
 

--- a/src/builders/signer.builders.ts
+++ b/src/builders/signer.builders.ts
@@ -1,11 +1,5 @@
 import {encodeIcrcAccount} from '@dfinity/ledger-icrc';
-import {
-  arrayOfNumberToUint8Array,
-  fromNullable,
-  isNullish,
-  nonNullish,
-  uint8ArrayToHexString
-} from '@dfinity/utils';
+import {fromNullable, isNullish, nonNullish} from '@dfinity/utils';
 import {TransferArgs} from '../constants/icrc-1.idl.constants';
 import {ApproveArgs, TransferFromArgs} from '../constants/icrc-2.idl.constants';
 import {TransferArgs as IcrcTransferArg} from '../declarations/icrc-1';
@@ -16,6 +10,7 @@ import {
 import type {icrc21_consent_info} from '../declarations/icrc-21';
 import {I18n} from '../types/i18n';
 import {SignerBuilderFn, SignerBuildersResult} from '../types/signer-builders';
+import {decodeMemo} from '../utils/builders.utils';
 import {formatAmount, formatDate} from '../utils/format.utils';
 import {decodeIdl} from '../utils/idl.utils';
 
@@ -316,9 +311,7 @@ const buildMemo = ({memo, en}: {memo: [] | [Uint8Array | number[]]; en: I18n}): 
     core: {memo: memoLabel}
   } = en;
 
-  return [
-    `${section(memoLabel)}\n0x${uint8ArrayToHexString(nullishMemo instanceof Uint8Array ? nullishMemo : arrayOfNumberToUint8Array(nullishMemo))}`
-  ];
+  return [`${section(memoLabel)}\n${decodeMemo(nullishMemo)}`];
 };
 
 const buildContentMessage = async (

--- a/src/utils/builders.utils.spec.ts
+++ b/src/utils/builders.utils.spec.ts
@@ -2,30 +2,32 @@ import {asciiStringToByteArray} from '@dfinity/utils';
 import {decodeMemo} from './builders.utils';
 
 describe('builders.utils', () => {
-  const memoText = 'PUPT'; // Reverse top-up memo
+  describe('decodeMemo', () => {
+    const memoText = 'PUPT'; // Reverse top-up memo
 
-  const memo = asciiStringToByteArray(memoText);
+    const memo = asciiStringToByteArray(memoText);
 
-  it('should return memo utf-8', () => {
-    const result = decodeMemo(memo);
+    it('should return memo utf-8', () => {
+      const result = decodeMemo(memo);
 
-    expect(result).toEqual(memoText);
-  });
+      expect(result).toEqual(memoText);
+    });
 
-  it('should return memo hex', () => {
-    vi.stubGlobal(
-      'TextDecoder',
-      class {
-        decode(_buffer: ArrayBuffer): string {
-          throw new Error();
+    it('should return memo hex', () => {
+      vi.stubGlobal(
+        'TextDecoder',
+        class {
+          decode(_buffer: ArrayBuffer): string {
+            throw new Error();
+          }
         }
-      }
-    );
+      );
 
-    const result = decodeMemo(memo);
+      const result = decodeMemo(memo);
 
-    expect(result).toEqual('0x50555054');
+      expect(result).toEqual('0x50555054');
 
-    vi.unstubAllGlobals();
+      vi.unstubAllGlobals();
+    });
   });
 });

--- a/src/utils/builders.utils.spec.ts
+++ b/src/utils/builders.utils.spec.ts
@@ -1,0 +1,31 @@
+import {asciiStringToByteArray} from '@dfinity/utils';
+import {decodeMemo} from './builders.utils';
+
+describe('builders.utils', () => {
+  const memoText = 'PUPT'; // Reverse top-up memo
+
+  const memo = asciiStringToByteArray(memoText);
+
+  it('should return memo utf-8', () => {
+    const result = decodeMemo(memo);
+
+    expect(result).toEqual(memoText);
+  });
+
+  it('should return memo hex', () => {
+    vi.stubGlobal(
+      'TextDecoder',
+      class {
+        decode(_buffer: ArrayBuffer): string {
+          throw new Error();
+        }
+      }
+    );
+
+    const result = decodeMemo(memo);
+
+    expect(result).toEqual('0x50555054');
+
+    vi.unstubAllGlobals();
+  });
+});

--- a/src/utils/builders.utils.ts
+++ b/src/utils/builders.utils.ts
@@ -1,0 +1,21 @@
+import {arrayOfNumberToUint8Array, uint8ArrayToHexString} from '@dfinity/utils';
+
+/**
+ * Decodes a memo into an utf-8 string. If decoding fails, fallback to hex.
+ *
+ * This is similar to how the decoder for consent messages of the ICP ledger handles the memo.
+ *
+ * @see {@link https://github.com/dfinity/ic/blob/master/packages/icrc-ledger-types/src/icrc21/lib.rs#L348}
+ *
+ * @param {Uint8Array | number[]} memo - The memo to decode. It can be either a `Uint8Array` or an array of numbers.
+ * @returns {string} The decoded string if successful, or the hexadecimal string representation if decoding fails.
+ */
+export const decodeMemo = (memo: Uint8Array | number[]): string => {
+  const memoArray = memo instanceof Uint8Array ? memo : arrayOfNumberToUint8Array(memo);
+
+  try {
+    return new TextDecoder('utf-8').decode(memoArray);
+  } catch (_err: unknown) {
+    return `0x${uint8ArrayToHexString(memo)}`;
+  }
+};


### PR DESCRIPTION
# Motivation

Prodsec suggests displaying the decoded memo in the consent message built by the library as UTF-8 instead of hex, similar to what is done by the ICP ledger.

See: https://github.com/dfinity/ic/blob/master/packages/icrc-ledger-types/src/icrc21/lib.rs#L348

# Changes

- Use `TextDecoder` to decode memo
- Create utils to decode the memo mostly for test purpose as it simplifies mocking `TextDecoder` without impacting other functions
