### PR TITLE
feat: Agent-js v2.3.0 breaking change

### DIFF
--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -12,12 +12,12 @@
 				"src/wallet_frontend"
 			],
 			"dependencies": {
-				"@dfinity/agent": "^2.1.3",
-				"@dfinity/auth-client": "^2.1.3",
-				"@dfinity/candid": "^2.1.3",
+				"@dfinity/agent": "^2.3.0",
+				"@dfinity/auth-client": "^2.3.0",
+				"@dfinity/candid": "^2.3.0",
 				"@dfinity/ledger-icp": "^2.6.8",
 				"@dfinity/ledger-icrc": "^2.7.3",
-				"@dfinity/principal": "^2.1.3",
+				"@dfinity/principal": "^2.3.0",
 				"@dfinity/utils": "^2.10.0",
 				"buffer": "^6.0.3",
 				"zod": "^3.24.1"
@@ -662,9 +662,9 @@
 			}
 		},
 		"node_modules/@dfinity/agent": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-2.1.3.tgz",
-			"integrity": "sha512-4XmqhFR3GQSUrmx7lMFx7DyHEhFkM6nz4O9FeYJ/WpkmPe8tulKaAfgWbWdTSCjbd8meCgKVHo+QYj+JHXagcw==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-2.3.0.tgz",
+			"integrity": "sha512-f/eNydwuOunTKRcZAW1RxrcmKyb1AFqZM/ysJJaqFCX9Y+men9NoBTeuUI23XKUp9YeDb9yinGyAlYqjb6VMPw==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@noble/curves": "^1.4.0",
@@ -675,37 +675,37 @@
 				"simple-cbor": "^0.4.1"
 			},
 			"peerDependencies": {
-				"@dfinity/candid": "^2.1.3",
-				"@dfinity/principal": "^2.1.3"
+				"@dfinity/candid": "^2.3.0",
+				"@dfinity/principal": "^2.3.0"
 			}
 		},
 		"node_modules/@dfinity/auth-client": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/@dfinity/auth-client/-/auth-client-2.1.3.tgz",
-			"integrity": "sha512-6lxv7w8FWSnu5FxMa75O1lddUQJWDDMgJCG1DeYM4+08dWy0TxV/CeEo2uInAdqwlZECgQYB3yQEZKUNkbA6OQ==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@dfinity/auth-client/-/auth-client-2.3.0.tgz",
+			"integrity": "sha512-UbV90FtVxHs6pMODomnb8xAS9k5qCj8tWbiZRS+oS9+ry39Cfcu8qCURFWOdFlrV7YzNeSk7xYqSlCAJi8luFQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"idb": "^7.0.2"
 			},
 			"peerDependencies": {
-				"@dfinity/agent": "^2.1.3",
-				"@dfinity/identity": "^2.1.3",
-				"@dfinity/principal": "^2.1.3"
+				"@dfinity/agent": "^2.3.0",
+				"@dfinity/identity": "^2.3.0",
+				"@dfinity/principal": "^2.3.0"
 			}
 		},
 		"node_modules/@dfinity/candid": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-2.1.3.tgz",
-			"integrity": "sha512-Asn7AfydLhhk7E5z9oW+5UL6ne11gxFlYTxHuhrIc7FdqYlM5Flcq1Wfg9EzRa6Btdol3w58Bcph7Brwh1bcIQ==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-2.3.0.tgz",
+			"integrity": "sha512-Xzj3EWfwaVZy90jq6WBRP4Cyqo93r3g8tvBea8W8PN3I4W6KcN2/9ZJaBhT3Y4NP+p2w4ZO6aJ+qp9xH990aYw==",
 			"license": "Apache-2.0",
 			"peerDependencies": {
-				"@dfinity/principal": "^2.1.3"
+				"@dfinity/principal": "^2.3.0"
 			}
 		},
 		"node_modules/@dfinity/identity": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/@dfinity/identity/-/identity-2.1.3.tgz",
-			"integrity": "sha512-qII0V91S1YeIz5/XRHomwrUhTME+C3oqdTnb99tBitXA2Gq6LU2JaCLbKbN7ehhSyW6EjO4tySJxANz6hYENcQ==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@dfinity/identity/-/identity-2.3.0.tgz",
+			"integrity": "sha512-nJbL9hNztfhjmdkSmzoUi/cuLmCtjm9/8O6dM100acMjqG1JoW4yF4Mgi/sKwCDCkpj+maY8SqQxI8hSPms9gA==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
@@ -714,9 +714,8 @@
 				"borc": "^2.1.1"
 			},
 			"peerDependencies": {
-				"@dfinity/agent": "^2.1.3",
-				"@dfinity/principal": "^2.1.3",
-				"@peculiar/webcrypto": "^1.4.0"
+				"@dfinity/agent": "^2.3.0",
+				"@dfinity/principal": "^2.3.0"
 			}
 		},
 		"node_modules/@dfinity/ledger-icp": {
@@ -752,9 +751,9 @@
 			"link": true
 		},
 		"node_modules/@dfinity/principal": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-2.1.3.tgz",
