### PR TITLE
Handled nonce is ignored in icrc_49_call_cannister protocol

### DIFF
--- a/src/api/signer.api.ts
+++ b/src/api/signer.api.ts
@@ -13,7 +13,7 @@ export class SignerApi extends Icrc21Canister {
   async call({
     owner,
     host,
-    params: {canisterId, method, arg}
+    params: {canisterId, method, arg, nonce}
   }: {
     params: IcrcCallCanisterRequestParams;
   } & SignerOptions): Promise<IcrcCallCanisterResult> {
@@ -22,7 +22,8 @@ export class SignerApi extends Icrc21Canister {
     const result = await agent.request({
       canisterId,
       method,
-      arg
+      arg,
+      nonce
     });
 
     return this.encodeResult(result);

--- a/src/icp-wallet.spec.ts
+++ b/src/icp-wallet.spec.ts
@@ -5,6 +5,7 @@ import {IcpWallet} from './icp-wallet';
 import {
   mockLocalBlockHeight,
   mockLocalCallParams,
+  mockLocalCallParamswithNonce,
   mockLocalCallResult,
   mockLocalCallTime,
   mockLocalRelyingPartyPrincipal
@@ -14,6 +15,7 @@ import {mockCanisterId} from './mocks/icrc-accounts.mocks';
 import {
   mockIcrc2ApproveLocalBlockHeight,
   mockIcrc2ApproveLocalCallParams,
+  mockIcrc2ApproveLocalCallParamsWithNonce,
   mockIcrc2ApproveLocalCallResult,
   mockIcrc2ApproveLocalCallTime,
   mockIcrc2LocalIcRootKey,
@@ -105,6 +107,7 @@ describe('icp-wallet', () => {
     };
 
     const {sender} = mockLocalCallParams;
+    const {nonce} = mockLocalCallParamswithNonce;
 
     beforeEach(() => {
       vi.setSystemTime(mockLocalCallTime);
@@ -218,6 +221,25 @@ describe('icp-wallet', () => {
 
       spy.mockRestore();
     });
+
+    it('should include nonce in call parameters when provided', async () => {
+      const mockCall = vi.fn().mockResolvedValue(mockLocalCallParamswithNonce);
+
+      // @ts-expect-error we mock call for testing purposes
+      icpWallet.call = mockCall;
+
+      const spy = vi
+        .spyOn(callUtils, 'decodeResponse')
+        .mockResolvedValue({Ok: mockLocalBlockHeight});
+
+      await icpWallet.icrc1Transfer({request, owner: sender, nonce});
+
+      expect(mockCall).toHaveBeenCalledWith({
+        params: mockLocalCallParamswithNonce
+      });
+
+      spy.mockRestore();
+    });
   });
 
   describe('icrc2Approve', () => {
@@ -231,6 +253,7 @@ describe('icp-wallet', () => {
     };
 
     const {sender} = mockIcrc2ApproveLocalCallParams;
+    const {nonce} = mockIcrc2ApproveLocalCallParamsWithNonce;
 
     beforeEach(() => {
       vi.setSystemTime(mockIcrc2ApproveLocalCallTime);
@@ -341,6 +364,25 @@ describe('icp-wallet', () => {
           host: mockParameters.host
         })
       );
+
+      spy.mockRestore();
+    });
+
+    it('should include nonce in call parameters when provided', async () => {
+      const mockCall = vi.fn().mockResolvedValue(mockIcrc2ApproveLocalCallParamsWithNonce);
+
+      // @ts-expect-error we mock call for testing purposes
+      icpWallet.call = mockCall;
+
+      const spy = vi
+        .spyOn(callUtils, 'decodeResponse')
+        .mockResolvedValue({Ok: mockIcrc2ApproveLocalBlockHeight});
+
+      await icpWallet.icrc2Approve({request, owner: sender, nonce});
+
+      expect(mockCall).toHaveBeenCalledWith({
+        params: mockIcrc2ApproveLocalCallParamsWithNonce
+      });
 
       spy.mockRestore();
     });

--- a/src/icp-wallet.ts
+++ b/src/icp-wallet.ts
@@ -61,12 +61,14 @@ export class IcpWallet extends RelyingParty {
     request,
     owner,
     ledgerCanisterId,
-    options
+    options,
+    nonce
   }: {
     options?: RelyingPartyRequestOptions;
     request: Icrc1TransferRequest;
     ledgerCanisterId?: PrincipalText;
-  } & Pick<IcrcAccount, 'owner'>): Promise<BlockHeight> => {
+  } & Pick<IcrcAccount, 'owner'> &
+    Pick<IcrcCallCanisterRequestParams, 'nonce'>): Promise<BlockHeight> => {
     // TODO: should we convert ic-js to zod? or should we map Icrc1TransferRequest to zod?
     const rawArgs = toIcrc1TransferRawRequest(request);
 
@@ -83,7 +85,8 @@ export class IcpWallet extends RelyingParty {
       sender: owner,
       method,
       canisterId,
-      arg
+      arg,
+      nonce
     };
 
     // TODO: uncomment nonce and add TODO - not yet supported by agent-js
@@ -111,12 +114,14 @@ export class IcpWallet extends RelyingParty {
     request,
     owner,
     ledgerCanisterId,
-    options
+    options,
+    nonce
   }: {
     options?: RelyingPartyRequestOptions;
     request: Icrc2ApproveRequest;
     ledgerCanisterId?: PrincipalText;
-  } & Pick<IcrcAccount, 'owner'>): Promise<BlockHeight> => {
+  } & Pick<IcrcAccount, 'owner'> &
+    Pick<IcrcCallCanisterRequestParams, 'nonce'>): Promise<BlockHeight> => {
     const rawArgs = toIcrc2ApproveRawRequest(request);
 
     const arg = encodeIdl({
@@ -132,7 +137,8 @@ export class IcpWallet extends RelyingParty {
       sender: owner,
       method,
       canisterId,
-      arg
+      arg,
+      nonce
     };
 
     // TODO: uncomment nonce and add TODO - not yet supported by agent-js

--- a/src/icrc-wallet.spec.ts
+++ b/src/icrc-wallet.spec.ts
@@ -9,10 +9,15 @@ import {
   mockLocalRelyingPartyPrincipal
 } from './mocks/call-utils.mocks';
 import {mockLocalIcRootKey} from './mocks/custom-http-agent-responses.mocks';
-import {mockIcrcLocalCallParams, mockLedgerCanisterId} from './mocks/icrc-call-utils.mocks';
+import {
+  mockIcrcLocalCallParams,
+  mockIcrcLocalCallParamsWithNonce,
+  mockLedgerCanisterId
+} from './mocks/icrc-call-utils.mocks';
 import {
   mockIcrc2ApproveLocalBlockHeight,
   mockIcrc2ApproveLocalCallParams,
+  mockIcrc2ApproveLocalCallParamsWithNonce,
   mockIcrc2ApproveLocalCallResult,
   mockIcrc2ApproveLocalCallTime,
   mockIcrc2LocalIcRootKey,
@@ -20,6 +25,7 @@ import {
   mockIcrc2LocalWalletPrincipal,
   mockIcrc2TransferFromLocalBlockHeight,
   mockIcrc2TransferFromLocalCallParams,
+  mockIcrc2TransferFromLocalCallParamsWithNonce,
   mockIcrc2TransferFromLocalCallResult,
   mockIcrc2TransferFromLocalCallTime
 } from './mocks/icrc2-call-utils.mocks';
@@ -109,6 +115,7 @@ describe('icrc-wallet', () => {
     };
 
     const {sender} = mockIcrcLocalCallParams;
+    const {nonce} = mockIcrcLocalCallParamsWithNonce;
 
     beforeEach(() => {
       vi.setSystemTime(mockLocalCallTime);
@@ -215,6 +222,29 @@ describe('icrc-wallet', () => {
 
       spy.mockRestore();
     });
+
+    it('should include nonce in call parameters when provided', async () => {
+      const mockCall = vi.fn().mockResolvedValue(mockLocalCallResult);
+      // @ts-expect-error we mock call for testing purposes
+      icrcWallet.call = mockCall;
+
+      const spy = vi
+        .spyOn(callUtils, 'decodeResponse')
+        .mockResolvedValue({Ok: mockLocalBlockHeight});
+
+      await icrcWallet.transfer({
+        params,
+        owner: sender,
+        ledgerCanisterId: mockLedgerCanisterId,
+        nonce
+      });
+
+      expect(mockCall).toHaveBeenCalledWith({
+        params: mockIcrcLocalCallParamsWithNonce
+      });
+
+      spy.mockRestore();
+    });
   });
 
   describe('approve', () => {
@@ -228,6 +258,7 @@ describe('icrc-wallet', () => {
     };
 
     const {sender} = mockIcrc2ApproveLocalCallParams;
+    const {nonce} = mockIcrc2ApproveLocalCallParamsWithNonce;
 
     beforeEach(() => {
       vi.setSystemTime(mockIcrc2ApproveLocalCallTime);
@@ -334,6 +365,31 @@ describe('icrc-wallet', () => {
 
       spy.mockRestore();
     });
+
+    // In the "approve" describe block:
+    // In the "approve" describe block:
+    it('should include nonce in call parameters when provided', async () => {
+      const mockCall = vi.fn().mockResolvedValue(mockIcrc2ApproveLocalCallParamsWithNonce);
+      // @ts-expect-error we mock call for testing purposes
+      icrcWallet.call = mockCall;
+
+      const spy = vi
+        .spyOn(callUtils, 'decodeResponse')
+        .mockResolvedValue({Ok: mockIcrc2ApproveLocalBlockHeight});
+
+      await icrcWallet.approve({
+        params,
+        owner: sender,
+        ledgerCanisterId: mockLedgerCanisterId,
+        nonce
+      });
+
+      expect(mockCall).toHaveBeenCalledWith({
+        params: mockIcrc2ApproveLocalCallParamsWithNonce
+      });
+
+      spy.mockRestore();
+    });
   });
 
   describe('transferFrom', () => {
@@ -350,6 +406,7 @@ describe('icrc-wallet', () => {
     };
 
     const {sender} = mockIcrc2TransferFromLocalCallParams;
+    const {nonce} = mockIcrc2TransferFromLocalCallParamsWithNonce;
 
     beforeEach(() => {
       vi.setSystemTime(mockIcrc2TransferFromLocalCallTime);
@@ -453,6 +510,30 @@ describe('icrc-wallet', () => {
           host: mockParameters.host
         })
       );
+
+      spy.mockRestore();
+    });
+
+    // In the "transferFrom" describe block:
+    it('should include nonce in call parameters when provided', async () => {
+      const mockCall = vi.fn().mockResolvedValue(mockIcrc2TransferFromLocalCallParamsWithNonce);
+      // @ts-expect-error we mock call for testing purposes
+      icrcWallet.call = mockCall;
+
+      const spy = vi
+        .spyOn(callUtils, 'decodeResponse')
+        .mockResolvedValue({Ok: mockIcrc2TransferFromLocalBlockHeight});
+
+      await icrcWallet.transferFrom({
+        params,
+        owner: sender,
+        ledgerCanisterId: mockLedgerCanisterId,
+        nonce
+      });
+
+      expect(mockCall).toHaveBeenCalledWith({
+        params: mockIcrc2TransferFromLocalCallParamsWithNonce
+      });
 
       spy.mockRestore();
     });

--- a/src/icrc-wallet.ts
+++ b/src/icrc-wallet.ts
@@ -66,12 +66,14 @@ export class IcrcWallet extends RelyingParty {
     params,
     owner,
     ledgerCanisterId: canisterId,
-    options
+    options,
+    nonce
   }: {
     params: TransferParams;
     ledgerCanisterId: PrincipalText;
     options?: RelyingPartyRequestOptions;
-  } & Pick<IcrcAccount, 'owner'>): Promise<IcrcBlockIndex> => {
+  } & Pick<IcrcAccount, 'owner'> &
+    Pick<IcrcCallCanisterRequestParams, 'nonce'>): Promise<IcrcBlockIndex> => {
     const rawArgs = toTransferArg(params);
 
     const arg = encodeIdl({
@@ -83,7 +85,8 @@ export class IcrcWallet extends RelyingParty {
       sender: owner,
       method: 'icrc1_transfer',
       canisterId,
-      arg
+      arg,
+      nonce
     };
 
     const callResult = await this.call({
@@ -127,12 +130,14 @@ export class IcrcWallet extends RelyingParty {
     params,
     owner,
     ledgerCanisterId: canisterId,
-    options
+    options,
+    nonce
   }: {
     params: ApproveParams;
     ledgerCanisterId: PrincipalText;
     options?: RelyingPartyRequestOptions;
-  } & Pick<IcrcAccount, 'owner'>): Promise<IcrcBlockIndex> => {
+  } & Pick<IcrcAccount, 'owner'> &
+    Pick<IcrcCallCanisterRequestParams, 'nonce'>): Promise<IcrcBlockIndex> => {
     const rawArgs = toApproveArgs(params);
 
     const arg = encodeIdl({
@@ -144,7 +149,8 @@ export class IcrcWallet extends RelyingParty {
       sender: owner,
       method: 'icrc2_approve',
       canisterId,
-      arg
+      arg,
+      nonce
     };
 
     const callResult = await this.call({
@@ -188,12 +194,14 @@ export class IcrcWallet extends RelyingParty {
     params,
     owner,
     ledgerCanisterId: canisterId,
-    options
+    options,
+    nonce
   }: {
     params: TransferFromParams;
     ledgerCanisterId: PrincipalText;
     options?: RelyingPartyRequestOptions;
-  } & Pick<IcrcAccount, 'owner'>): Promise<IcrcBlockIndex> => {
+  } & Pick<IcrcAccount, 'owner'> &
+    Pick<IcrcCallCanisterRequestParams, 'nonce'>): Promise<IcrcBlockIndex> => {
     const rawArgs = toTransferFromArgs(params);
 
     const arg = encodeIdl({
@@ -205,7 +213,8 @@ export class IcrcWallet extends RelyingParty {
       sender: owner,
       method: 'icrc2_transfer_from',
       canisterId,
-      arg
+      arg,
+      nonce
     };
 
     const callResult = await this.call({

--- a/src/mocks/call-utils.mocks.ts
+++ b/src/mocks/call-utils.mocks.ts
@@ -16,6 +16,14 @@ export const mockLocalCallParams: IcrcCallCanisterRequestParams = {
   sender: 'f2uoh-ddrrp-y5mqp-dwbtm-y67ln-pslmx-esrv3-ttjch-uvxie-mvgcb-4qe'
 };
 
+export const mockLocalCallParamswithNonce: IcrcCallCanisterRequestParams = {
+  arg: 'RElETAZte24AbAKzsNrDA2ithsqDBQFufW54bAb7ygECxvy2AgO6ieXCBAGi3pTrBgGC8/ORDATYo4yoDX0BBQEdP0Duk4WbdYJC1svDpO9SpE+aElxKU7FNBuH2LAIAAZBOAAAAwJaxAg==',
+  nonce: 'RElBuH2BOAAAAwJaxAg==',
+  canisterId: 'ryjl3-tyaaa-aaaaa-aaaba-cai',
+  method: 'icrc1_transfer',
+  sender: 'f2uoh-ddrrp-y5mqp-dwbtm-y67ln-pslmx-esrv3-ttjch-uvxie-mvgcb-4qe'
+};
+
 export const mockLocalCallResult: IcrcCallCanisterResult = {
   certificate:
     '2dn3omlzaWduYXR1cmVYMIRlD8DyLTRm4cNY6ZYOIyTx/5MZ7bGHm2unaMz/78KwFhA++pJExycUC+ZdrleFtGR0cmVlgwGDAYIEWCBnoHoMNr/grlp/CTec5CDL8m2lBsedNjlIbnPEmQxfw4MBggRYIPQ0BrYO1QSm0QyNoDRxrTtwUFsidOwark3+6UV+JtxcgwJOcmVxdWVzdF9zdGF0dXODAYMBggRYIHmgpM2nhmBMmPTLNI4WwCwObyUBWpO58wQwfhjJhJDAgwGDAlggQBd9b5Wer4jblY8wZ41iWRNkXZT9L37cT9l1rL+cJv+DAYMCRXJlcGx5ggNYe0RJREwIawK8igF9xf7SAQFrCNHEmHwCwpHsuQJ/lMHHiQQD64KolwQEocPr/QcF8Ifm2wkGk+W+yAx/65zb1Q8HbALH68TQCXHEmLG1DX1sAZuzvqYKfWwBi73ymwF9bAG/m7fwDX1sAaO7kYwKeGwBnLq2nAJ9AQAAcoMCRnN0YXR1c4IDR3JlcGxpZWSCBFggf+PvzTp6ZYO4iR1pdq/Y8YNeG4MEPJXP4L8gGVbqOZmCBFggVwwB8Q5BRZqLTjr4nQIwBlx0QLT5Tm15csdqVWMZWn2DAYIEWCDf3DBRUg7g1jtKxYGDfk+uS85noU/fMxkHfyyhi82vfoMCRHRpbWWCA0nezZjXi6ip/Rc=',

--- a/src/mocks/custom-http-agent.mocks.ts
+++ b/src/mocks/custom-http-agent.mocks.ts
@@ -16,6 +16,16 @@ export const mockRequestPayload: Pick<
   method: mockRequestMethod
 };
 
+export const mockRequestPayloadWithNonce: Pick<
+  IcrcCallCanisterRequestParams,
+  'canisterId' | 'method' | 'arg' | 'nonce'
+> = {
+  arg: uint8ArrayToBase64(new Uint8Array([1, 2, 3, 4])),
+  nonce: uint8ArrayToBase64(new Uint8Array([1, 4, 5, 2])),
+  canisterId: mockCanisterId,
+  method: mockRequestMethod
+};
+
 export const mockRequestDetails: CallRequest = {
   arg: new Uint8Array([68, 73, 68, 76, 6, 109, 123, 110, 0, 108]),
   canister_id: Principal.fromText(mockCanisterId),

--- a/src/mocks/icrc-call-utils.mocks.ts
+++ b/src/mocks/icrc-call-utils.mocks.ts
@@ -7,3 +7,10 @@ export const mockIcrcLocalCallParams = {
   canisterId: mockLedgerCanisterId,
   arg: 'RElETAZte24AbAKzsNrDA2ithsqDBQFufW54bAb7ygECxvy2AgO6ieXCBAGi3pTrBgGC8/ORDATYo4yoDX0BBQEdP0Duk4WbdYJC1svDpO9SpE+aElxKU7FNBuH2LAIAAAAAAMCWsQI='
 };
+
+export const mockIcrcLocalCallParamsWithNonce = {
+  ...mockLocalCallParams,
+  canisterId: mockLedgerCanisterId,
+  arg: 'RElETAZte24AbAKzsNrDA2ithsqDBQFufW54bAb7ygECxvy2AgO6ieXCBAGi3pTrBgGC8/ORDATYo4yoDX0BBQEdP0Duk4WbdYJC1svDpO9SpE+aElxKU7FNBuH2LAIAAAAAAMCWsQI=',
+  nonce: 'RElBuH2BOAAAAwJaxAg=='
+};

--- a/src/mocks/icrc2-call-utils.mocks.ts
+++ b/src/mocks/icrc2-call-utils.mocks.ts
@@ -28,6 +28,14 @@ export const mockIcrc2ApproveLocalCallParams = {
   arg: 'RElETAZufW17bgFueGwCs7DawwNorYbKgwUCbAjG/LYCALqJ5cIEAqLelOsGAoLz85EMA9ijjKgNfZGcnL8NAN6n99oNA8uW3LQOBAEFAZBOAAAAgOHrFwAAAR1wrhf9pp3iZ9Bw1WInTn+Deg5NH72sw5brmCMkAgA='
 };
 
+export const mockIcrc2ApproveLocalCallParamsWithNonce = {
+  sender: mockIcrc2LocalWalletPrincipal.toText(),
+  method: 'icrc2_approve',
+  canisterId: mockLedgerCanisterId,
+  arg: 'RElETAZufW17bgFueGwCs7DawwNorYbKgwUCbAjG/LYCALqJ5cIEAqLelOsGAoLz85EMA9ijjKgNfZGcnL8NAN6n99oNA8uW3LQOBAEFAZBOAAAAgOHrFwAAAR1wrhf9pp3iZ9Bw1WInTn+Deg5NH72sw5brmCMkAgA=',
+  nonce: 'RElET7DawwNorYbKgwUCAgA='
+};
+
 export const mockIcrc2ApproveLocalCallResult: IcrcCallCanisterResult = {
   certificate:
     '2dn3omlzaWduYXR1cmVYMIC3logCob8DYcIFy9gebO0DvZVd2iccOAz5AHL3aAxsYCZThCisjNBEyONoQv0DPWR0cmVlgwGDAYIEWCAS9O1o7R14YUVtryMC6wOuqmjDSDbx9KmJQHyCDPd+VYMBggRYIL82mnbOr7Ko9rvdYzaGWcIiOsRbiHRqrB66XO9NBFHngwJOcmVxdWVzdF9zdGF0dXODAYIEWCAHPsrkYM5hgpPtyoKK/NOHGHctkzcEZfRc2gdsdJqe9IMBggRYIFM7zdSXahl4OcOAf1cZZln87BKyv4WzJhBF27kKpiR+gwJYIPcCRu6ehaKC8oNJ55f+vDizz1uJejM/bnYIck6iFlAsgwGDAkVyZXBseYIDWIFESURMCGsCvIoBfcX+0gEBawnRxJh8AsKR7LkCf+uCqJcEA6HD6/0HBJyE6PwIBfCH5tsJBpPlvsgMf4WP7pUPBuuc29UPB2wCx+vE0AlxxJixtQ19bAGLvfKbAX1sAb+bt/ANfWwBkq7O5Q99bAGju5GMCnhsAZy6tpwCfQEAAAiDAkZzdGF0dXOCA0dyZXBsaWVkgwGCBFggsSMhqVzG1RvK/79hnq0Fwcpekky581QV2c0zi57paLCDAkR0aW1lggNJ69ajhMbo/IoY',
@@ -45,6 +53,13 @@ export const mockIcrc2TransferFromLocalCallParams = {
   ...mockIcrc2ApproveLocalCallParams,
   method: 'icrc2_transfer_from',
   arg: 'RElETAZte24AbAKzsNrDA2ithsqDBQFufW54bAf7ygECxvy2AgPhhcGUAgHqyoqeBAK6ieXCBAGC8/ORDATYo4yoDX0BBQEdcK4X/aad4mfQcNViJ05/g3oOTR+9rMOW65gjJAIAAAABHf20rMt4azj3bZ3NzvryHiiKwr6v1kT6ns4Zi0cCAAAAwPD1Cw=='
+};
+
+export const mockIcrc2TransferFromLocalCallParamsWithNonce = {
+  ...mockIcrc2ApproveLocalCallParams,
+  method: 'icrc2_transfer_from',
+  arg: 'RElETAZte24AbAKzsNrDA2ithsqDBQFufW54bAf7ygECxvy2AgPhhcGUAgHqyoqeBAK6ieXCBAGC8/ORDATYo4yoDX0BBQEdcK4X/aad4mfQcNViJ05/g3oOTR+9rMOW65gjJAIAAAABHf20rMt4azj3bZ3NzvryHiiKwr6v1kT6ns4Zi0cCAAAAwPD1Cw==',
+  nonce: 'RElET7DawwNorYbKgwUCAgA='
 };
 
 export const mockIcrc2TransferFromLocalCallResult: IcrcCallCanisterResult = {


### PR DESCRIPTION
# Motivation

We needed to improve security by ensuring that a nonce is properly injected into ICRC-49 calls.
The nonce is arbitrary data (up to 32 bytes) that can be used to create distinct requests with otherwise identical fields.

# Changes

The request payload is now transformed to include the nonce, ensuring it is correctly encoded and added via a transform function.

# Tests

New unit tests verify that the nonce is passed through call parameters in wallet methods and that the custom HTTP agent correctly registers and applies the nonce transform.