### PR TITLE
feat: added nonce parameter to signer.api call method

### DIFF
--- a/src/api/signer.api.spec.ts
+++ b/src/api/signer.api.spec.ts
@@ -62,7 +62,7 @@ describe('Signer-api', () => {
       expect(result).toEqual(mockCallCanisterSuccess);
     });
 
-    it('should call request wiht nonce if nonce is provided', async () => {
+    it('should call request with nonce if nonce is provided', async () => {
       const agent = await CustomHttpAgent.create();
       const spy = vi.spyOn(agent, 'request');
       const nonce = uint8ArrayToBase64(httpAgent.makeNonce());

--- a/src/api/signer.api.spec.ts
+++ b/src/api/signer.api.spec.ts
@@ -2,6 +2,7 @@ import * as httpAgent from '@dfinity/agent';
 import {Ed25519KeyIdentity} from '@dfinity/identity';
 import {IcrcLedgerCanister} from '@dfinity/ledger-icrc';
 import {Principal} from '@dfinity/principal';
+import {uint8ArrayToBase64} from '@dfinity/utils';
 import {mockCallCanisterSuccess} from '../mocks/call-canister.mocks';
 import {mockRepliedLocalCertificate} from '../mocks/custom-http-agent-responses.mocks';
 import {mockRequestDetails, mockRequestPayload} from '../mocks/custom-http-agent.mocks';
@@ -48,11 +49,25 @@ describe('Signer-api', () => {
   });
 
   describe('call', () => {
-    it('should call request and return the properly encoded result', async () => {
+    it('should call request and return the properly encoded result if nonce not provided', async () => {
       const result = await signerApi.call({
         params: {
           ...mockRequestPayload,
           sender: identity.getPrincipal().toText()
+        },
+        ...signerOptions
+      });
+
+      expect(result).toEqual(mockCallCanisterSuccess);
+    });
+
+    it('should call request and return the properly encoded result if nonce not provided', async () => {
+      const nonce = uint8ArrayToBase64(httpAgent.makeNonce());
+      const result = await signerApi.call({
+        params: {
+          ...mockRequestPayload,
+          sender: identity.getPrincipal().toText(),
+          nonce
         },
         ...signerOptions
       });

--- a/src/api/signer.api.spec.ts
+++ b/src/api/signer.api.spec.ts
@@ -3,6 +3,7 @@ import {Ed25519KeyIdentity} from '@dfinity/identity';
 import {IcrcLedgerCanister} from '@dfinity/ledger-icrc';
 import {Principal} from '@dfinity/principal';
 import {uint8ArrayToBase64} from '@dfinity/utils';
+import {CustomHttpAgent} from '../agent/custom-http-agent';
 import {mockCallCanisterSuccess} from '../mocks/call-canister.mocks';
 import {mockRepliedLocalCertificate} from '../mocks/custom-http-agent-responses.mocks';
 import {mockRequestDetails, mockRequestPayload} from '../mocks/custom-http-agent.mocks';
@@ -49,7 +50,7 @@ describe('Signer-api', () => {
   });
 
   describe('call', () => {
-    it('should call request and return the properly encoded result if nonce not provided', async () => {
+    it('should call request and return the properly encoded result', async () => {
       const result = await signerApi.call({
         params: {
           ...mockRequestPayload,
@@ -61,9 +62,12 @@ describe('Signer-api', () => {
       expect(result).toEqual(mockCallCanisterSuccess);
     });
 
-    it('should call request and return the properly encoded result if nonce not provided', async () => {
+    it('should call request wiht nonce if nonce is provided', async () => {
+      const agent = await CustomHttpAgent.create();
+      const spy = vi.spyOn(agent, 'request');
       const nonce = uint8ArrayToBase64(httpAgent.makeNonce());
-      const result = await signerApi.call({
+
+      await signerApi.call({
         params: {
           ...mockRequestPayload,
           sender: identity.getPrincipal().toText(),
@@ -72,7 +76,7 @@ describe('Signer-api', () => {
         ...signerOptions
       });
 
-      expect(result).toEqual(mockCallCanisterSuccess);
+      expect(spy).toHaveBeenCalledWith(expect.objectContaining({nonce}));
     });
   });
 

--- a/src/api/signer.api.ts
+++ b/src/api/signer.api.ts
@@ -13,7 +13,7 @@ export class SignerApi extends Icrc21Canister {
   async call({
     owner,
     host,
-    params: {canisterId, method, arg}
+    params: {canisterId, method, arg, nonce}
   }: {
     params: IcrcCallCanisterRequestParams;
   } & SignerOptions): Promise<IcrcCallCanisterResult> {
@@ -22,7 +22,8 @@ export class SignerApi extends Icrc21Canister {
     const result = await agent.request({
       canisterId,
       method,
-      arg
+      arg,
+      nonce
     });
 
     return this.encodeResult(result);


### PR DESCRIPTION
# Motivation

We needed to improve security by ensuring that a nonce is properly injected into ICRC-49 calls.
The nonce is arbitrary data (up to 32 bytes) that can be used to create distinct requests with otherwise identical fields.

# Changes

- Updated the SignerApi.call method to accept an optional nonce property.
- Updated tests to cover both cases: with and without the nonce.

# Tests

Added new unit test to cover new logic.