-			"integrity": "sha512-HtiAfZcs+ToPYFepVJdFlorIfPA56KzC6J97ZuH2lGNMTAfJA+NEBzLe476B4wVCAwZ0TiGJ27J4ks9O79DFEg==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-2.3.0.tgz",
+			"integrity": "sha512-rb3TsxR3L/Vq2GWV/GGIMXPbzDDqxNohPbNW8nJKhpcm8Ds00tCVEmPUDqrn735xJW0Pmzog/6/S1L9jG2UT9g==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@noble/hashes": "^1.3.1"
@@ -1882,48 +1881,6 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@peculiar/asn1-schema": {
-			"version": "2.3.13",
-			"resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.3.13.tgz",
-			"integrity": "sha512-3Xq3a01WkHRZL8X04Zsfg//mGaA21xlL4tlVn4v2xGT0JStiztATRkMwa5b+f/HXmY2smsiLXYK46Gwgzvfg3g==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"asn1js": "^3.0.5",
-				"pvtsutils": "^1.3.5",
-				"tslib": "^2.6.2"
-			}
-		},
-		"node_modules/@peculiar/json-schema": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.12.tgz",
-			"integrity": "sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"tslib": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=8.0.0"
-			}
-		},
-		"node_modules/@peculiar/webcrypto": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.5.0.tgz",
-			"integrity": "sha512-BRs5XUAwiyCDQMsVA9IDvDa7UBR9gAvPHgugOeGng3YN6vJ9JYonyDc0lNczErgtCWtucjR5N7VtaonboD/ezg==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@peculiar/asn1-schema": "^2.3.8",
-				"@peculiar/json-schema": "^1.1.12",
-				"pvtsutils": "^1.3.5",
-				"tslib": "^2.6.2",
-				"webcrypto-core": "^1.8.0"
-			},
-			"engines": {
-				"node": ">=10.12.0"
-			}
-		},
 		"node_modules/@pkgjs/parseargs": {
 			"version": "0.11.0",
 			"resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -2849,21 +2806,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/asn1js": {
-			"version": "3.0.5",
-			"resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.5.tgz",
-			"integrity": "sha512-FVnvrKJwpt9LP2lAMl8qZswRNm3T4q9CON+bxldk2iwk3FFpuwhx2FfinyitizWHsVYyaY+y5JzDR0rCMV5yTQ==",
-			"license": "BSD-3-Clause",
-			"peer": true,
-			"dependencies": {
-				"pvtsutils": "^1.3.2",
-				"pvutils": "^1.1.3",
-				"tslib": "^2.4.0"
-			},
-			"engines": {
-				"node": ">=12.0.0"
 			}
 		},
 		"node_modules/assertion-error": {
@@ -5212,26 +5154,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/pvtsutils": {
-			"version": "1.3.6",
-			"resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
-			"integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"tslib": "^2.8.1"
-			}
-		},
-		"node_modules/pvutils": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.3.tgz",
-			"integrity": "sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ==",
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">=6.0.0"
-			}
-		},
 		"node_modules/queue-microtask": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -6169,6 +6091,7 @@
 			"version": "2.8.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true,
 			"license": "0BSD"
 		},
 		"node_modules/type-check": {
@@ -6462,20 +6385,6 @@
 				"jsdom": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/webcrypto-core": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.8.1.tgz",
-			"integrity": "sha512-P+x1MvlNCXlKbLSOY4cYrdreqPG5hbzkmawbcXLKN/mf6DZW0SdNNkZ+sjwsqVkI4A4Ko2sPZmkZtCKY58w83A==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@peculiar/asn1-schema": "^2.3.13",
-				"@peculiar/json-schema": "^1.1.12",
-				"asn1js": "^3.0.5",
-				"pvtsutils": "^1.3.5",
-				"tslib": "^2.7.0"
 			}
 		},
 		"node_modules/which": {

--- a/demo/package.json
+++ b/demo/package.json
@@ -53,12 +53,12 @@
 	},
 	"type": "module",
 	"dependencies": {
-		"@dfinity/agent": "^2.1.3",
-		"@dfinity/auth-client": "^2.1.3",
-		"@dfinity/candid": "^2.1.3",
+		"@dfinity/agent": "^2.3.0",
+		"@dfinity/auth-client": "^2.3.0",
+		"@dfinity/candid": "^2.3.0",
 		"@dfinity/ledger-icp": "^2.6.8",
 		"@dfinity/ledger-icrc": "^2.7.3",
-		"@dfinity/principal": "^2.1.3",
+		"@dfinity/principal": "^2.3.0",
 		"@dfinity/utils": "^2.10.0",
 		"buffer": "^6.0.3",
 		"zod": "^3.24.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@dfinity/eslint-config-oisy-wallet": "^0.0.6",
-        "@dfinity/identity": "^2.1.3",
+        "@dfinity/identity": "^2.3.0",
         "@dfinity/internet-identity-playwright": "^0.0.4",
         "@playwright/test": "^1.49.1",
         "@types/jest": "^29.5.14",
@@ -26,11 +26,11 @@
         "node": ">=22"
       },
       "peerDependencies": {
-        "@dfinity/agent": "^2",
-        "@dfinity/candid": "^2",
+        "@dfinity/agent": "^2.3.0",
+        "@dfinity/candid": "^2.3.0",
         "@dfinity/ledger-icp": "^2",
         "@dfinity/ledger-icrc": "^2",
-        "@dfinity/principal": "^2",
+        "@dfinity/principal": "^2.3.0",
         "@dfinity/utils": "^2",
         "@dfinity/zod-schemas": "*",
         "borc": "^2.1.1",
@@ -280,9 +280,9 @@
       }
     },
     "node_modules/@dfinity/agent": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-2.1.3.tgz",
