### PR TITLE
feat: add key for each in demo

### DIFF
--- a/demo/src/relying_party_frontend/src/lib/components/Accounts.svelte
+++ b/demo/src/relying_party_frontend/src/lib/components/Accounts.svelte
@@ -27,7 +27,7 @@
 		<Value id="accounts" testId="accounts" title="Accounts">
 			{#if nonNullish($accountsStore)}
 				<ul in:fade data-tid="accounts-list">
-					{#each $accountsStore as account}
+					{#each $accountsStore as account (account.owner)}
 						<li>{account.owner}</li>
 					{/each}
 				</ul>

--- a/demo/src/relying_party_frontend/src/lib/components/PermissionsScopes.svelte
+++ b/demo/src/relying_party_frontend/src/lib/components/PermissionsScopes.svelte
@@ -8,6 +8,6 @@
 	let { scopes }: Props = $props();
 </script>
 
-{#each scopes as scope}
+{#each scopes as scope (scope.scope.method)}
 	<p>{scope.scope.method}: <strong>{scope.state}</strong></p>
 {/each}

--- a/demo/src/relying_party_frontend/src/lib/components/SupportedStandards.svelte
+++ b/demo/src/relying_party_frontend/src/lib/components/SupportedStandards.svelte
@@ -27,7 +27,7 @@
 {#if nonNullish(supportedStandards)}
 	<Value id="supported-standards" testId="supported-standards" title="Supported standards">
 		<ul in:fade>
-			{#each supportedStandards as standard}
+			{#each supportedStandards as standard (standard.name)}
 				<li>{standard.name}</li>
 			{/each}
 		</ul>

--- a/demo/src/wallet_frontend/src/lib/ConfirmPermissions.svelte
+++ b/demo/src/wallet_frontend/src/lib/ConfirmPermissions.svelte
@@ -75,7 +75,7 @@
 			<p class="font-bold dark:text-white">Requested Permissions</p>
 
 			<ul class="mt-2 mb-4 dark:text-white" data-tid="requested-permissions-list">
-				{#each scopes as scope}
+				{#each scopes as scope (scope.scope.method)}
 					<li>
 						<input type="checkbox" onchange={() => onToggle(scope)} class="mr-1" />
 						{scope.scope.method}


### PR DESCRIPTION
# Motivation

The latest linter provided in [#516] is more strict about `each` and required each of those to be keyed.

For example:

```
30:6  error  Each block should have a key  svelte/require-each-key
```

# Changes

- Add keys to each
