### PR TITLE
build: bump agent-js v2.4.0

### DIFF
--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -12,12 +12,12 @@
 				"src/wallet_frontend"
 			],
 			"dependencies": {
-				"@dfinity/agent": "^2.3.0",
-				"@dfinity/auth-client": "^2.3.0",
-				"@dfinity/candid": "^2.3.0",
+				"@dfinity/agent": "^2.4.0",
+				"@dfinity/auth-client": "^2.4.0",
+				"@dfinity/candid": "^2.4.0",
 				"@dfinity/ledger-icp": "^2.6.11",
 				"@dfinity/ledger-icrc": "^2.7.6",
-				"@dfinity/principal": "^2.3.0",
+				"@dfinity/principal": "^2.4.0",
 				"@dfinity/utils": "^2.11.0",
 				"buffer": "^6.0.3",
 				"zod": "^3.24.2"
@@ -644,9 +644,9 @@
 			}
 		},
 		"node_modules/@dfinity/agent": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-2.3.0.tgz",
-			"integrity": "sha512-f/eNydwuOunTKRcZAW1RxrcmKyb1AFqZM/ysJJaqFCX9Y+men9NoBTeuUI23XKUp9YeDb9yinGyAlYqjb6VMPw==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-2.4.0.tgz",
+			"integrity": "sha512-9ez+lgQr09jUonYUw1NRxPG81yGVillKp0hp79WQ3o/XDn6wbDq/YcMh3/62z8PpGJRLyt2+FlE3pxoGlzWHbw==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@noble/curves": "^1.4.0",
@@ -657,31 +657,31 @@
 				"simple-cbor": "^0.4.1"
 			},
 			"peerDependencies": {
-				"@dfinity/candid": "^2.3.0",
-				"@dfinity/principal": "^2.3.0"
+				"@dfinity/candid": "^2.4.0",
+				"@dfinity/principal": "^2.4.0"
 			}
 		},
 		"node_modules/@dfinity/auth-client": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/@dfinity/auth-client/-/auth-client-2.3.0.tgz",
-			"integrity": "sha512-UbV90FtVxHs6pMODomnb8xAS9k5qCj8tWbiZRS+oS9+ry39Cfcu8qCURFWOdFlrV7YzNeSk7xYqSlCAJi8luFQ==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/@dfinity/auth-client/-/auth-client-2.4.0.tgz",
+			"integrity": "sha512-vjCpdFoPOxjrpCEJUZrn8N/MnfuH7m0s13qEfQWJ3hRRb5cjYhLBACl3T1wDSi1mqhi2rT2Y2UVuStThE99/Sg==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"idb": "^7.0.2"
 			},
 			"peerDependencies": {
-				"@dfinity/agent": "^2.3.0",
-				"@dfinity/identity": "^2.3.0",
-				"@dfinity/principal": "^2.3.0"
+				"@dfinity/agent": "^2.4.0",
+				"@dfinity/identity": "^2.4.0",
+				"@dfinity/principal": "^2.4.0"
 			}
 		},
 		"node_modules/@dfinity/candid": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-2.3.0.tgz",
-			"integrity": "sha512-Xzj3EWfwaVZy90jq6WBRP4Cyqo93r3g8tvBea8W8PN3I4W6KcN2/9ZJaBhT3Y4NP+p2w4ZO6aJ+qp9xH990aYw==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-2.4.0.tgz",
+			"integrity": "sha512-ZVuBIFlWOZOvEZaLtBKE2666rab32XSdHo1BtzdDy36NMvQbRXkZRbIEd7xoZXRud2wK7pk5cNsZULnXghAORg==",
 			"license": "Apache-2.0",
 			"peerDependencies": {
-				"@dfinity/principal": "^2.3.0"
+				"@dfinity/principal": "^2.4.0"
 			}
 		},
 		"node_modules/@dfinity/eslint-config-oisy-wallet": {
@@ -713,9 +713,9 @@
 			}
 		},
 		"node_modules/@dfinity/identity": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/@dfinity/identity/-/identity-2.3.0.tgz",
