### PR TITLE
feat: handle heartbeat messages even when the signer is busy

### DIFF
--- a/src/signer.spec.ts
+++ b/src/signer.spec.ts
@@ -1682,7 +1682,7 @@ describe('Signer', () => {
               });
             });
 
-            describe('Busy', async () => {
+            describe('Busy', () => {
               let messageEvent: MessageEvent;
 
               beforeEach(async () => {

--- a/src/signer.spec.ts
+++ b/src/signer.spec.ts
@@ -476,14 +476,16 @@ describe('Signer', () => {
           expect(notifyErrorSpy).not.toHaveBeenCalled();
         });
 
-        it('should not handle with busy', () => {
+        it('should not handle with busy', async () => {
           const handleWithBusySpy = vi.spyOn(
             signer as unknown as {handleWithBusy: () => void},
             'handleWithBusy'
           );
           const messageEvent = new MessageEvent('message', requestStatus);
           window.dispatchEvent(messageEvent);
-          expect(handleWithBusySpy).not.toHaveBeenCalled();
+          await vi.waitFor(() => {
+            expect(handleWithBusySpy).not.toHaveBeenCalled();
+          });
         });
       });
 
@@ -1680,7 +1682,7 @@ describe('Signer', () => {
               });
             });
 
-            describe('Busy', () => {
+            describe('Busy', async () => {
               let messageEvent: MessageEvent;
 
               beforeEach(async () => {

--- a/src/signer.spec.ts
+++ b/src/signer.spec.ts
@@ -435,14 +435,14 @@ describe('Signer', () => {
 
         const assertNotifyReady = () => {
           expect(postMessageMock).toHaveBeenCalledWith(
-              {
-                jsonrpc: JSON_RPC_VERSION_2,
-                id: testId,
-                result: 'ready'
-              },
-              testOrigin
+            {
+              jsonrpc: JSON_RPC_VERSION_2,
+              id: testId,
+              result: 'ready'
+            },
+            testOrigin
           );
-        }
+        };
 
         it('should notify READY for icrc29_status', () => {
           const messageEvent = new MessageEvent('message', requestStatus);

--- a/src/signer.ts
+++ b/src/signer.ts
@@ -132,7 +132,7 @@ export class Signer {
 
     // The heartbeat might be triggered while the signer is busy processing requests.
     // Since these informative requests do not impact the signer's behavior, it is acceptable to provide a response.
-    const {handled: handledHeartbeat} = await this.handleHeartbeatMessage(message);
+    const {handled: handledHeartbeat} = this.handleHeartbeatMessage(message);
     if (handledHeartbeat) {
       return;
     }
@@ -155,7 +155,7 @@ export class Signer {
     });
   };
 
-  private async handleHeartbeatMessage(message: SignerMessageEvent): Promise<{handled: boolean}> {
+  private handleHeartbeatMessage(message: SignerMessageEvent): {handled: boolean} {
     const {handled: statusRequestHandled} = this.handleStatusRequest(message);
     if (statusRequestHandled) {
       return {handled: true};

--- a/src/signer.ts
+++ b/src/signer.ts
@@ -130,8 +130,6 @@ export class Signer {
       return;
     }
 
-    // The heartbeat might be triggered while the signer is busy processing requests.
-    // Since these informative requests do not impact the signer's behavior, it is acceptable to provide a response.
     const {handled: handledHeartbeat} = this.handleHeartbeatMessage(message);
     if (handledHeartbeat) {
       return;
@@ -155,6 +153,16 @@ export class Signer {
     });
   };
 
+  /**
+   * Handles a potential heartbeat message request.
+   *
+   * The heartbeat might be triggered while the signer is busy processing requests.
+   * Since these informative requests do not impact the signer's behavior, it is acceptable to provide a response.
+   *
+   * @private
+   * @param {SignerMessageEvent} message - The message event to process.
+   * @returns {{ handled: boolean }} - An object indicating whether the message was handled.
+   */
   private handleHeartbeatMessage(message: SignerMessageEvent): {handled: boolean} {
     const {handled: statusRequestHandled} = this.handleStatusRequest(message);
     if (statusRequestHandled) {


### PR DESCRIPTION
# Motivation
When Kongswap sends the icrc29_status event while connecting, the Oisy wallet encounters a 'busy' error (SignerErrorCode.BUSY). This causes the Oisy Wallet Signer popup to close with a slight delay.

# Root cause of the issue
We are not exactly sure where the issue arises, but we assume that some changes in the clients (dapps or libraries) result in the relying party requesting the status while the signer is actually busy handling other requests. For example, this can occur if the client starts polling for status too frequently.

After some reflection, we also noticed that this potential issue could arise even if nothing had changed. Periodic status requests have been introduced to check whether the connection is still open and valid, and if not, to automatically disconnect the relying party—for instance, if the user closes the signer window. This behavior is also suggested (and implemented) for clients to terminate the connection on their side.

This means that clients already poll the signer periodically and, by extension, may inadvertently disconnect themselves while, for example, a canister call is being executed. This creates a potential race condition where the connection is closed on the client side because a status request occurs at the same time the signer is actively performing work.

# Changes
- A separate function 'handleHeartbeatMessage(..)' to specifically handle the heartbeat (icrc29_status) without posting a BUSY error has been introduced. If this method is handled further execution is immediately  aborted in the  onMessage(..) function
- Move the handling of the status request to this new function that finds place before cheking for statuses.
- Added few comments

# TODOs

We added two TODOs in the test for minor questions we want to tackle separately.
