### PR TITLE
build: require agent-js v2.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@dfinity/eslint-config-oisy-wallet": "^0.0.6",
-        "@dfinity/identity": "^2.1.3",
+        "@dfinity/identity": "^2.3.0",
         "@dfinity/internet-identity-playwright": "^0.0.4",
         "@playwright/test": "^1.49.1",
         "@types/jest": "^29.5.14",
@@ -26,11 +26,11 @@
         "node": ">=22"
       },
       "peerDependencies": {
-        "@dfinity/agent": "^2",
-        "@dfinity/candid": "^2",
+        "@dfinity/agent": "^2.3.0",
+        "@dfinity/candid": "^2.3.0",
         "@dfinity/ledger-icp": "^2",
         "@dfinity/ledger-icrc": "^2",
-        "@dfinity/principal": "^2",
+        "@dfinity/principal": "^2.3.0",
         "@dfinity/utils": "^2",
         "@dfinity/zod-schemas": "*",
         "borc": "^2.1.1",
@@ -280,9 +280,9 @@
       }
     },
     "node_modules/@dfinity/agent": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-2.1.3.tgz",
-      "integrity": "sha512-4XmqhFR3GQSUrmx7lMFx7DyHEhFkM6nz4O9FeYJ/WpkmPe8tulKaAfgWbWdTSCjbd8meCgKVHo+QYj+JHXagcw==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-2.3.0.tgz",
+      "integrity": "sha512-f/eNydwuOunTKRcZAW1RxrcmKyb1AFqZM/ysJJaqFCX9Y+men9NoBTeuUI23XKUp9YeDb9yinGyAlYqjb6VMPw==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
@@ -294,18 +294,18 @@
         "simple-cbor": "^0.4.1"
       },
       "peerDependencies": {
-        "@dfinity/candid": "^2.1.3",
-        "@dfinity/principal": "^2.1.3"
+        "@dfinity/candid": "^2.3.0",
+        "@dfinity/principal": "^2.3.0"
       }
     },
     "node_modules/@dfinity/candid": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-2.1.3.tgz",
-      "integrity": "sha512-Asn7AfydLhhk7E5z9oW+5UL6ne11gxFlYTxHuhrIc7FdqYlM5Flcq1Wfg9EzRa6Btdol3w58Bcph7Brwh1bcIQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-2.3.0.tgz",
+      "integrity": "sha512-Xzj3EWfwaVZy90jq6WBRP4Cyqo93r3g8tvBea8W8PN3I4W6KcN2/9ZJaBhT3Y4NP+p2w4ZO6aJ+qp9xH990aYw==",
       "license": "Apache-2.0",
       "peer": true,
       "peerDependencies": {
-        "@dfinity/principal": "^2.1.3"
+        "@dfinity/principal": "^2.3.0"
       }
     },
     "node_modules/@dfinity/eslint-config-oisy-wallet": {
@@ -331,9 +331,9 @@
       }
     },
     "node_modules/@dfinity/identity": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@dfinity/identity/-/identity-2.1.3.tgz",
-      "integrity": "sha512-qII0V91S1YeIz5/XRHomwrUhTME+C3oqdTnb99tBitXA2Gq6LU2JaCLbKbN7ehhSyW6EjO4tySJxANz6hYENcQ==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/identity/-/identity-2.3.0.tgz",
+      "integrity": "sha512-nJbL9hNztfhjmdkSmzoUi/cuLmCtjm9/8O6dM100acMjqG1JoW4yF4Mgi/sKwCDCkpj+maY8SqQxI8hSPms9gA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -342,9 +342,8 @@
         "borc": "^2.1.1"
       },
       "peerDependencies": {
-        "@dfinity/agent": "^2.1.3",
-        "@dfinity/principal": "^2.1.3",
-        "@peculiar/webcrypto": "^1.4.0"
+        "@dfinity/agent": "^2.3.0",
+        "@dfinity/principal": "^2.3.0"
       }
     },
     "node_modules/@dfinity/internet-identity-playwright": {
@@ -387,9 +386,9 @@
       }
     },
     "node_modules/@dfinity/principal": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-2.1.3.tgz",
