### PR TITLE
build: ignore src/tsconfig file

### DIFF
--- a/esbuild.mjs
+++ b/esbuild.mjs
@@ -50,6 +50,7 @@ const bundleFiles = () => {
         !file.includes('test') &&
         !file.includes('spec') &&
         !file.includes('mock') &&
+        !file.includes('tsconfig') &&
         statSync(join(process.cwd(), 'src', file)).isFile()
     )
     .map((file) => `src/${file}`);


### PR DESCRIPTION
# Motivation

We have a tsconfig file in src folder for test purpose because our editors don't find the reference to the main tsconfig for test. This file should not be compiled to js and be included in the bundle.
