### PR TITLE
chore: pr title and description checks

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,44 @@
+name: 'PR checks'
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+      - labeled
+
+jobs:
+  check-pr-title:
+    name: 'check-pr-title:required'
+    runs-on: ubuntu-24.04
+    env:
+      TITLE: ${{ github.event.pull_request.title }}
+    steps:
+      - name: 'Check PR Title'
+        run: |
+          if [[ "$TITLE" =~ ^(feat|fix|chore|build|ci|docs|style|refactor|perf|test)\!?\: ]]; then
+              echo "PR Title passes"
+          else
+              echo "PR Title does not match conventions:"
+              echo "   verb: description"
+              echo "or for a breaking change:"
+              echo "   verb!: description"
+              exit 1
+          fi
+
+  check-pr-description:
+    name: 'check-pr-description:required'
+    runs-on: ubuntu-24.04
+    env:
+      DESCRIPTION: ${{ github.event.pull_request.body }}
+    steps:
+      - name: 'Check PR Description for Jira/Atlassian Links'
+        run: |
+          if [[ "$DESCRIPTION" =~ https:\/\/[a-zA-Z0-9]*\.(atlassian|jira)\.[a-z]{2,3} ]]; then
+              echo "PR Description contains a link to Jira or Atlassian, which is not allowed."
+              exit 1
+          else
+              echo "PR Description passes"
+          fi


### PR DESCRIPTION
# Motivation

Similar to OISY, we want to ensure that PR titles follow conventional commit semantics and do not contain any links to Jira (which is not public).

# Notes 

The script is similar to the [one](https://github.com/dfinity/oisy-wallet/blob/main/.github/workflows/pr-checks.yml) of OISY minus the `(scope)`.

i.e.

OISY:

```
if [[ "$TITLE" =~ ^(feat|fix|chore|build|ci|docs|style|refactor|perf|test)(\([-a-zA-Z0-9,]+\))\!?\: ]]; then
```

Signer:

```
if [[ "$TITLE" =~ ^(feat|fix|chore|build|ci|docs|style|refactor|perf|test)\!?\: ]]; then
```



