### PR TITLE
feat: added new method to set owner after establishing connection signer with wallet

### DIFF
--- a/src/constants/signer.constants.ts
+++ b/src/constants/signer.constants.ts
@@ -24,6 +24,11 @@ export enum SignerErrorCode {
   BUSY = 503,
 
   /**
+   * Owner is not set on the signer.
+   */
+  NOT_INITIALIZED = 504,
+
+  /**
    * A generic error.
    * @see https://github.com/dfinity/wg-identity-authentication/blob/main/topics/icrc_25_signer_interaction_standard.md#errors
    */

--- a/src/handlers/signer-errors.handlers.spec.ts
+++ b/src/handlers/signer-errors.handlers.spec.ts
@@ -6,6 +6,7 @@ import {
   notifyErrorActionAborted,
   notifyErrorBusy,
   notifyErrorMissingPrompt,
+  notifyErrorNotInitializes,
   notifyErrorPermissionNotGranted,
   notifyErrorRequestNotSupported,
   notifyErrorSenderNotAllowed,
@@ -176,6 +177,25 @@ describe('Signer-errors.handlers', () => {
       };
 
       notifyErrorBusy({id: requestId, origin: testOrigin});
+
+      const expectedMessage: RpcResponseWithError = {
+        jsonrpc: JSON_RPC_VERSION_2,
+        id: requestId,
+        error
+      };
+
+      expect(postMessageMock).toHaveBeenCalledWith(expectedMessage, testOrigin);
+    });
+  });
+
+  describe('notifyErrorNotInitializes', () => {
+    it('should post an error message indicating the signer is not initialized (owner missing)', () => {
+      const error = {
+        code: SignerErrorCode.NOT_INITIALIZED,
+        message: 'The signer does not have an owner set.'
+      };
+
+      notifyErrorNotInitializes({id: requestId, origin: testOrigin});
 
       const expectedMessage: RpcResponseWithError = {
         jsonrpc: JSON_RPC_VERSION_2,

--- a/src/handlers/signer-errors.handlers.ts
+++ b/src/handlers/signer-errors.handlers.ts
@@ -76,3 +76,13 @@ export const notifyErrorBusy = (notify: Notify): void => {
     }
   });
 };
+
+export const notifyErrorNotInitializes = (notify: Notify): void => {
+  notifyError({
+    ...notify,
+    error: {
+      code: SignerErrorCode.NOT_INITIALIZED,
+      message: 'The signer does not have an owner set.'
+    }
+  });
+};

--- a/src/types/signer-options.ts
+++ b/src/types/signer-options.ts
@@ -20,7 +20,7 @@ const IdentitySchema = z.custom<Identity>((value: unknown): boolean => {
   }
 }, 'The value provided is not a valid Identity.');
 
-const IdentityNotAnonymousSchema = IdentitySchema.refine(
+export const IdentityNotAnonymousSchema = IdentitySchema.refine(
   (identity) => !identity.getPrincipal().isAnonymous(),
   {
     message: 'The Principal is anonymous and cannot be used.'
@@ -45,15 +45,7 @@ const SessionOptionsSchema = z.object({
   sessionPermissionExpirationInMilliseconds: z.number().positive().optional()
 });
 
-export const SignerOptionsSchema = z.object({
-  /**
-   * The owner who interacts with the signer.
-   *
-   * When the signer is initialized, the owner should be signed in to the consumer dApp.
-   * Upon signing out, it is up to the consumer to disconnect the signer.
-   */
-  owner: IdentityNotAnonymousSchema,
-
+export const SignerInitOptionsSchema = z.object({
   /**
    * The replica's host to which the signer should connect to.
    * If localhost or 127.0.0.1 are provided, the signer will automatically connect to a local replica and fetch the root key for the agent.
@@ -66,4 +58,24 @@ export const SignerOptionsSchema = z.object({
   sessionOptions: SessionOptionsSchema.optional()
 });
 
+export const SignerOptionsSchema = z.object({
+  /**
+   * The replica's host to which the signer should connect to.
+   * If localhost or 127.0.0.1 are provided, the signer will automatically connect to a local replica and fetch the root key for the agent.
+   */
+  host: SignerHostSchema,
+  /**
+   * Options for managing session behavior, including session expiration times.
+   */
+  sessionOptions: SessionOptionsSchema.optional(),
+  /**
+   * The owner who interacts with the signer.
+   *
+   * When the signer is initialized, the owner should be signed in to the consumer dApp.
+   * Upon signing out, it is up to the consumer to disconnect the signer.
+   */
+  owner: IdentityNotAnonymousSchema,
+});
+
 export type SignerOptions = z.infer<typeof SignerOptionsSchema>;
+export type SignerInitOptions = z.infer<typeof SignerInitOptionsSchema>;


### PR DESCRIPTION


# Motivation

We are updating the oisy-signer so that it now waits for a valid owner to be set before processing non‑read‑only messages, ensuring that it returns a clear NOT_INITIALIZED error when not logged in. 

# Changes

Added new method to init owner after the connection was established between Signer and wallet

# Tests

Added new unit test to cover new logic.