-      "integrity": "sha512-4XmqhFR3GQSUrmx7lMFx7DyHEhFkM6nz4O9FeYJ/WpkmPe8tulKaAfgWbWdTSCjbd8meCgKVHo+QYj+JHXagcw==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-2.3.0.tgz",
+      "integrity": "sha512-f/eNydwuOunTKRcZAW1RxrcmKyb1AFqZM/ysJJaqFCX9Y+men9NoBTeuUI23XKUp9YeDb9yinGyAlYqjb6VMPw==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
@@ -294,18 +294,18 @@
         "simple-cbor": "^0.4.1"
       },
       "peerDependencies": {
-        "@dfinity/candid": "^2.1.3",
-        "@dfinity/principal": "^2.1.3"
+        "@dfinity/candid": "^2.3.0",
+        "@dfinity/principal": "^2.3.0"
       }
     },
     "node_modules/@dfinity/candid": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-2.1.3.tgz",
-      "integrity": "sha512-Asn7AfydLhhk7E5z9oW+5UL6ne11gxFlYTxHuhrIc7FdqYlM5Flcq1Wfg9EzRa6Btdol3w58Bcph7Brwh1bcIQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-2.3.0.tgz",
+      "integrity": "sha512-Xzj3EWfwaVZy90jq6WBRP4Cyqo93r3g8tvBea8W8PN3I4W6KcN2/9ZJaBhT3Y4NP+p2w4ZO6aJ+qp9xH990aYw==",
       "license": "Apache-2.0",
       "peer": true,
       "peerDependencies": {
-        "@dfinity/principal": "^2.1.3"
+        "@dfinity/principal": "^2.3.0"
       }
     },
     "node_modules/@dfinity/eslint-config-oisy-wallet": {
@@ -331,9 +331,9 @@
       }
     },
     "node_modules/@dfinity/identity": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@dfinity/identity/-/identity-2.1.3.tgz",
-      "integrity": "sha512-qII0V91S1YeIz5/XRHomwrUhTME+C3oqdTnb99tBitXA2Gq6LU2JaCLbKbN7ehhSyW6EjO4tySJxANz6hYENcQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/identity/-/identity-2.3.0.tgz",
+      "integrity": "sha512-nJbL9hNztfhjmdkSmzoUi/cuLmCtjm9/8O6dM100acMjqG1JoW4yF4Mgi/sKwCDCkpj+maY8SqQxI8hSPms9gA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -342,9 +342,8 @@
         "borc": "^2.1.1"
       },
       "peerDependencies": {
-        "@dfinity/agent": "^2.1.3",
-        "@dfinity/principal": "^2.1.3",
-        "@peculiar/webcrypto": "^1.4.0"
+        "@dfinity/agent": "^2.3.0",
+        "@dfinity/principal": "^2.3.0"
       }
     },
     "node_modules/@dfinity/internet-identity-playwright": {
@@ -387,9 +386,9 @@
       }
     },
     "node_modules/@dfinity/principal": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-2.1.3.tgz",
