### PR TITLE
feat: Added new setOwner method to establish connection before initialization of the owner

### DIFF
--- a/src/types/signer-options.ts
+++ b/src/types/signer-options.ts
@@ -20,7 +20,7 @@ const IdentitySchema = z.custom<Identity>((value: unknown): boolean => {
   }
 }, 'The value provided is not a valid Identity.');
 
-const IdentityNotAnonymousSchema = IdentitySchema.refine(
+export const IdentityNotAnonymousSchema = IdentitySchema.refine(
   (identity) => !identity.getPrincipal().isAnonymous(),
   {
     message: 'The Principal is anonymous and cannot be used.'
@@ -67,3 +67,4 @@ export const SignerOptionsSchema = z.object({
 });
 
 export type SignerOptions = z.infer<typeof SignerOptionsSchema>;
+export type SignerInitOptions = Omit<SignerOptions, 'owner'>;


### PR DESCRIPTION


# Motivation

We are updating the oisy-signer so that it now waits for a valid owner to be set before processing non‑read‑only messages, ensuring that it returns a clear NOT_INITIALIZED error when not logged in.

# Changes

I removed the need to set the owner during initialization and added a setOwner method to assign it later. Now, if no owner is set when a method that requires it is called, the signer returns a NOT_INITIALIZED error via the notifyError function.

# Tests

I updated the tests so that when an owner is not set, the owner-dependent methods return a NOT_INITIALIZED error via notifyError.