### PR TITLE
feat: use local replica url constant in demo

### DIFF
--- a/demo/src/core/stores/auth.store.ts
+++ b/demo/src/core/stores/auth.store.ts
@@ -1,7 +1,8 @@
 import {
 	AUTH_MAX_TIME_TO_LIVE,
 	AUTH_POPUP_HEIGHT,
-	AUTH_POPUP_WIDTH
+	AUTH_POPUP_WIDTH,
+	LOCAL_REPLICA_URL
 } from '$core/constants/app.constants';
 import type { OptionIdentity } from '$core/types/identity';
 import { createAuthClient } from '$core/utils/auth.utils';
@@ -56,11 +57,13 @@ const initAuthStore = (): AuthStore => {
 				const container = import.meta.env.VITE_CONTAINER;
 				const iiId = import.meta.env.VITE_INTERNET_IDENTITY_ID;
 
+				const localHost = URL.parse(LOCAL_REPLICA_URL);
+
 				const identityProvider =
 					nonNullish(container) && nonNullish(iiId)
 						? /apple/i.test(navigator?.vendor)
-							? `http://localhost:4943?canisterId=${iiId}`
-							: `http://${iiId}.localhost:4943`
+							? `${LOCAL_REPLICA_URL}?canisterId=${iiId}`
+							: `http://${iiId}.${localHost?.host ?? 'localhost:4943'}`
 						: `https://identity.${domain ?? 'ic0.app'}`;
 
 				await authClient?.login({

--- a/demo/src/wallet_frontend/src/routes/sign/+page.svelte
+++ b/demo/src/wallet_frontend/src/routes/sign/+page.svelte
@@ -10,6 +10,7 @@
 	import ConsentMessage from '$lib/ConsentMessage.svelte';
 	import GetICP from '$lib/GetICP.svelte';
 	import CallCanister from '$lib/CallCanister.svelte';
+	import { LOCAL_REPLICA_URL } from '$core/constants/app.constants';
 
 	let signer = $state<Signer | undefined>(undefined);
 
@@ -26,7 +27,7 @@
 
 		signer = Signer.init({
 			owner: $authStore.identity,
-			host: 'http://localhost:4943'
+			host: LOCAL_REPLICA_URL
 		});
 
 		return () => {


### PR DESCRIPTION
# Motivation

Spotted few references that duplicated the constant. It's more practical to always use the same reference to be able to easily switch port (which is my use case as I'm currently using the wallet each Monday in Juno live).