-      "integrity": "sha512-HtiAfZcs+ToPYFepVJdFlorIfPA56KzC6J97ZuH2lGNMTAfJA+NEBzLe476B4wVCAwZ0TiGJ27J4ks9O79DFEg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-2.3.0.tgz",
+      "integrity": "sha512-rb3TsxR3L/Vq2GWV/GGIMXPbzDDqxNohPbNW8nJKhpcm8Ds00tCVEmPUDqrn735xJW0Pmzog/6/S1L9jG2UT9g==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
@@ -1118,51 +1117,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/@peculiar/asn1-schema": {
-      "version": "2.3.13",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.3.13.tgz",
-      "integrity": "sha512-3Xq3a01WkHRZL8X04Zsfg//mGaA21xlL4tlVn4v2xGT0JStiztATRkMwa5b+f/HXmY2smsiLXYK46Gwgzvfg3g==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "asn1js": "^3.0.5",
-        "pvtsutils": "^1.3.5",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@peculiar/json-schema": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.12.tgz",
-      "integrity": "sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@peculiar/webcrypto": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.5.0.tgz",
-      "integrity": "sha512-BRs5XUAwiyCDQMsVA9IDvDa7UBR9gAvPHgugOeGng3YN6vJ9JYonyDc0lNczErgtCWtucjR5N7VtaonboD/ezg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@peculiar/asn1-schema": "^2.3.8",
-        "@peculiar/json-schema": "^1.1.12",
-        "pvtsutils": "^1.3.5",
-        "tslib": "^2.6.2",
-        "webcrypto-core": "^1.8.0"
-      },
-      "engines": {
-        "node": ">=10.12.0"
       }
     },
     "node_modules/@pkgr/core": {
@@ -2101,22 +2055,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/asn1js": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.5.tgz",
-      "integrity": "sha512-FVnvrKJwpt9LP2lAMl8qZswRNm3T4q9CON+bxldk2iwk3FFpuwhx2FfinyitizWHsVYyaY+y5JzDR0rCMV5yTQ==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "pvtsutils": "^1.3.2",
-        "pvutils": "^1.1.3",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
       }
     },
     "node_modules/assertion-error": {
@@ -5556,28 +5494,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/pvtsutils": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.5.tgz",
-      "integrity": "sha512-ARvb14YB9Nm2Xi6nBq1ZX6dAM0FsJnuk+31aUp4TrcZEdKUlSqOqsxJHUPJDNE3qiIp+iUPEIeR6Je/tgV7zsA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.6.1"
-      }
-    },
-    "node_modules/pvutils": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.3.tgz",
-      "integrity": "sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -7999,21 +7915,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/webcrypto-core": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.8.1.tgz",
-      "integrity": "sha512-P+x1MvlNCXlKbLSOY4cYrdreqPG5hbzkmawbcXLKN/mf6DZW0SdNNkZ+sjwsqVkI4A4Ko2sPZmkZtCKY58w83A==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@peculiar/asn1-schema": "^2.3.13",
-        "@peculiar/json-schema": "^1.1.12",
-        "asn1js": "^3.0.5",
-        "pvtsutils": "^1.3.5",
-        "tslib": "^2.7.0"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@dfinity/eslint-config-oisy-wallet": "^0.0.6",
-        "@dfinity/identity": "^2.3.0",
+        "@dfinity/identity": "^2.1.3",
         "@dfinity/internet-identity-playwright": "^0.0.4",
         "@playwright/test": "^1.49.1",
         "@types/jest": "^29.5.14",
@@ -280,9 +280,9 @@
       }
     },
     "node_modules/@dfinity/agent": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-2.3.0.tgz",
-      "integrity": "sha512-f/eNydwuOunTKRcZAW1RxrcmKyb1AFqZM/ysJJaqFCX9Y+men9NoBTeuUI23XKUp9YeDb9yinGyAlYqjb6VMPw==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-2.1.3.tgz",
+      "integrity": "sha512-4XmqhFR3GQSUrmx7lMFx7DyHEhFkM6nz4O9FeYJ/WpkmPe8tulKaAfgWbWdTSCjbd8meCgKVHo+QYj+JHXagcw==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
@@ -294,18 +294,18 @@
         "simple-cbor": "^0.4.1"
       },
       "peerDependencies": {
-        "@dfinity/candid": "^2.3.0",
-        "@dfinity/principal": "^2.3.0"
+        "@dfinity/candid": "^2.1.3",
+        "@dfinity/principal": "^2.1.3"
       }
     },
     "node_modules/@dfinity/candid": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-2.3.0.tgz",
-      "integrity": "sha512-Xzj3EWfwaVZy90jq6WBRP4Cyqo93r3g8tvBea8W8PN3I4W6KcN2/9ZJaBhT3Y4NP+p2w4ZO6aJ+qp9xH990aYw==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-2.1.3.tgz",
+      "integrity": "sha512-Asn7AfydLhhk7E5z9oW+5UL6ne11gxFlYTxHuhrIc7FdqYlM5Flcq1Wfg9EzRa6Btdol3w58Bcph7Brwh1bcIQ==",
       "license": "Apache-2.0",
       "peer": true,
       "peerDependencies": {
-        "@dfinity/principal": "^2.3.0"
+        "@dfinity/principal": "^2.1.3"
       }
     },
     "node_modules/@dfinity/eslint-config-oisy-wallet": {
@@ -331,9 +331,9 @@
       }
     },
     "node_modules/@dfinity/identity": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@dfinity/identity/-/identity-2.3.0.tgz",
