### PR TITLE
Handled nonce is ignored in icrc_49_call_cannister protocol

### DIFF
--- a/src/agent/custom-http-agent.ts
+++ b/src/agent/custom-http-agent.ts
@@ -36,6 +36,7 @@ export class CustomHttpAgent {
   static async create(
     options?: HttpAgentOptions & {
       shouldFetchRootKey?: boolean;
+      useQueryNonces?: boolean;
     }
   ): Promise<CustomHttpAgent> {
     const agent = await HttpAgent.create(options);

--- a/src/api/agent.api.spec.ts
+++ b/src/api/agent.api.spec.ts
@@ -47,7 +47,8 @@ describe('AgentApi', () => {
       expect(CustomHttpAgent.create).toHaveBeenCalledWith({
         identity,
         shouldFetchRootKey: true,
-        host: 'http://localhost:8080'
+        host: 'http://localhost:8080',
+        useQueryNonces: true,
       });
 
       expect(agent).toEqual({test: 'mockCustomAgent'});
@@ -88,7 +89,8 @@ describe('AgentApi', () => {
       expect(CustomHttpAgent.create).toHaveBeenCalledWith({
         identity,
         shouldFetchRootKey: true,
-        host: 'http://localhost:8080'
+        host: 'http://localhost:8080',
+        useQueryNonces: true,
       });
     });
 
@@ -103,7 +105,8 @@ describe('AgentApi', () => {
       expect(CustomHttpAgent.create).toHaveBeenCalledWith({
         identity,
         host: 'https://icp-api.io',
-        shouldFetchRootKey: false
+        shouldFetchRootKey: false,
+        useQueryNonces: true,
       });
     });
 
@@ -117,7 +120,8 @@ describe('AgentApi', () => {
       expect(CustomHttpAgent.create).toHaveBeenCalledWith({
         identity,
         host: 'https://icp-api.io',
-        shouldFetchRootKey: false
+        shouldFetchRootKey: false,
+        useQueryNonces: true,
       });
     });
 
@@ -132,7 +136,8 @@ describe('AgentApi', () => {
       expect(CustomHttpAgent.create).toHaveBeenCalledWith({
         identity,
         shouldFetchRootKey: true,
-        host: 'http://127.0.0.1:8000'
+        host: 'http://127.0.0.1:8000',
+        useQueryNonces: true,
       });
     });
   });

--- a/src/api/agent.api.spec.ts
+++ b/src/api/agent.api.spec.ts
@@ -48,7 +48,7 @@ describe('AgentApi', () => {
         identity,
         shouldFetchRootKey: true,
         host: 'http://localhost:8080',
-        useQueryNonces: true,
+        useQueryNonces: true
       });
 
       expect(agent).toEqual({test: 'mockCustomAgent'});
@@ -90,7 +90,7 @@ describe('AgentApi', () => {
         identity,
         shouldFetchRootKey: true,
         host: 'http://localhost:8080',
-        useQueryNonces: true,
+        useQueryNonces: true
       });
     });
 
@@ -106,7 +106,7 @@ describe('AgentApi', () => {
         identity,
         host: 'https://icp-api.io',
         shouldFetchRootKey: false,
-        useQueryNonces: true,
+        useQueryNonces: true
       });
     });
 
@@ -121,7 +121,7 @@ describe('AgentApi', () => {
         identity,
         host: 'https://icp-api.io',
         shouldFetchRootKey: false,
-        useQueryNonces: true,
+        useQueryNonces: true
       });
     });
 
@@ -137,7 +137,7 @@ describe('AgentApi', () => {
         identity,
         shouldFetchRootKey: true,
         host: 'http://127.0.0.1:8000',
-        useQueryNonces: true,
+        useQueryNonces: true
       });
     });
   });

--- a/src/api/agent.api.ts
+++ b/src/api/agent.api.ts
@@ -32,7 +32,7 @@ export abstract class AgentApi {
       identity,
       host: host ?? MAINNET_REPLICA_URL,
       shouldFetchRootKey,
-      useQueryNonces: true,
+      useQueryNonces: true
     });
   }
 }

--- a/src/api/agent.api.ts
+++ b/src/api/agent.api.ts
@@ -31,7 +31,8 @@ export abstract class AgentApi {
     return await CustomHttpAgent.create({
       identity,
       host: host ?? MAINNET_REPLICA_URL,
-      shouldFetchRootKey
+      shouldFetchRootKey,
+      useQueryNonces: true,
     });
   }
 }

--- a/src/api/icrc21-canister.api.spec.ts
+++ b/src/api/icrc21-canister.api.spec.ts
@@ -151,7 +151,8 @@ describe('icrc-21.canister.api', () => {
       expect(CustomHttpAgent.create).toHaveBeenCalledWith({
         identity: signerOptions.owner,
         host: signerOptions.host,
-        shouldFetchRootKey: true
+        shouldFetchRootKey: true,
+        useQueryNonces: true,
       });
 
       // TODO: spyOn nor function does work with vitest and Actor.createActor. Not against a better idea than disabling eslint for next line.

--- a/src/api/icrc21-canister.api.spec.ts
+++ b/src/api/icrc21-canister.api.spec.ts
@@ -152,7 +152,7 @@ describe('icrc-21.canister.api', () => {
         identity: signerOptions.owner,
         host: signerOptions.host,
         shouldFetchRootKey: true,
-        useQueryNonces: true,
+        useQueryNonces: true
       });
 
       // TODO: spyOn nor function does work with vitest and Actor.createActor. Not against a better idea than disabling eslint for next line.


### PR DESCRIPTION
# Motivation
We need to use a nonce in our ICRC-49 calls. The nonce is arbitrary data (up to 32 bytes) that can be used to create distinct requests with otherwise identical fields.

# Changes
Added `useQueryNonces` to the `HttpAgent` options to automatically generate a nonce parameter for each `icrc49_call_canister` call.

# Tests
Updated the tests to verify that requests are made with the `useQueryNonce` parameter.
