### PR TITLE
fx(frontend) Temporarily disable the busy error notification for icrc29_status rpc events 

### DIFF
--- a/src/signer.spec.ts
+++ b/src/signer.spec.ts
@@ -398,6 +398,12 @@ describe('Signer', () => {
           notifyPermissionsSpy = vi.spyOn(signerSuccessHandlers, 'notifyPermissionScopes');
           notifyErrorSpy = vi.spyOn(signerHandlers, 'notifyError');
         });
+        // TODO: remove this test once the busy error notification issue has been fixed
+        it('should not notify an error when status is requested', () => {
+          const messageEvent = new MessageEvent('message', requestStatus);
+          window.dispatchEvent(messageEvent);
+          expect(notifyErrorSpy).not.toHaveBeenCalled();
+        });
 
         it('should notify READY for icrc29_status', () => {
           const messageEvent = new MessageEvent('message', requestStatus);

--- a/src/signer.ts
+++ b/src/signer.ts
@@ -6,6 +6,7 @@ import {
   ICRC25_PERMISSION_GRANTED,
   ICRC25_REQUEST_PERMISSIONS,
   ICRC27_ACCOUNTS,
+  ICRC29_STATUS,
   ICRC49_CALL_CANISTER
 } from './constants/icrc.constants';
 import {SIGNER_DEFAULT_SCOPES, SignerErrorCode} from './constants/signer.constants';
@@ -245,7 +246,12 @@ export class Signer {
    * @returns {boolean} returns true` if the signer is busy, otherwise `false`.
    */
   private assertNotBusy({data: msgData, origin}: SignerMessageEvent): {busy: boolean} {
-    if (this.#busy) {
+    // TODO: This is a temporary workaround to suppress the busy error, which is likely triggered due
+    //  to an error raised by *.safeParse(data)
+    //  A follow-up pull-request with a clean fix will be provided asap
+    //  Original code:
+    // if (this.#busy) {
+    if (this.#busy && msgData?.method !== ICRC29_STATUS) {
       notifyErrorBusy({
         id: msgData?.id ?? null,
         origin


### PR DESCRIPTION
# Motivation
Currently a user is not able KongSwap to connect to his principle through the Oisy wallet  

# Changes
- The proposal provided by Thomas Gladdines to disable error notifications for icrc29_status events.
- Added a clear TODO statement.
- Referenced the constant ICRC29_STATUS instead of using a hardcoded string.

# Tests
An additional test with name "" has been added which will fail when the event **icrc29_status** occurs 