-      "integrity": "sha512-HtiAfZcs+ToPYFepVJdFlorIfPA56KzC6J97ZuH2lGNMTAfJA+NEBzLe476B4wVCAwZ0TiGJ27J4ks9O79DFEg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-2.3.0.tgz",
+      "integrity": "sha512-rb3TsxR3L/Vq2GWV/GGIMXPbzDDqxNohPbNW8nJKhpcm8Ds00tCVEmPUDqrn735xJW0Pmzog/6/S1L9jG2UT9g==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
@@ -1118,51 +1117,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/@peculiar/asn1-schema": {
-      "version": "2.3.13",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.3.13.tgz",
-      "integrity": "sha512-3Xq3a01WkHRZL8X04Zsfg//mGaA21xlL4tlVn4v2xGT0JStiztATRkMwa5b+f/HXmY2smsiLXYK46Gwgzvfg3g==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "asn1js": "^3.0.5",
-        "pvtsutils": "^1.3.5",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@peculiar/json-schema": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.12.tgz",
-      "integrity": "sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@peculiar/webcrypto": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.5.0.tgz",
-      "integrity": "sha512-BRs5XUAwiyCDQMsVA9IDvDa7UBR9gAvPHgugOeGng3YN6vJ9JYonyDc0lNczErgtCWtucjR5N7VtaonboD/ezg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@peculiar/asn1-schema": "^2.3.8",
-        "@peculiar/json-schema": "^1.1.12",
-        "pvtsutils": "^1.3.5",
-        "tslib": "^2.6.2",
-        "webcrypto-core": "^1.8.0"
-      },
-      "engines": {
-        "node": ">=10.12.0"
       }
     },
     "node_modules/@pkgr/core": {
@@ -2101,22 +2055,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/asn1js": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.5.tgz",
-      "integrity": "sha512-FVnvrKJwpt9LP2lAMl8qZswRNm3T4q9CON+bxldk2iwk3FFpuwhx2FfinyitizWHsVYyaY+y5JzDR0rCMV5yTQ==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "pvtsutils": "^1.3.2",
-        "pvutils": "^1.1.3",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
       }
     },
     "node_modules/assertion-error": {
@@ -5556,28 +5494,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/pvtsutils": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.5.tgz",
-      "integrity": "sha512-ARvb14YB9Nm2Xi6nBq1ZX6dAM0FsJnuk+31aUp4TrcZEdKUlSqOqsxJHUPJDNE3qiIp+iUPEIeR6Je/tgV7zsA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.6.1"
-      }
-    },
-    "node_modules/pvutils": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.3.tgz",
-      "integrity": "sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -7999,21 +7915,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/webcrypto-core": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.8.1.tgz",
-      "integrity": "sha512-P+x1MvlNCXlKbLSOY4cYrdreqPG5hbzkmawbcXLKN/mf6DZW0SdNNkZ+sjwsqVkI4A4Ko2sPZmkZtCKY58w83A==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@peculiar/asn1-schema": "^2.3.13",
-        "@peculiar/json-schema": "^1.1.12",
-        "asn1js": "^3.0.5",
-        "pvtsutils": "^1.3.5",
-        "tslib": "^2.7.0"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
   },
   "devDependencies": {
     "@dfinity/eslint-config-oisy-wallet": "^0.0.6",
-    "@dfinity/identity": "^2.1.3",
+    "@dfinity/identity": "^2.3.0",
     "@dfinity/internet-identity-playwright": "^0.0.4",
     "@playwright/test": "^1.49.1",
     "@types/jest": "^29.5.14",
@@ -92,11 +92,11 @@
     "node": ">=22"
   },
   "peerDependencies": {
-    "@dfinity/agent": "^2",
-    "@dfinity/candid": "^2",
+    "@dfinity/agent": "^2.3.0",
+    "@dfinity/candid": "^2.3.0",
     "@dfinity/ledger-icp": "^2",
     "@dfinity/ledger-icrc": "^2",
-    "@dfinity/principal": "^2",
+    "@dfinity/principal": "^2.3.0",
     "@dfinity/utils": "^2",
     "@dfinity/zod-schemas": "*",
     "borc": "^2.1.1",


### PR DESCRIPTION
# Motivation

We recently set the agent-js dependencies to `^v2` which actually was a mistake as the library requires  some improvements that were delivered in agent-js v2.1.x.

Since v2.1.3 is buggy and the agent-js has been patched in a new version (that also contains a breaking changes #466), we revert to being explicit in terms of version requirements and bump to the latest version.