### PR TITLE
feat: integrated customTransfrom to customHttpAgent

### DIFF
--- a/src/agent/custom-http-agent.spec.ts
+++ b/src/agent/custom-http-agent.spec.ts
@@ -27,7 +27,7 @@ import {
   UndefinedRequestDetailsError,
   UndefinedRootKeyError
 } from './custom-http-agent';
-import {customAddTransform} from './custom-transform-agent';
+import * as transformAgent from './custom-transform-agent';
 
 vi.mock('@dfinity/agent', async (importOriginal) => {
   const originalModule = await importOriginal<typeof import('@dfinity/agent')>();
@@ -90,7 +90,7 @@ describe('CustomHttpAgent', () => {
   });
 
   it('should call customAddTransform in the constructor', async () => {
-    const spyCustomAddTransform = vi.mocked(customAddTransform);
+    const spyCustomAddTransform = vi.spyOn(transformAgent, 'customAddTransform');
 
     const agent = await CustomHttpAgent.create();
 

--- a/src/agent/custom-http-agent.spec.ts
+++ b/src/agent/custom-http-agent.spec.ts
@@ -1,7 +1,7 @@
 import * as httpAgent from '@dfinity/agent';
 import {RequestId, SubmitResponse} from '@dfinity/agent';
 import {Ed25519KeyIdentity} from '@dfinity/identity';
-import {base64ToUint8Array, uint8ArrayToBase64} from '@dfinity/utils';
+import {base64ToUint8Array, nonNullish} from '@dfinity/utils';
 import {MockInstance} from 'vitest';
 import {
   mockLocalIcRootKey,
@@ -15,7 +15,8 @@ import {
 import {
   mockRequestDetails,
   mockRequestMethod,
-  mockRequestPayload
+  mockRequestPayload,
+  mockRequestPayloadWithNonce
 } from '../mocks/custom-http-agent.mocks';
 import {mockCanisterId} from '../mocks/icrc-accounts.mocks';
 import {
@@ -26,6 +27,7 @@ import {
   UndefinedRequestDetailsError,
   UndefinedRootKeyError
 } from './custom-http-agent';
+import {customAddTransform} from './custom-transform-agent';
 
 vi.mock('@dfinity/agent', async (importOriginal) => {
   const originalModule = await importOriginal<typeof import('@dfinity/agent')>();
@@ -51,6 +53,10 @@ vi.mock('@dfinity/agent', async (importOriginal) => {
     pollForResponse: vi.fn()
   };
 });
+
+vi.mock('./custom-transform-agent', () => ({
+  customAddTransform: vi.fn(() => vi.fn())
+}));
 
 describe('CustomHttpAgent', () => {
   const mockResponse: SubmitResponse['response'] = {
@@ -81,6 +87,17 @@ describe('CustomHttpAgent', () => {
   afterEach(() => {
     vi.clearAllMocks();
     vi.useRealTimers();
+  });
+
+  it('should call customAddTransform in the constructor', async () => {
+    const spyCustomAddTransform = vi.mocked(customAddTransform);
+
+    const agent = await CustomHttpAgent.create();
+
+    expect(agent).toBeInstanceOf(CustomHttpAgent);
+
+    expect(spyCustomAddTransform).toHaveBeenCalledOnce();
+    spyCustomAddTransform.mockRestore();
   });
 
   it('should create a CustomHttpAgent with the correct options', async () => {
@@ -150,7 +167,7 @@ describe('CustomHttpAgent', () => {
           spyCall = vi.spyOn(agent.agent, 'call').mockResolvedValue(mockRepliedSubmitResponse);
         });
 
-        it('should call agent on request', async () => {
+        it('should call agent on request without nonce', async () => {
           await agent.request(mockRequestPayload);
 
           expect(spyCall).toHaveBeenCalledOnce();
@@ -161,86 +178,33 @@ describe('CustomHttpAgent', () => {
           });
         });
 
+        it('should call agent on request with nonce', async () => {
+          await agent.request(mockRequestPayloadWithNonce);
+
+          expect(spyCall).toHaveBeenCalledOnce();
+          expect(spyCall).toHaveBeenCalledWith(mockCanisterId, {
+            arg: base64ToUint8Array(mockRequestPayload.arg),
+            effectiveCanisterId: mockCanisterId,
+            methodName: mockRequestMethod,
+            nonce:
+              nonNullish(mockRequestPayloadWithNonce.nonce) &&
+              base64ToUint8Array(mockRequestPayloadWithNonce.nonce)
+          });
+        });
+
         it('should make a request and return a certificate and request details', async () => {
           const response = await agent.request(mockRequestPayload);
 
           expect(response.certificate).toEqual(certificate);
           expect(response.requestDetails).toEqual(mockRequestDetails);
         });
-      });
 
-      it('should call transform if a nonce is provided', async () => {
-        const spyTransform = vi.spyOn(agent.agent, 'addTransform');
+        it('should make a request with nonce and return a certificate and request details', async () => {
+          const response = await agent.request(mockRequestPayloadWithNonce);
 
-        const nonce = uint8ArrayToBase64(httpAgent.makeNonce());
-
-        await agent.request({
-          ...mockRequestPayload,
-          nonce
+          expect(response.certificate).toEqual(certificate);
+          expect(response.requestDetails).toEqual(mockRequestDetails);
         });
-
-        expect(spyTransform).toHaveBeenCalledOnce();
-        expect(spyTransform).toHaveBeenCalledWith('update', expect.any(Function));
-
-        const [[firstArg, secondArg]] = spyTransform.mock.calls;
-
-        expect(firstArg).toBe('update');
-        expect(secondArg).toBeInstanceOf(Function);
-
-        enum Endpoint {
-          Query = 'read',
-          ReadState = 'read_state',
-          Call = 'call'
-        }
-
-        const mockRequest = {
-          endpoint: Endpoint.Call,
-          request: {
-            headers: new Map()
-          },
-          body: {nonce: []}
-        };
-
-        await secondArg(mockRequest as unknown as httpAgent.HttpAgentSubmitRequest);
-
-        expect(mockRequest.body.nonce).toEqual(base64ToUint8Array(nonce));
-      });
-
-      it('should call transform when no nonce is provided and reassign a new nonce', async () => {
-        const spyTransform = vi.spyOn(agent.agent, 'addTransform');
-        const spyMakeNonce = vi.spyOn(httpAgent, 'makeNonce');
-
-        await agent.request({
-          ...mockRequestPayload
-        });
-
-        expect(spyTransform).toHaveBeenCalledOnce();
-        expect(spyTransform).toHaveBeenCalledWith('update', expect.any(Function));
-
-        const [[firstArg, secondArg]] = spyTransform.mock.calls;
-
-        expect(firstArg).toBe('update');
-        expect(secondArg).toBeInstanceOf(Function);
-
-        enum Endpoint {
-          Query = 'read',
-          ReadState = 'read_state',
-          Call = 'call'
-        }
-
-        const mockRequest = {
-          endpoint: Endpoint.Call,
-          request: {
-            headers: new Map()
-          },
-          body: {nonce: []}
-        };
-
-        await secondArg(mockRequest as unknown as httpAgent.HttpAgentSubmitRequest);
-
-        const nonceValue = spyMakeNonce.mock.results[0].value;
-
-        expect(mockRequest.body.nonce).toEqual(nonceValue);
       });
 
       describe('Invalid response', () => {
@@ -394,7 +358,7 @@ describe('CustomHttpAgent', () => {
         });
 
         describe('Valid response', () => {
-          it('should call agent on request', async () => {
+          it('should call agent on request without nonce', async () => {
             await agent.request(mockRequestPayload);
 
             expect(spyCall).toHaveBeenCalledOnce();
@@ -402,6 +366,20 @@ describe('CustomHttpAgent', () => {
               arg: base64ToUint8Array(mockRequestPayload.arg),
               effectiveCanisterId: mockCanisterId,
               methodName: mockRequestMethod
+            });
+          });
+
+          it('should call agent on request with nonce', async () => {
+            await agent.request(mockRequestPayloadWithNonce);
+
+            expect(spyCall).toHaveBeenCalledOnce();
+            expect(spyCall).toHaveBeenCalledWith(mockCanisterId, {
+              arg: base64ToUint8Array(mockRequestPayload.arg),
+              effectiveCanisterId: mockCanisterId,
+              methodName: mockRequestMethod,
+              nonce:
+                nonNullish(mockRequestPayloadWithNonce.nonce) &&
+                base64ToUint8Array(mockRequestPayloadWithNonce.nonce)
             });
           });
 
@@ -417,80 +395,6 @@ describe('CustomHttpAgent', () => {
 
             expect(spyPollForResponse).toHaveBeenCalledOnce();
           });
-        });
-
-        it('should call transform if a nonce is provided', async () => {
-          const spyTransform = vi.spyOn(agent.agent, 'addTransform');
-
-          const nonce = uint8ArrayToBase64(httpAgent.makeNonce());
-
-          await agent.request({
-            ...mockRequestPayload,
-            nonce
-          });
-
-          expect(spyTransform).toHaveBeenCalledOnce();
-          expect(spyTransform).toHaveBeenCalledWith('update', expect.any(Function));
-
-          const [[firstArg, secondArg]] = spyTransform.mock.calls;
-
-          expect(firstArg).toBe('update');
-          expect(secondArg).toBeInstanceOf(Function);
-
-          enum Endpoint {
-            Query = 'read',
-            ReadState = 'read_state',
-            Call = 'call'
-          }
-
-          const mockRequest = {
-            endpoint: Endpoint.Call,
-            request: {
-              headers: new Map()
-            },
-            body: {nonce: []}
-          };
-
-          await secondArg(mockRequest as unknown as httpAgent.HttpAgentSubmitRequest);
-
-          expect(mockRequest.body.nonce).toEqual(base64ToUint8Array(nonce));
-        });
-
-        it('should call transform when no nonce is provided and reassign a new nonce', async () => {
-          const spyTransform = vi.spyOn(agent.agent, 'addTransform');
-          const spyMakeNonce = vi.spyOn(httpAgent, 'makeNonce');
-
-          await agent.request({
-            ...mockRequestPayload
-          });
-
-          expect(spyTransform).toHaveBeenCalledOnce();
-          expect(spyTransform).toHaveBeenCalledWith('update', expect.any(Function));
-
-          const [[firstArg, secondArg]] = spyTransform.mock.calls;
-
-          expect(firstArg).toBe('update');
-          expect(secondArg).toBeInstanceOf(Function);
-
-          enum Endpoint {
-            Query = 'read',
-            ReadState = 'read_state',
-            Call = 'call'
-          }
-
-          const mockRequest = {
-            endpoint: Endpoint.Call,
-            request: {
-              headers: new Map()
-            },
-            body: {nonce: []}
-          };
-
-          await secondArg(mockRequest as unknown as httpAgent.HttpAgentSubmitRequest);
-
-          const nonceValue = spyMakeNonce.mock.results[0].value;
-
-          expect(mockRequest.body.nonce).toEqual(nonceValue);
         });
 
         describe('Invalid response', () => {

--- a/src/agent/custom-http-agent.spec.ts
+++ b/src/agent/custom-http-agent.spec.ts
@@ -181,14 +181,16 @@ describe('CustomHttpAgent', () => {
         it('should call agent on request with nonce', async () => {
           await agent.request(mockRequestPayloadWithNonce);
 
+          const mockedNonce =
+            nonNullish(mockRequestPayloadWithNonce.nonce) &&
+            base64ToUint8Array(mockRequestPayloadWithNonce.nonce);
+
           expect(spyCall).toHaveBeenCalledOnce();
           expect(spyCall).toHaveBeenCalledWith(mockCanisterId, {
             arg: base64ToUint8Array(mockRequestPayload.arg),
             effectiveCanisterId: mockCanisterId,
             methodName: mockRequestMethod,
-            nonce:
-              nonNullish(mockRequestPayloadWithNonce.nonce) &&
-              base64ToUint8Array(mockRequestPayloadWithNonce.nonce)
+            nonce: mockedNonce
           });
         });
 
@@ -372,14 +374,16 @@ describe('CustomHttpAgent', () => {
           it('should call agent on request with nonce', async () => {
             await agent.request(mockRequestPayloadWithNonce);
 
+            const mockedNonce =
+              nonNullish(mockRequestPayloadWithNonce.nonce) &&
+              base64ToUint8Array(mockRequestPayloadWithNonce.nonce);
+
             expect(spyCall).toHaveBeenCalledOnce();
             expect(spyCall).toHaveBeenCalledWith(mockCanisterId, {
               arg: base64ToUint8Array(mockRequestPayload.arg),
               effectiveCanisterId: mockCanisterId,
               methodName: mockRequestMethod,
-              nonce:
-                nonNullish(mockRequestPayloadWithNonce.nonce) &&
-                base64ToUint8Array(mockRequestPayloadWithNonce.nonce)
+              nonce: mockedNonce
             });
           });
 

--- a/src/agent/custom-http-agent.spec.ts
+++ b/src/agent/custom-http-agent.spec.ts
@@ -54,10 +54,6 @@ vi.mock('@dfinity/agent', async (importOriginal) => {
   };
 });
 
-vi.mock('./custom-transform-agent', () => ({
-  customAddTransform: vi.fn(() => vi.fn())
-}));
-
 describe('CustomHttpAgent', () => {
   const mockResponse: SubmitResponse['response'] = {
     body: null,

--- a/src/agent/custom-http-agent.ts
+++ b/src/agent/custom-http-agent.ts
@@ -2,11 +2,8 @@ import {
   CallRequest,
   Certificate,
   HttpAgent,
-  Nonce,
   defaultStrategy,
   lookupResultToBuffer,
-  makeNonce,
-  makeNonceTransform,
   pollForResponse as pollForResponseAgent,
   type HttpAgentOptions,
   type SubmitResponse
@@ -15,6 +12,7 @@ import {bufFromBufLike} from '@dfinity/candid';
 import {Principal} from '@dfinity/principal';
 import {base64ToUint8Array, isNullish, nonNullish} from '@dfinity/utils';
 import type {IcrcCallCanisterRequestParams} from '../types/icrc-requests';
+import {customAddTransform} from './custom-transform-agent';
 import {HttpAgentProvider} from './http-agent-provider';
 
 export type CustomHttpAgentResponse = Pick<Required<SubmitResponse>, 'requestDetails'> & {
@@ -30,6 +28,7 @@ export class UndefinedRootKeyError extends Error {}
 export class CustomHttpAgent extends HttpAgentProvider {
   private constructor(agent: HttpAgent) {
     super(agent);
+    this._agent.addTransform('update', customAddTransform());
   }
 
   static async create(
@@ -45,13 +44,12 @@ export class CustomHttpAgent extends HttpAgentProvider {
     method: methodName,
     nonce
   }: Omit<IcrcCallCanisterRequestParams, 'sender'>): Promise<CustomHttpAgentResponse> => {
-    this.attachRequestNonce({nonce});
-
     const {requestDetails, ...restResponse} = await this._agent.call(canisterId, {
       methodName,
       arg: base64ToUint8Array(arg),
       // effectiveCanisterId is optional but, actually mandatory according SDK team.
-      effectiveCanisterId: canisterId
+      effectiveCanisterId: canisterId,
+      nonce: nonNullish(nonce) ? base64ToUint8Array(nonce) : undefined
     });
 
     this.assertRequestDetails(requestDetails);
@@ -185,18 +183,5 @@ export class CustomHttpAgent extends HttpAgentProvider {
     );
 
     return {certificate, requestDetails};
-  }
-
-  private attachRequestNonce({nonce}: Pick<IcrcCallCanisterRequestParams, 'nonce'>): void {
-    if (isNullish(nonce)) {
-      // We always assign the transformer to generate a random nonce because we maintain a static reference to an agent. This ensures that even if the agent was previously configured with a transformer using a relying party's nonce, it will always generate a fresh one.
-      this._agent.addTransform('update', makeNonceTransform(makeNonce));
-      return;
-    }
-
-    this._agent.addTransform(
-      'update',
-      makeNonceTransform((): Nonce => base64ToUint8Array(nonce) as Nonce)
-    );
   }
 }

--- a/src/mocks/custom-http-agent.mocks.ts
+++ b/src/mocks/custom-http-agent.mocks.ts
@@ -16,6 +16,11 @@ export const mockRequestPayload: Pick<
   method: mockRequestMethod
 };
 
+export const mockRequestPayloadWithNonce: Omit<IcrcCallCanisterRequestParams, 'sender'> = {
+  ...mockRequestPayload,
+  nonce: uint8ArrayToBase64(new Uint8Array([1, 2, 3]))
+};
+
 export const mockRequestDetails: CallRequest = {
   arg: new Uint8Array([68, 73, 68, 76, 6, 109, 123, 110, 0, 108]),
   canister_id: Principal.fromText(mockCanisterId),


### PR DESCRIPTION
# Motivation

We needed to improve security by ensuring that a nonce is properly injected into ICRC-49 calls.
The nonce is arbitrary data (up to 32 bytes) that can be used to create distinct requests with otherwise identical fields.

# Changes

Integrated the new custom-transform-agent into CustomHttpAgent to enable transformation of icrc_49 calls.

# Tests

Added tests to cover the logic by spying on the customTransform call.