-			"integrity": "sha512-nJbL9hNztfhjmdkSmzoUi/cuLmCtjm9/8O6dM100acMjqG1JoW4yF4Mgi/sKwCDCkpj+maY8SqQxI8hSPms9gA==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/@dfinity/identity/-/identity-2.4.0.tgz",
+			"integrity": "sha512-OxszeQ8J1i0eXThckE35lz9xHvlemsa1c/H0zyfJoomWL2NeyoFrHaWtxFRyyQrTlgCvEWgRZKed7U1MhEJwjg==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
@@ -724,8 +724,8 @@
 				"borc": "^2.1.1"
 			},
 			"peerDependencies": {
-				"@dfinity/agent": "^2.3.0",
-				"@dfinity/principal": "^2.3.0"
+				"@dfinity/agent": "^2.4.0",
+				"@dfinity/principal": "^2.4.0"
 			}
 		},
 		"node_modules/@dfinity/ledger-icp": {
@@ -761,9 +761,9 @@
 			"link": true
 		},
 		"node_modules/@dfinity/principal": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-2.3.0.tgz",
-			"integrity": "sha512-rb3TsxR3L/Vq2GWV/GGIMXPbzDDqxNohPbNW8nJKhpcm8Ds00tCVEmPUDqrn735xJW0Pmzog/6/S1L9jG2UT9g==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-2.4.0.tgz",
+			"integrity": "sha512-gBKCyxrPYKdqHVk/Qh9cfxN0Hnt4BvRYVo5KgNEAOKyoySCIPO39xlcfE6JJzWtLqEftQLMbeSMrLrTHDdMZ5w==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@noble/hashes": "^1.3.1"

--- a/demo/package.json
+++ b/demo/package.json
@@ -51,12 +51,12 @@
 	},
 	"type": "module",
 	"dependencies": {
-		"@dfinity/agent": "^2.3.0",
-		"@dfinity/auth-client": "^2.3.0",
-		"@dfinity/candid": "^2.3.0",
+		"@dfinity/agent": "^2.4.0",
+		"@dfinity/auth-client": "^2.4.0",
+		"@dfinity/candid": "^2.4.0",
 		"@dfinity/ledger-icp": "^2.6.11",
 		"@dfinity/ledger-icrc": "^2.7.6",
-		"@dfinity/principal": "^2.3.0",
+		"@dfinity/principal": "^2.4.0",
 		"@dfinity/utils": "^2.11.0",
 		"buffer": "^6.0.3",
 		"zod": "^3.24.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@dfinity/eslint-config-oisy-wallet": "^0.1.1",
-        "@dfinity/identity": "^2.3.0",
+        "@dfinity/identity": "^2.4.0",
         "@dfinity/internet-identity-playwright": "^0.0.5",
         "@playwright/test": "^1.51.0",
         "@types/jest": "^29.5.14",
@@ -26,11 +26,11 @@
         "node": ">=22"
       },
       "peerDependencies": {
-        "@dfinity/agent": "^2.3.0",
-        "@dfinity/candid": "^2.3.0",
+        "@dfinity/agent": "^2.4.0",
+        "@dfinity/candid": "^2.4.0",
         "@dfinity/ledger-icp": "^2",
         "@dfinity/ledger-icrc": "^2",
-        "@dfinity/principal": "^2.3.0",
+        "@dfinity/principal": "^2.4.0",
         "@dfinity/utils": "^2",
         "@dfinity/zod-schemas": "*",
         "borc": "^2.1.1",
@@ -280,9 +280,9 @@
       }
     },
     "node_modules/@dfinity/agent": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-2.3.0.tgz",
-      "integrity": "sha512-f/eNydwuOunTKRcZAW1RxrcmKyb1AFqZM/ysJJaqFCX9Y+men9NoBTeuUI23XKUp9YeDb9yinGyAlYqjb6VMPw==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-2.4.0.tgz",
+      "integrity": "sha512-9ez+lgQr09jUonYUw1NRxPG81yGVillKp0hp79WQ3o/XDn6wbDq/YcMh3/62z8PpGJRLyt2+FlE3pxoGlzWHbw==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
@@ -294,18 +294,18 @@
         "simple-cbor": "^0.4.1"
       },
       "peerDependencies": {
-        "@dfinity/candid": "^2.3.0",
-        "@dfinity/principal": "^2.3.0"
+        "@dfinity/candid": "^2.4.0",
+        "@dfinity/principal": "^2.4.0"
       }
     },
     "node_modules/@dfinity/candid": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-2.3.0.tgz",
