### PR TITLE
feat: added new method addTransfrom to add nonce to icrc_49_call_canister call params

### DIFF
--- a/src/agent/custom-http-agent.spec.ts
+++ b/src/agent/custom-http-agent.spec.ts
@@ -1,6 +1,6 @@
 import * as httpAgent from '@dfinity/agent';
 import {RequestId, SubmitResponse} from '@dfinity/agent';
-import {base64ToUint8Array} from '@dfinity/utils';
+import {base64ToUint8Array, uint8ArrayToBase64} from '@dfinity/utils';
 import {MockInstance} from 'vitest';
 import {
   mockLocalIcRootKey,
@@ -32,6 +32,7 @@ vi.mock('@dfinity/agent', async (importOriginal) => {
   class MockHttpAgent {
     call = vi.fn();
     create = vi.fn();
+    addTransform = vi.fn();
 
     get rootKey(): ArrayBuffer {
       return mockLocalIcRootKey.buffer;
@@ -156,6 +157,53 @@ describe('CustomHttpAgent', () => {
           expect(response.certificate).toEqual(certificate);
           expect(response.requestDetails).toEqual(mockRequestDetails);
         });
+      });
+
+      it('should call transform if a nonce is provided', async () => {
+        const spyTransform = vi.spyOn(agent.agent, 'addTransform');
+
+        const nonce = uint8ArrayToBase64(httpAgent.makeNonce());
+
+        await agent.request({
+          ...mockRequestPayload,
+          nonce
+        });
+
+        expect(spyTransform).toHaveBeenCalledOnce();
+        expect(spyTransform).toHaveBeenCalledWith('update', expect.any(Function));
+
+        const [[firstArg, secondArg]] = spyTransform.mock.calls;
+
+        expect(firstArg).toBe('update');
+        expect(secondArg).toBeInstanceOf(Function);
+
+        enum Endpoint {
+          Query = 'read',
+          ReadState = 'read_state',
+          Call = 'call'
+        }
+
+        const mockRequest = {
+          endpoint: Endpoint.Call,
+          request: {
+            headers: new Map()
+          },
+          body: {nonce: []}
+        };
+
+        await secondArg(mockRequest as unknown as httpAgent.HttpAgentSubmitRequest);
+
+        expect(mockRequest.body.nonce).toEqual(base64ToUint8Array(nonce));
+      });
+
+      it('should not call transform if nonce is not provided', async () => {
+        const spyTransform = vi.spyOn(agent.agent, 'addTransform');
+
+        await agent.request({
+          ...mockRequestPayload
+        });
+
+        expect(spyTransform).not.toHaveBeenCalled();
       });
 
       describe('Invalid response', () => {
@@ -332,6 +380,53 @@ describe('CustomHttpAgent', () => {
 
             expect(spyPollForResponse).toHaveBeenCalledOnce();
           });
+        });
+
+        it('should call transform if a nonce is provided', async () => {
+          const spyTransform = vi.spyOn(agent.agent, 'addTransform');
+
+          const nonce = uint8ArrayToBase64(httpAgent.makeNonce());
+
+          await agent.request({
+            ...mockRequestPayload,
+            nonce
+          });
+
+          expect(spyTransform).toHaveBeenCalledOnce();
+          expect(spyTransform).toHaveBeenCalledWith('update', expect.any(Function));
+
+          const [[firstArg, secondArg]] = spyTransform.mock.calls;
+
+          expect(firstArg).toBe('update');
+          expect(secondArg).toBeInstanceOf(Function);
+
+          enum Endpoint {
+            Query = 'read',
+            ReadState = 'read_state',
+            Call = 'call'
+          }
+
+          const mockRequest = {
+            endpoint: Endpoint.Call,
+            request: {
+              headers: new Map()
+            },
+            body: {nonce: []}
+          };
+
+          await secondArg(mockRequest as unknown as httpAgent.HttpAgentSubmitRequest);
+
+          expect(mockRequest.body.nonce).toEqual(base64ToUint8Array(nonce));
+        });
+
+        it('should not call transform if nonce is not provided', async () => {
+          const spyTransform = vi.spyOn(agent.agent, 'addTransform');
+
+          await agent.request({
+            ...mockRequestPayload
+          });
+
+          expect(spyTransform).not.toHaveBeenCalled();
         });
 
         describe('Invalid response', () => {

--- a/src/agent/custom-http-agent.ts
+++ b/src/agent/custom-http-agent.ts
@@ -1,6 +1,8 @@
 import {
   Certificate,
   HttpAgent,
+  HttpAgentRequest,
+  Nonce,
   defaultStrategy,
   lookupResultToBuffer,
   pollForResponse as pollForResponseAgent,
@@ -52,12 +54,18 @@ export class CustomHttpAgent {
   request = async ({
     arg,
     canisterId,
-    method: methodName
+    method: methodName,
+    nonce
   }: Pick<
     // This could have been made agnostic by inlining the types here, but for simplicity and because they are strongly typed, I decided to reuse the interface.
     IcrcCallCanisterRequestParams,
-    'canisterId' | 'method' | 'arg'
+    'canisterId' | 'method' | 'arg' | 'nonce'
   >): Promise<CustomHttpAgentResponse> => {
+    if (nonNullish(nonce)) {
+      const formattedNonce = base64ToUint8Array(nonce) as Nonce;
+      this.addNonceTransform(formattedNonce);
+    }
+
     const {requestDetails, ...restResponse} = await this.#agent.call(canisterId, {
       methodName,
       arg: base64ToUint8Array(arg),
@@ -196,5 +204,21 @@ export class CustomHttpAgent {
     );
 
     return {certificate, requestDetails};
+  }
+
+  private addNonceTransform(nonce: Nonce): void {
+    this.#agent.addTransform('update', (args): Promise<HttpAgentRequest> => {
+      if (args.endpoint !== 'call') {
+        return Promise.resolve(args);
+      }
+
+      return Promise.resolve({
+        ...args,
+        body: {
+          ...args.body,
+          nonce
+        }
+      });
+    });
   }
 }


### PR DESCRIPTION
# Motivation

We needed to improve security by ensuring that a nonce is properly injected into ICRC-49 calls.
The nonce is arbitrary data (up to 32 bytes) that can be used to create distinct requests with otherwise identical fields.

# Changes

The request payload is now transformed to include the nonce, ensuring it is correctly encoded and injected via a transform function.

# Tests

All tests have been run successfully.