### PR TITLE
dependabot: reduce frequency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
   - package-ecosystem: npm
     directory: '/'
     schedule:
-      interval: weekly
+      interval: monthly
     allow:
       - dependency-type: development
     ignore:
@@ -18,7 +18,7 @@ updates:
   - package-ecosystem: npm
     directory: '/demo'
     schedule:
-      interval: weekly
+      interval: monthly
     ignore:
       - dependency-name: '@types/*'
       - dependency-name: '@typescript-eslint/*'


### PR DESCRIPTION
# Motivation

We  reduce the frequency of dependabot PRs to monthly, since weekly leads to a bit too much maintenance for a lib that does not change that often.