-      "integrity": "sha512-nJbL9hNztfhjmdkSmzoUi/cuLmCtjm9/8O6dM100acMjqG1JoW4yF4Mgi/sKwCDCkpj+maY8SqQxI8hSPms9gA==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@dfinity/identity/-/identity-2.1.3.tgz",
+      "integrity": "sha512-qII0V91S1YeIz5/XRHomwrUhTME+C3oqdTnb99tBitXA2Gq6LU2JaCLbKbN7ehhSyW6EjO4tySJxANz6hYENcQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -342,8 +342,9 @@
         "borc": "^2.1.1"
       },
       "peerDependencies": {
-        "@dfinity/agent": "^2.3.0",
-        "@dfinity/principal": "^2.3.0"
+        "@dfinity/agent": "^2.1.3",
+        "@dfinity/principal": "^2.1.3",
+        "@peculiar/webcrypto": "^1.4.0"
       }
     },
     "node_modules/@dfinity/internet-identity-playwright": {
@@ -386,9 +387,9 @@
       }
     },
     "node_modules/@dfinity/principal": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-2.3.0.tgz",
-      "integrity": "sha512-rb3TsxR3L/Vq2GWV/GGIMXPbzDDqxNohPbNW8nJKhpcm8Ds00tCVEmPUDqrn735xJW0Pmzog/6/S1L9jG2UT9g==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-2.1.3.tgz",
+      "integrity": "sha512-HtiAfZcs+ToPYFepVJdFlorIfPA56KzC6J97ZuH2lGNMTAfJA+NEBzLe476B4wVCAwZ0TiGJ27J4ks9O79DFEg==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
@@ -1117,6 +1118,51 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@peculiar/asn1-schema": {
+      "version": "2.3.13",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.3.13.tgz",
+      "integrity": "sha512-3Xq3a01WkHRZL8X04Zsfg//mGaA21xlL4tlVn4v2xGT0JStiztATRkMwa5b+f/HXmY2smsiLXYK46Gwgzvfg3g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "asn1js": "^3.0.5",
+        "pvtsutils": "^1.3.5",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@peculiar/json-schema": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.12.tgz",
+      "integrity": "sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@peculiar/webcrypto": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.5.0.tgz",
+      "integrity": "sha512-BRs5XUAwiyCDQMsVA9IDvDa7UBR9gAvPHgugOeGng3YN6vJ9JYonyDc0lNczErgtCWtucjR5N7VtaonboD/ezg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.3.8",
+        "@peculiar/json-schema": "^1.1.12",
+        "pvtsutils": "^1.3.5",
+        "tslib": "^2.6.2",
+        "webcrypto-core": "^1.8.0"
+      },
+      "engines": {
+        "node": ">=10.12.0"
       }
     },
     "node_modules/@pkgr/core": {
@@ -2055,6 +2101,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/asn1js": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.5.tgz",
+      "integrity": "sha512-FVnvrKJwpt9LP2lAMl8qZswRNm3T4q9CON+bxldk2iwk3FFpuwhx2FfinyitizWHsVYyaY+y5JzDR0rCMV5yTQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "pvtsutils": "^1.3.2",
+        "pvutils": "^1.1.3",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/assertion-error": {
@@ -5494,6 +5556,28 @@
         "node": ">=6"
       }
     },
+    "node_modules/pvtsutils": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.5.tgz",
+      "integrity": "sha512-ARvb14YB9Nm2Xi6nBq1ZX6dAM0FsJnuk+31aUp4TrcZEdKUlSqOqsxJHUPJDNE3qiIp+iUPEIeR6Je/tgV7zsA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.6.1"
+      }
+    },
+    "node_modules/pvutils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.3.tgz",
+      "integrity": "sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -7915,6 +7999,21 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/webcrypto-core": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.8.1.tgz",
+      "integrity": "sha512-P+x1MvlNCXlKbLSOY4cYrdreqPG5hbzkmawbcXLKN/mf6DZW0SdNNkZ+sjwsqVkI4A4Ko2sPZmkZtCKY58w83A==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.3.13",
+        "@peculiar/json-schema": "^1.1.12",
+        "asn1js": "^3.0.5",
+        "pvtsutils": "^1.3.5",
+        "tslib": "^2.7.0"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@dfinity/eslint-config-oisy-wallet": "^0.0.6",
-        "@dfinity/identity": "^2.1.3",
+        "@dfinity/identity": "^2.3.0",
         "@dfinity/internet-identity-playwright": "^0.0.4",
         "@playwright/test": "^1.49.1",
         "@types/jest": "^29.5.14",
@@ -280,9 +280,9 @@
       }
     },
     "node_modules/@dfinity/agent": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-2.1.3.tgz",
