### PR TITLE
feat: added nonceTransform to reassign value for nonce

### DIFF
--- a/src/agent/custom-http-agent.spec.ts
+++ b/src/agent/custom-http-agent.spec.ts
@@ -446,6 +446,43 @@ describe('CustomHttpAgent', () => {
           expect(mockRequest.body.nonce).toEqual(base64ToUint8Array(nonce));
         });
 
+        it('should call transform when no nonce is provided and reassign a new nonce', async () => {
+          const spyTransform = vi.spyOn(agent.agent, 'addTransform');
+          const spyMakeNonce = vi.spyOn(httpAgent, 'makeNonce');
+
+          await agent.request({
+            ...mockRequestPayload
+          });
+
+          expect(spyTransform).toHaveBeenCalledOnce();
+          expect(spyTransform).toHaveBeenCalledWith('update', expect.any(Function));
+
+          const [[firstArg, secondArg]] = spyTransform.mock.calls;
+
+          expect(firstArg).toBe('update');
+          expect(secondArg).toBeInstanceOf(Function);
+
+          enum Endpoint {
+            Query = 'read',
+            ReadState = 'read_state',
+            Call = 'call'
+          }
+
+          const mockRequest = {
+            endpoint: Endpoint.Call,
+            request: {
+              headers: new Map()
+            },
+            body: {nonce: []}
+          };
+
+          await secondArg(mockRequest as unknown as httpAgent.HttpAgentSubmitRequest);
+
+          const nonceValue = spyMakeNonce.mock.results[0].value;
+
+          expect(mockRequest.body.nonce).toEqual(nonceValue);
+        });
+
         describe('Invalid response', () => {
           it('should throw UndefinedRequestDetailsError if requestDetails is null', async () => {
             spyCall.mockResolvedValue({

--- a/src/agent/custom-http-agent.spec.ts
+++ b/src/agent/custom-http-agent.spec.ts
@@ -196,14 +196,41 @@ describe('CustomHttpAgent', () => {
         expect(mockRequest.body.nonce).toEqual(base64ToUint8Array(nonce));
       });
 
-      it('should not call transform if nonce is not provided', async () => {
+      it('should call transform when no nonce is provided and reassign a new nonce', async () => {
         const spyTransform = vi.spyOn(agent.agent, 'addTransform');
+        const spyMakeNonce = vi.spyOn(httpAgent, 'makeNonce');
 
         await agent.request({
           ...mockRequestPayload
         });
 
-        expect(spyTransform).not.toHaveBeenCalled();
+        expect(spyTransform).toHaveBeenCalledOnce();
+        expect(spyTransform).toHaveBeenCalledWith('update', expect.any(Function));
+
+        const [[firstArg, secondArg]] = spyTransform.mock.calls;
+
+        expect(firstArg).toBe('update');
+        expect(secondArg).toBeInstanceOf(Function);
+
+        enum Endpoint {
+          Query = 'read',
+          ReadState = 'read_state',
+          Call = 'call'
+        }
+
+        const mockRequest = {
+          endpoint: Endpoint.Call,
+          request: {
+            headers: new Map()
+          },
+          body: {nonce: []}
+        };
+
+        await secondArg(mockRequest as unknown as httpAgent.HttpAgentSubmitRequest);
+
+        const nonceValue = spyMakeNonce.mock.results[0].value;
+
+        expect(mockRequest.body.nonce).toEqual(nonceValue);
       });
 
       describe('Invalid response', () => {
@@ -417,16 +444,6 @@ describe('CustomHttpAgent', () => {
           await secondArg(mockRequest as unknown as httpAgent.HttpAgentSubmitRequest);
 
           expect(mockRequest.body.nonce).toEqual(base64ToUint8Array(nonce));
-        });
-
-        it('should not call transform if nonce is not provided', async () => {
-          const spyTransform = vi.spyOn(agent.agent, 'addTransform');
-
-          await agent.request({
-            ...mockRequestPayload
-          });
-
-          expect(spyTransform).not.toHaveBeenCalled();
         });
 
         describe('Invalid response', () => {

--- a/src/agent/custom-http-agent.ts
+++ b/src/agent/custom-http-agent.ts
@@ -4,6 +4,7 @@ import {
   Nonce,
   defaultStrategy,
   lookupResultToBuffer,
+  makeNonce,
   makeNonceTransform,
   pollForResponse as pollForResponseAgent,
   type CallRequest,
@@ -201,7 +202,8 @@ export class CustomHttpAgent {
 
   private attachRequestNonce({nonce}: Pick<IcrcCallCanisterRequestParams, 'nonce'>): void {
     if (isNullish(nonce)) {
-      // Consumer has not provided a nonce. Therefore, we let agent-js generate one for the request.
+      // Consumer has not provided a nonce. Therefore, we generate a new one for the request to reassign current value.
+      this.#agent.addTransform('update', makeNonceTransform(makeNonce));
       return;
     }
 

--- a/src/agent/custom-http-agent.ts
+++ b/src/agent/custom-http-agent.ts
@@ -202,7 +202,7 @@ export class CustomHttpAgent {
 
   private attachRequestNonce({nonce}: Pick<IcrcCallCanisterRequestParams, 'nonce'>): void {
     if (isNullish(nonce)) {
-      // Consumer has not provided a nonce. Therefore, we generate a new one for the request to reassign current value.
+      // We always assign the transformer to generate a random nonce because we maintain a static reference to an agent. This ensures that even if the agent was previously configured with a transformer using a relying party's nonce, it will always generate a fresh one.
       this.#agent.addTransform('update', makeNonceTransform(makeNonce));
       return;
     }


### PR DESCRIPTION
# Motivation

We needed to improve security by ensuring that a nonce is properly injected into ICRC-49 calls.
The nonce is arbitrary data (up to 32 bytes) that can be used to create distinct requests with otherwise identical fields.

# Changes

Added new nonceTransform to reassign nonce value if it is not provided by client.

# Tests

Added new unit test to cover new logic.
