### PR TITLE
test: fix playwright awaiting count elements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@dfinity/eslint-config-oisy-wallet": "^0.1.0",
         "@dfinity/identity": "^2.3.0",
         "@dfinity/internet-identity-playwright": "^0.0.5",
-        "@playwright/test": "^1.49.1",
+        "@playwright/test": "^1.51.0",
         "@types/jest": "^29.5.14",
         "@types/node": "^22.10.2",
         "esbuild": "^0.25.0",
@@ -1224,13 +1224,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.50.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.50.1.tgz",
-      "integrity": "sha512-Jii3aBg+CEDpgnuDxEp/h7BimHcUTDlpEtce89xEumlJ5ef2hqepZ+PWp1DDpYC/VO9fmWVI1IlEaoI5fK9FXQ==",
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.51.0.tgz",
+      "integrity": "sha512-dJ0dMbZeHhI+wb77+ljx/FeC8VBP6j/rj9OAojO08JI80wTZy6vRk9KvHKiDCUh4iMpEiseMgqRBIeW+eKX6RA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.50.1"
+        "playwright": "1.51.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -5293,13 +5293,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.50.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.50.1.tgz",
-      "integrity": "sha512-G8rwsOQJ63XG6BbKj2w5rHeavFjy5zynBA9zsJMMtBoe/Uf757oG12NXz6e6OirF7RCrTVAKFXbLmn1RbL7Qaw==",
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.51.0.tgz",
+      "integrity": "sha512-442pTfGM0xxfCYxuBa/Pu6B2OqxqqaYq39JS8QDMGThUvIOCd6s0ANDog3uwA0cHavVlnTQzGCN7Id2YekDSXA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.50.1"
+        "playwright-core": "1.51.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -5312,9 +5312,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.50.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.50.1.tgz",
-      "integrity": "sha512-ra9fsNWayuYumt+NiM069M6OkcRb1FZSK8bgi66AtpFoWkg2+y0bJSNmkFrWhMbEBbVKC/EruAHH3g0zmtwGmQ==",
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.51.0.tgz",
+      "integrity": "sha512-x47yPE3Zwhlil7wlNU/iktF7t2r/URR3VLbH6EknJd/04Qc/PSJ0EY3CMXipmglLG+zyRxW6HNo2EGbKLHPWMg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "@dfinity/eslint-config-oisy-wallet": "^0.1.0",
     "@dfinity/identity": "^2.3.0",
     "@dfinity/internet-identity-playwright": "^0.0.5",
-    "@playwright/test": "^1.49.1",
+    "@playwright/test": "^1.51.0",
     "@types/jest": "^29.5.14",
     "@types/node": "^22.10.2",
     "esbuild": "^0.25.0",


### PR DESCRIPTION
# Motivation

E2E tests are currently failing on main and in PRs ([example](https://github.com/dfinity/oisy-wallet-signer/actions/runs/13840293026/job/38726882890?pr=505)). The issue is unrelated to our code but seems to be related to Playwright not properly awaiting element counts. While there is nothing mentioned in the CHANGELOG, it appears that bumping Playwright resolves the issue.

# Notes

The test might also be flaky, but there haven't been any issues so far. That’s why I suggest first trying to bump Playwright.

# Changes

- Bump latest Playwright