-      "integrity": "sha512-4XmqhFR3GQSUrmx7lMFx7DyHEhFkM6nz4O9FeYJ/WpkmPe8tulKaAfgWbWdTSCjbd8meCgKVHo+QYj+JHXagcw==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-2.3.0.tgz",
+      "integrity": "sha512-f/eNydwuOunTKRcZAW1RxrcmKyb1AFqZM/ysJJaqFCX9Y+men9NoBTeuUI23XKUp9YeDb9yinGyAlYqjb6VMPw==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
@@ -294,18 +294,18 @@
         "simple-cbor": "^0.4.1"
       },
       "peerDependencies": {
-        "@dfinity/candid": "^2.1.3",
-        "@dfinity/principal": "^2.1.3"
+        "@dfinity/candid": "^2.3.0",
+        "@dfinity/principal": "^2.3.0"
       }
     },
     "node_modules/@dfinity/candid": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-2.1.3.tgz",
-      "integrity": "sha512-Asn7AfydLhhk7E5z9oW+5UL6ne11gxFlYTxHuhrIc7FdqYlM5Flcq1Wfg9EzRa6Btdol3w58Bcph7Brwh1bcIQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-2.3.0.tgz",
+      "integrity": "sha512-Xzj3EWfwaVZy90jq6WBRP4Cyqo93r3g8tvBea8W8PN3I4W6KcN2/9ZJaBhT3Y4NP+p2w4ZO6aJ+qp9xH990aYw==",
       "license": "Apache-2.0",
       "peer": true,
       "peerDependencies": {
-        "@dfinity/principal": "^2.1.3"
+        "@dfinity/principal": "^2.3.0"
       }
     },
     "node_modules/@dfinity/eslint-config-oisy-wallet": {
@@ -331,9 +331,9 @@
       }
     },
     "node_modules/@dfinity/identity": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@dfinity/identity/-/identity-2.1.3.tgz",
-      "integrity": "sha512-qII0V91S1YeIz5/XRHomwrUhTME+C3oqdTnb99tBitXA2Gq6LU2JaCLbKbN7ehhSyW6EjO4tySJxANz6hYENcQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/identity/-/identity-2.3.0.tgz",
+      "integrity": "sha512-nJbL9hNztfhjmdkSmzoUi/cuLmCtjm9/8O6dM100acMjqG1JoW4yF4Mgi/sKwCDCkpj+maY8SqQxI8hSPms9gA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -342,9 +342,8 @@
         "borc": "^2.1.1"
       },
       "peerDependencies": {
-        "@dfinity/agent": "^2.1.3",
-        "@dfinity/principal": "^2.1.3",
-        "@peculiar/webcrypto": "^1.4.0"
+        "@dfinity/agent": "^2.3.0",
+        "@dfinity/principal": "^2.3.0"
       }
     },
     "node_modules/@dfinity/internet-identity-playwright": {
@@ -387,9 +386,9 @@
       }
     },
     "node_modules/@dfinity/principal": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-2.1.3.tgz",
