### PR TITLE
chore: downgrade typescript to v5.4.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "jsdom": "^26.0.0",
         "prettier": "^3.4.2",
         "prettier-plugin-organize-imports": "^4.1.0",
-        "typescript": "^5.6.3",
+        "typescript": "^5.4.5",
         "vitest": "^3.0.2"
       },
       "engines": {
@@ -6352,9 +6352,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
-      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "jsdom": "^26.0.0",
     "prettier": "^3.4.2",
     "prettier-plugin-organize-imports": "^4.1.0",
-    "typescript": "^5.6.3",
+    "typescript": "^5.4.5",
     "vitest": "^3.0.2"
   },
   "engines": {


### PR DESCRIPTION
# Motivation

For simplicity reason, downgrade TypeScript to avoid error such as following to popups when migrating to eslint v9:

```
Error: src/agent/agentjs-cbor-copy.ts(37,29): error TS2345: Argument of type 'Uint8Array<ArrayBufferLike>' is not assignable to parameter of type 'ArrayBuffer'.
  Type 'Uint8Array<ArrayBufferLike>' is missing the following properties from type 'ArrayBuffer': maxByteLength, resizable, resize, detached, and 2 more.
```

Ultimately we should solve those but, to ease the migration, it's easier to just stick to an older version of TypeScript as we do in OISY.

# Example

https://github.com/dfinity/oisy-wallet-signer/actions/runs/13391900122/job/37401311340?pr=474
