### PR TITLE
feat: Prepare the method to specifically handle readonly message requests 

### DIFF
--- a/src/signer.ts
+++ b/src/signer.ts
@@ -130,8 +130,9 @@ export class Signer {
       return;
     }
 
-    const {handled: handledHeartbeat} = this.handleHeartbeatMessage(message);
-    if (handledHeartbeat) {
+    // all ready-only message requests must be handled before any
+    const {handled: handledReadOnly} = this.handleReadOnlyMessage(message);
+    if (handledReadOnly) {
       return;
     }
 
@@ -154,20 +155,22 @@ export class Signer {
   };
 
   /**
-   * Handles a potential heartbeat message request.
+   * Handles a potential readonly-only message request.
    *
-   * The heartbeat might be triggered while the signer is busy processing requests.
-   * Since these informative requests do not impact the signer's behavior, it is acceptable to provide a response.
+   * The readonly-only message request might be triggered while the signer is busy processing requests.
+   * Since these informative requests do not impact the signer's behavior, it is acceptable to provide a response read-only requests.
    *
    * @private
    * @param {SignerMessageEvent} message - The message event to process.
    * @returns {{ handled: boolean }} - An object indicating whether the message was handled.
    */
-  private handleHeartbeatMessage(message: SignerMessageEvent): {handled: boolean} {
+  private handleReadOnlyMessage(message: SignerMessageEvent): {handled: boolean} {
     const {handled: statusRequestHandled} = this.handleStatusRequest(message);
     if (statusRequestHandled) {
       return {handled: true};
     }
+
+    // TODO: handle any read-only message requests here (e.g. handleSupportedStandards(..))
 
     return {handled: false};
   }

--- a/src/signer.ts
+++ b/src/signer.ts
@@ -130,7 +130,6 @@ export class Signer {
       return;
     }
 
-    // all ready-only message requests must be handled before any
     const {handled: handledReadOnly} = this.handleReadOnlyMessage(message);
     if (handledReadOnly) {
       return;
@@ -169,9 +168,7 @@ export class Signer {
     if (statusRequestHandled) {
       return {handled: true};
     }
-
-    // TODO: handle any read-only message requests here (e.g. handleSupportedStandards(..))
-
+    // TODO: handle read-only message requests in the future here (e.g. handleSupportedStandards(..))
     return {handled: false};
   }
 


### PR DESCRIPTION
# Motivation
All read-only message requests must be handled within a dedicated method (handleReadOnlyMessage). This enables the signer to specifically handle read-only methods to fulfil the requirement:
**Respond to message requests that don't require user approval while the signer is busy**

# Changes
- Changed method name handleHeartbeatMessage(..) to handleReadOnlyMessage(..)
- Updated method code documentation
- Added TODO comment to handleReadOnlyMessage(..)
- 
# Tests
No tests are affected by this change. I also did not find tests that would require a naming change, since no test directly called handleHeartbeatMessage(..)
