### PR TITLE
build: make peer dependencies up-to-next when releasing next

### DIFF
--- a/scripts/update-version.mjs
+++ b/scripts/update-version.mjs
@@ -39,9 +39,8 @@ const updateVersion = async () => {
 
   // Peer dependencies need to point to wip references but only the @dfinity ones - e.g. @dfinity/utils@0.0.1-next
   const peerDependencies = Object.entries(packageJson.peerDependencies ?? {})
-    .filter(([key]) => key.startsWith('@dfinity'))
-    .reduce((acc, [key, _value]) => {
-      acc[key] = `*`;
+    .reduce((acc, [key, value]) => {
+      acc[key] = key.startsWith('@dfinity') ? '*' : value;
       return acc;
     }, {});
 

--- a/scripts/update-version.mjs
+++ b/scripts/update-version.mjs
@@ -38,11 +38,13 @@ const updateVersion = async () => {
   });
 
   // Peer dependencies need to point to wip references but only the @dfinity ones - e.g. @dfinity/utils@0.0.1-next
-  const peerDependencies = Object.entries(packageJson.peerDependencies ?? {})
-    .reduce((acc, [key, value]) => {
+  const peerDependencies = Object.entries(packageJson.peerDependencies ?? {}).reduce(
+    (acc, [key, value]) => {
       acc[key] = key.startsWith('@dfinity') ? '*' : value;
       return acc;
-    }, {});
+    },
+    {}
+  );
 
   writeFileSync(
     packagePath,
@@ -50,7 +52,7 @@ const updateVersion = async () => {
       {
         ...packageJson,
         version,
-        ...(Object.keys(peerDependencies).length > 0 && { peerDependencies }),
+        ...(Object.keys(peerDependencies).length > 0 && {peerDependencies})
       },
       null,
       2

--- a/scripts/update-version.mjs
+++ b/scripts/update-version.mjs
@@ -37,12 +37,21 @@ const updateVersion = async () => {
     currentVersion: packageJson.version
   });
 
+  // Peer dependencies need to point to wip references but only the @dfinity ones - e.g. @dfinity/utils@0.0.1-next
+  const peerDependencies = Object.entries(packageJson.peerDependencies ?? {})
+    .filter(([key]) => key.startsWith('@dfinity'))
+    .reduce((acc, [key, _value]) => {
+      acc[key] = `*`;
+      return acc;
+    }, {});
+
   writeFileSync(
     packagePath,
     JSON.stringify(
       {
         ...packageJson,
-        version
+        version,
+        ...(Object.keys(peerDependencies).length > 0 && { peerDependencies }),
       },
       null,
       2


### PR DESCRIPTION
# Motivation

Similar to `ic-js` , we want to release the next version with no specific peer dependencies versions.