-      "integrity": "sha512-HtiAfZcs+ToPYFepVJdFlorIfPA56KzC6J97ZuH2lGNMTAfJA+NEBzLe476B4wVCAwZ0TiGJ27J4ks9O79DFEg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-2.3.0.tgz",
+      "integrity": "sha512-rb3TsxR3L/Vq2GWV/GGIMXPbzDDqxNohPbNW8nJKhpcm8Ds00tCVEmPUDqrn735xJW0Pmzog/6/S1L9jG2UT9g==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
@@ -1118,51 +1117,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/@peculiar/asn1-schema": {
-      "version": "2.3.13",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.3.13.tgz",
-      "integrity": "sha512-3Xq3a01WkHRZL8X04Zsfg//mGaA21xlL4tlVn4v2xGT0JStiztATRkMwa5b+f/HXmY2smsiLXYK46Gwgzvfg3g==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "asn1js": "^3.0.5",
-        "pvtsutils": "^1.3.5",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@peculiar/json-schema": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.12.tgz",
-      "integrity": "sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@peculiar/webcrypto": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.5.0.tgz",
-      "integrity": "sha512-BRs5XUAwiyCDQMsVA9IDvDa7UBR9gAvPHgugOeGng3YN6vJ9JYonyDc0lNczErgtCWtucjR5N7VtaonboD/ezg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@peculiar/asn1-schema": "^2.3.8",
-        "@peculiar/json-schema": "^1.1.12",
-        "pvtsutils": "^1.3.5",
-        "tslib": "^2.6.2",
-        "webcrypto-core": "^1.8.0"
-      },
-      "engines": {
-        "node": ">=10.12.0"
       }
     },
     "node_modules/@pkgr/core": {
@@ -2101,22 +2055,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/asn1js": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.5.tgz",
-      "integrity": "sha512-FVnvrKJwpt9LP2lAMl8qZswRNm3T4q9CON+bxldk2iwk3FFpuwhx2FfinyitizWHsVYyaY+y5JzDR0rCMV5yTQ==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "pvtsutils": "^1.3.2",
-        "pvutils": "^1.1.3",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
       }
     },
     "node_modules/assertion-error": {
@@ -5556,28 +5494,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/pvtsutils": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.5.tgz",
-      "integrity": "sha512-ARvb14YB9Nm2Xi6nBq1ZX6dAM0FsJnuk+31aUp4TrcZEdKUlSqOqsxJHUPJDNE3qiIp+iUPEIeR6Je/tgV7zsA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.6.1"
-      }
-    },
-    "node_modules/pvutils": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.3.tgz",
-      "integrity": "sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -7999,21 +7915,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/webcrypto-core": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.8.1.tgz",
-      "integrity": "sha512-P+x1MvlNCXlKbLSOY4cYrdreqPG5hbzkmawbcXLKN/mf6DZW0SdNNkZ+sjwsqVkI4A4Ko2sPZmkZtCKY58w83A==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@peculiar/asn1-schema": "^2.3.13",
-        "@peculiar/json-schema": "^1.1.12",
-        "asn1js": "^3.0.5",
-        "pvtsutils": "^1.3.5",
-        "tslib": "^2.7.0"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
   },
   "devDependencies": {
     "@dfinity/eslint-config-oisy-wallet": "^0.0.6",
-    "@dfinity/identity": "^2.1.3",
+    "@dfinity/identity": "^2.3.0",
     "@dfinity/internet-identity-playwright": "^0.0.4",
     "@playwright/test": "^1.49.1",
     "@types/jest": "^29.5.14",
@@ -92,11 +92,11 @@
     "node": ">=22"
   },
   "peerDependencies": {
-    "@dfinity/agent": "^2",
-    "@dfinity/candid": "^2",
+    "@dfinity/agent": "^2.3.0",
+    "@dfinity/candid": "^2.3.0",
     "@dfinity/ledger-icp": "^2",
     "@dfinity/ledger-icrc": "^2",
-    "@dfinity/principal": "^2",
+    "@dfinity/principal": "^2.3.0",
     "@dfinity/utils": "^2",
     "@dfinity/zod-schemas": "*",
     "borc": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
   },
   "devDependencies": {
     "@dfinity/eslint-config-oisy-wallet": "^0.0.6",
-    "@dfinity/identity": "^2.3.0",
+    "@dfinity/identity": "^2.1.3",
     "@dfinity/internet-identity-playwright": "^0.0.4",
     "@playwright/test": "^1.49.1",
     "@types/jest": "^29.5.14",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
   },
   "devDependencies": {
     "@dfinity/eslint-config-oisy-wallet": "^0.0.6",
-    "@dfinity/identity": "^2.1.3",
+    "@dfinity/identity": "^2.3.0",
     "@dfinity/internet-identity-playwright": "^0.0.4",
     "@playwright/test": "^1.49.1",
     "@types/jest": "^29.5.14",

--- a/src/agent/custom-http-agent.spec.ts
+++ b/src/agent/custom-http-agent.spec.ts
@@ -1,7 +1,7 @@
-import type {RequestId, SubmitResponse} from '@dfinity/agent';
 import * as httpAgent from '@dfinity/agent';
+import {RequestId, SubmitResponse} from '@dfinity/agent';
 import {base64ToUint8Array} from '@dfinity/utils';
-import type {MockInstance} from 'vitest';
+import {MockInstance} from 'vitest';
 import {
   mockLocalIcRootKey,
   mockRejectedLocalCallTime,
@@ -22,7 +22,8 @@ import {
   InvalidCertificateReplyError,
   InvalidCertificateStatusError,
   RequestError,
-  UndefinedRequestDetailsError
+  UndefinedRequestDetailsError,
+  UndefinedRootKeyError
 } from './custom-http-agent';
 
 vi.mock('@dfinity/agent', async (importOriginal) => {
@@ -278,6 +279,11 @@ describe('CustomHttpAgent', () => {
             InvalidCertificateReplyError
           );
         });
+      });
+
+      it('should throw an exception if the agent root key is not defined', async () => {
+        vi.spyOn(agent.agent, 'rootKey', 'get').mockReturnValue(null);
+        await expect(agent.request(mockRequestPayload)).rejects.toThrow(UndefinedRootKeyError);
       });
     });
 

--- a/src/agent/custom-http-agent.ts
+++ b/src/agent/custom-http-agent.ts
@@ -21,6 +21,7 @@ export class UndefinedRequestDetailsError extends Error {}
 export class RequestError extends Error {}
 export class InvalidCertificateReplyError extends Error {}
 export class InvalidCertificateStatusError extends Error {}
+export class UndefinedRootKeyError extends Error {}
 
 // To extend the HttpAgent, we would have to override the static create function.
 // While this is possible, it would require using Object.assign to clone the HttpAgent into a CustomHttpAgent, because the super function does not accept generics.
