### PR TITLE
ci: remove scope from PR message

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,7 @@ updates:
       - dependency-name: 'eslint'
       - dependency-name: 'eslint-*'
     commit-message:
-      prefix: "build"
+      prefix: 'build'
 
   - package-ecosystem: npm
     directory: '/demo'
@@ -27,4 +27,4 @@ updates:
       - dependency-name: 'eslint'
       - dependency-name: 'eslint-*'
     commit-message:
-      prefix: "build"
+      prefix: 'build'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,8 @@ updates:
       - dependency-name: '@typescript-eslint/*'
       - dependency-name: 'eslint'
       - dependency-name: 'eslint-*'
+    commit-message:
+      prefix: "build"
 
   - package-ecosystem: npm
     directory: '/demo'
@@ -24,3 +26,5 @@ updates:
       - dependency-name: '@typescript-eslint/*'
       - dependency-name: 'eslint'
       - dependency-name: 'eslint-*'
+    commit-message:
+      prefix: "build"


### PR DESCRIPTION
# Motivation

We want to remove the scope from the PR title (commit message) created by dependabot, so that `build(dev-deps):...` becomes `build:...`

According to [documentation](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#commit-message--), to remove the `scope` in the PR title/commit message, we need to define the `prefix` value and not set the `include` parameter.