-      "integrity": "sha512-Xzj3EWfwaVZy90jq6WBRP4Cyqo93r3g8tvBea8W8PN3I4W6KcN2/9ZJaBhT3Y4NP+p2w4ZO6aJ+qp9xH990aYw==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-2.4.0.tgz",
+      "integrity": "sha512-ZVuBIFlWOZOvEZaLtBKE2666rab32XSdHo1BtzdDy36NMvQbRXkZRbIEd7xoZXRud2wK7pk5cNsZULnXghAORg==",
       "license": "Apache-2.0",
       "peer": true,
       "peerDependencies": {
-        "@dfinity/principal": "^2.3.0"
+        "@dfinity/principal": "^2.4.0"
       }
     },
     "node_modules/@dfinity/eslint-config-oisy-wallet": {
@@ -337,9 +337,9 @@
       }
     },
     "node_modules/@dfinity/identity": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@dfinity/identity/-/identity-2.3.0.tgz",
-      "integrity": "sha512-nJbL9hNztfhjmdkSmzoUi/cuLmCtjm9/8O6dM100acMjqG1JoW4yF4Mgi/sKwCDCkpj+maY8SqQxI8hSPms9gA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/identity/-/identity-2.4.0.tgz",
+      "integrity": "sha512-OxszeQ8J1i0eXThckE35lz9xHvlemsa1c/H0zyfJoomWL2NeyoFrHaWtxFRyyQrTlgCvEWgRZKed7U1MhEJwjg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -348,8 +348,8 @@
         "borc": "^2.1.1"
       },
       "peerDependencies": {
-        "@dfinity/agent": "^2.3.0",
-        "@dfinity/principal": "^2.3.0"
+        "@dfinity/agent": "^2.4.0",
+        "@dfinity/principal": "^2.4.0"
       }
     },
     "node_modules/@dfinity/internet-identity-playwright": {
@@ -392,9 +392,9 @@
       }
     },
     "node_modules/@dfinity/principal": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-2.3.0.tgz",
-      "integrity": "sha512-rb3TsxR3L/Vq2GWV/GGIMXPbzDDqxNohPbNW8nJKhpcm8Ds00tCVEmPUDqrn735xJW0Pmzog/6/S1L9jG2UT9g==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-2.4.0.tgz",
+      "integrity": "sha512-gBKCyxrPYKdqHVk/Qh9cfxN0Hnt4BvRYVo5KgNEAOKyoySCIPO39xlcfE6JJzWtLqEftQLMbeSMrLrTHDdMZ5w==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
   },
   "devDependencies": {
     "@dfinity/eslint-config-oisy-wallet": "^0.1.1",
-    "@dfinity/identity": "^2.3.0",
+    "@dfinity/identity": "^2.4.0",
     "@dfinity/internet-identity-playwright": "^0.0.5",
     "@playwright/test": "^1.51.0",
     "@types/jest": "^29.5.14",
@@ -92,11 +92,11 @@
     "node": ">=22"
   },
   "peerDependencies": {
-    "@dfinity/agent": "^2.3.0",
-    "@dfinity/candid": "^2.3.0",
+    "@dfinity/agent": "^2.4.0",
+    "@dfinity/candid": "^2.4.0",
     "@dfinity/ledger-icp": "^2",
     "@dfinity/ledger-icrc": "^2",
-    "@dfinity/principal": "^2.3.0",
+    "@dfinity/principal": "^2.4.0",
     "@dfinity/utils": "^2",
     "@dfinity/zod-schemas": "*",
     "borc": "^2.1.1",


### PR DESCRIPTION
# Motivation

Agent-js [v.2.4.0](https://github.com/dfinity/agent-js/releases/tag/v2.4.0) contains an improvement - supporting nonce for call - required to implement a feature in the signer. That's why we need to bump the library.

# Changes

- Bum agent in lib and demo.