@@ -124,6 +125,10 @@ export class CustomHttpAgent {
     // @see agent-js: https://github.com/dfinity/agent-js/blob/21cf4700eff1de7f6f15304b758a16e5881afca3/packages/agent/src/actor.ts#L545
 
     const {certificate: cert} = body;
+
+    if (isNullish(this.#agent.rootKey)) {
+      throw new UndefinedRootKeyError();
+    }
 
     const certificate = await Certificate.create({
       certificate: bufFromBufLike(cert),

--- a/src/utils/call.utils.spec.ts
+++ b/src/utils/call.utils.spec.ts
@@ -124,10 +124,6 @@ describe('call.utils', () => {
 
     beforeEach(() => {
       vi.setSystemTime(mockLocalCallTime);
-
-      createSpy = vi.spyOn(agent.HttpAgent, 'create').mockResolvedValue({
-        rootKey: mockLocalIcRootKey.buffer
-      } as unknown as agent.HttpAgent);
     });
 
     afterEach(() => {
@@ -135,36 +131,64 @@ describe('call.utils', () => {
       vi.useRealTimers();
     });
 
-    it('should decode success response', async () => {
-      const response = await decodeResponse({
-        params: mockLocalCallParams,
-        result: mockLocalCallResult,
-        resultRecordClass: TransferResult
+    describe('With agent root key', () => {
+      beforeEach(() => {
+        createSpy = vi.spyOn(agent.HttpAgent, 'create').mockResolvedValue({
+          rootKey: mockLocalIcRootKey.buffer
+        } as unknown as agent.HttpAgent);
       });
 
-      expect(response).toEqual({
-        Ok: mockLocalBlockHeight
+      it('should decode success response', async () => {
+        const response = await decodeResponse({
+          params: mockLocalCallParams,
+          result: mockLocalCallResult,
+          resultRecordClass: TransferResult
+        });
+
+        expect(response).toEqual({
+          Ok: mockLocalBlockHeight
+        });
+      });
+
+      it('should create agent with a custom host', async () => {
+        const host = 'http://localhost:8080';
+
+        const response = await decodeResponse({
+          params: mockLocalCallParams,
+          result: mockLocalCallResult,
+          resultRecordClass: TransferResult,
+          host
+        });
+
+        expect(response).toEqual({
+          Ok: mockLocalBlockHeight
+        });
+
+        expect(createSpy).toHaveBeenCalledWith({
+          host,
+          identity: new AnonymousIdentity(),
+          shouldFetchRootKey: true
+        });
       });
     });
 
-    it('should create agent with a custom host', async () => {
-      const host = 'http://localhost:8080';
-
-      const response = await decodeResponse({
-        params: mockLocalCallParams,
-        result: mockLocalCallResult,
-        resultRecordClass: TransferResult,
-        host
+    describe('Without agent root key', () => {
+      beforeEach(() => {
+        createSpy = vi.spyOn(agent.HttpAgent, 'create').mockResolvedValue({
+          rootKey: null
+        } as unknown as agent.HttpAgent);
       });
 
-      expect(response).toEqual({
-        Ok: mockLocalBlockHeight
-      });
-
-      expect(createSpy).toHaveBeenCalledWith({
-        host,
-        identity: new AnonymousIdentity(),
-        shouldFetchRootKey: true
+      it('should throw an exception is agent root key is undefined', async () => {
+        await expect(
+          decodeResponse({
+            params: mockLocalCallParams,
+            result: mockLocalCallResult,
+            resultRecordClass: TransferResult
+          })
+        ).rejects.toThrowError(
+          'Missing agent root key, which is required to certify the response.'
+        );
       });
     });
 

--- a/src/utils/call.utils.ts
+++ b/src/utils/call.utils.ts
@@ -78,6 +78,11 @@ export const decodeResponse = async <T>({
     ...(localhost && {shouldFetchRootKey: true})
   });
 
+  assertNonNullish(
+    agent.rootKey,
+    'Missing agent root key, which is required to certify the response.'
+  );
+
   const certificate = await Certificate.create({
     certificate: base64ToUint8Array(cert),
     rootKey: agent.rootKey,


### PR DESCRIPTION
# Motivation

We recently set the agent-js dependencies to ^v2 which actually was a mistake as the library requires some improvements that were delivered in agent-js v2.1.x.

Since v2.1.3 is buggy and the agent-js has been patched in a new version, we revert to being explicit in terms of version requirements and bump to the latest version.

There is also an hidden / not communicated breaking changes in Agent-js v2.3.0. The `rootKey` has been modified from being always defined to being potentially `null`. That's why we have to adapt the code to catch potential exception.

# Notes

We unfortunately have to bump and patch the change in the same PR because one necessit the other.

# Changes

- Bump Agent-js v2.3.0 in library
- Add assertion and throw errors for `agent.rootKey` being potentially null
- Bump Agent-js v2.3.0 in demo
