### PR TITLE
build: normalize @dfinity peer dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,13 +26,13 @@
         "node": ">=22"
       },
       "peerDependencies": {
-        "@dfinity/agent": "^2.1.3",
-        "@dfinity/candid": "^2.1.3",
-        "@dfinity/ledger-icp": "^2.6.8",
-        "@dfinity/ledger-icrc": "^2.7.3",
-        "@dfinity/principal": "^2.1.3",
-        "@dfinity/utils": "^2.10.0",
-        "@dfinity/zod-schemas": "^0.0.2",
+        "@dfinity/agent": "^2",
+        "@dfinity/candid": "^2",
+        "@dfinity/ledger-icp": "^2",
+        "@dfinity/ledger-icrc": "^2",
+        "@dfinity/principal": "^2",
+        "@dfinity/utils": "^2",
+        "@dfinity/zod-schemas": "*",
         "borc": "^2.1.1",
         "simple-cbor": "^0.4.1",
         "zod": "^3.23.8"

--- a/package.json
+++ b/package.json
@@ -92,13 +92,13 @@
     "node": ">=22"
   },
   "peerDependencies": {
-    "@dfinity/agent": "^2.1.3",
-    "@dfinity/candid": "^2.1.3",
-    "@dfinity/ledger-icp": "^2.6.8",
-    "@dfinity/ledger-icrc": "^2.7.3",
-    "@dfinity/principal": "^2.1.3",
-    "@dfinity/utils": "^2.10.0",
-    "@dfinity/zod-schemas": "^0.0.2",
+    "@dfinity/agent": "^2",
+    "@dfinity/candid": "^2",
+    "@dfinity/ledger-icp": "^2",
+    "@dfinity/ledger-icrc": "^2",
+    "@dfinity/principal": "^2",
+    "@dfinity/utils": "^2",
+    "@dfinity/zod-schemas": "*",
     "borc": "^2.1.1",
     "simple-cbor": "^0.4.1",
     "zod": "^3.23.8"


### PR DESCRIPTION
# Motivation

In OISY often times we use the `next` version of `ic-js` packages. To avoid conflicts we normalize the versions to the major one.
