### PR TITLE
feat: added new SignerInitOptions and removed unnecessary owner tests

### DIFF
--- a/src/types/signer-options.spec.ts
+++ b/src/types/signer-options.spec.ts
@@ -1,159 +1,91 @@
-import {AnonymousIdentity} from '@dfinity/agent';
-import {Ed25519KeyIdentity} from '@dfinity/identity';
-import {SignerOptionsSchema} from './signer-options';
+import {SignerInitOptionsSchema} from './signer-options';
 
 describe('SignerOptions', () => {
-  describe('Owner', () => {
-    it('should validate a valid owner', () => {
-      const identity = Ed25519KeyIdentity.generate();
-
-      const validSignerOptions = {
-        owner: identity
-      };
-
-      expect(() => SignerOptionsSchema.parse(validSignerOptions)).not.toThrow();
-    });
-
-    it('should throw an error for invalid identity', () => {
-      const invalidIdentity = {id: 'not-an-identity'};
-
-      const invalidSignerOptions = {
-        owner: invalidIdentity
-      };
-
-      expect(() => SignerOptionsSchema.parse(invalidSignerOptions)).toThrow(
-        'The value provided is not a valid Identity.'
-      );
-    });
-
-    it('should throw an error for invalid principal', () => {
-      const invalidIdentity = {_principal: {id: 'not-a-principal'}};
-
-      const invalidSignerOptions = {
-        owner: invalidIdentity
-      };
-
-      expect(() => SignerOptionsSchema.parse(invalidSignerOptions)).toThrow(
-        'The value provided is not a valid Identity.'
-      );
-    });
-
-    it('should throw an error for an anonymous Principal', () => {
-      const invalidSignerOptions = {
-        owner: new AnonymousIdentity()
-      };
-
-      expect(() => SignerOptionsSchema.parse(invalidSignerOptions)).toThrow(
-        'The Principal is anonymous and cannot be used.'
-      );
-    });
-  });
-
   describe('Host', () => {
-    const owner = Ed25519KeyIdentity.generate();
-
     it('should validate when host is not provided (optional)', () => {
-      const validSignerOptions = {
-        owner
-      };
-
-      const result = SignerOptionsSchema.parse(validSignerOptions);
+      const result = SignerInitOptionsSchema.parse({});
       expect(result.host).toBeUndefined();
     });
 
     it('should validate when a valid host is provided', () => {
       const validSignerOptions = {
-        owner,
         host: 'https://test.com'
       };
 
-      expect(() => SignerOptionsSchema.parse(validSignerOptions)).not.toThrow();
+      expect(() => SignerInitOptionsSchema.parse(validSignerOptions)).not.toThrow();
     });
 
     it('should throw an error for an invalid host URL', () => {
       const invalidSignerOptions = {
-        owner,
         host: 'invalid-url'
       };
 
-      expect(() => SignerOptionsSchema.parse(invalidSignerOptions)).toThrow('Invalid url');
+      expect(() => SignerInitOptionsSchema.parse(invalidSignerOptions)).toThrow('Invalid url');
     });
 
     it('should validate when localhost is used as host', () => {
       const validSignerOptions = {
-        owner,
         host: 'http://localhost:4987'
       };
 
-      expect(() => SignerOptionsSchema.parse(validSignerOptions)).not.toThrow();
+      expect(() => SignerInitOptionsSchema.parse(validSignerOptions)).not.toThrow();
     });
   });
 
   describe('SessionOptions', () => {
-    const owner = Ed25519KeyIdentity.generate();
-
     it('should validate when optional sessionOptions is not provided', () => {
-      const validSignerOptions = {
-        owner
-      };
-
-      const result = SignerOptionsSchema.parse(validSignerOptions);
+      const result = SignerInitOptionsSchema.parse({});
       expect(result.sessionOptions).toBeUndefined();
     });
 
     it('should validate when valid sessionOptions are provided', () => {
       const validSignerOptions = {
-        owner,
         sessionOptions: {
           sessionPermissionExpirationInMilliseconds: 7 * 24 * 60 * 60 * 1000
         }
       };
 
-      expect(() => SignerOptionsSchema.parse(validSignerOptions)).not.toThrow();
+      expect(() => SignerInitOptionsSchema.parse(validSignerOptions)).not.toThrow();
     });
 
     it('should throw an error for invalid sessionPermissionExpirationInMilliseconds (negative)', () => {
       const invalidSignerOptions = {
-        owner,
         sessionOptions: {
           sessionPermissionExpirationInMilliseconds: -1000
         }
       };
 
-      expect(() => SignerOptionsSchema.parse(invalidSignerOptions)).toThrow();
+      expect(() => SignerInitOptionsSchema.parse(invalidSignerOptions)).toThrow();
     });
 
     it('should throw an error for invalid sessionPermissionExpirationInMilliseconds (zero)', () => {
       const invalidSignerOptions = {
-        owner,
         sessionOptions: {
           sessionPermissionExpirationInMilliseconds: 0
         }
       };
 
-      expect(() => SignerOptionsSchema.parse(invalidSignerOptions)).toThrow();
+      expect(() => SignerInitOptionsSchema.parse(invalidSignerOptions)).toThrow();
     });
 
     it('should throw an error for non-numeric sessionPermissionExpirationInMilliseconds', () => {
       const invalidSignerOptions = {
-        owner,
         sessionOptions: {
           sessionPermissionExpirationInMilliseconds: 'not-a-number'
         }
       };
 
-      expect(() => SignerOptionsSchema.parse(invalidSignerOptions)).toThrow();
+      expect(() => SignerInitOptionsSchema.parse(invalidSignerOptions)).toThrow();
     });
 
     it('should validate when sessionPermissionExpirationInMilliseconds is a positive number', () => {
       const validSignerOptions = {
-        owner,
         sessionOptions: {
           sessionPermissionExpirationInMilliseconds: 5000
         }
       };
 
-      expect(() => SignerOptionsSchema.parse(validSignerOptions)).not.toThrow();
+      expect(() => SignerInitOptionsSchema.parse(validSignerOptions)).not.toThrow();
     });
   });
 });

--- a/src/types/signer-options.ts
+++ b/src/types/signer-options.ts
@@ -20,7 +20,7 @@ const IdentitySchema = z.custom<Identity>((value: unknown): boolean => {
   }
 }, 'The value provided is not a valid Identity.');
 
-const IdentityNotAnonymousSchema = IdentitySchema.refine(
+export const IdentityNotAnonymousSchema = IdentitySchema.refine(
   (identity) => !identity.getPrincipal().isAnonymous(),
   {
     message: 'The Principal is anonymous and cannot be used.'
@@ -66,4 +66,9 @@ export const SignerOptionsSchema = z.object({
   sessionOptions: SessionOptionsSchema.optional()
 });
 
+export const SignerInitOptionsSchema = SignerOptionsSchema.omit({
+  owner: true
+});
+
 export type SignerOptions = z.infer<typeof SignerOptionsSchema>;
+export type SignerInitOptions = Omit<SignerOptions, 'owner'>;


### PR DESCRIPTION
# Motivation

We are updating the oisy-signer so that it now waits for a valid owner to be set before processing non‑read‑only messages, ensuring that it returns a clear NOT_INITIALIZED error when not logged in.

# Changes

Added a new SignerInitSchema and SignerInitOptions without the owner property, allowing the Signer to establish a connection without specifying an owner.

# Tests

Removed unnecessary tests for the owner field in SignerInitOptions.