### PR TITLE
feat: added defaultAgent to icrc_21 call

### DIFF
--- a/src/api/icrc21-canister.api.spec.ts
+++ b/src/api/icrc21-canister.api.spec.ts
@@ -1,12 +1,13 @@
 import {Actor} from '@dfinity/agent';
 import {Ed25519KeyIdentity} from '@dfinity/identity';
 import {Principal} from '@dfinity/principal';
-import * as agent from '../agent/http-agent-provider';
 import type {
   _SERVICE as Icrc21Actor,
   icrc21_consent_message_request,
   icrc21_consent_message_response
 } from '../declarations/icrc-21';
+// eslint-disable-next-line import/no-relative-parent-imports
+import * as httpAgentProvider from '../agent/http-agent-provider';
 // eslint-disable-next-line import/no-relative-parent-imports
 import {idlFactory} from '../declarations/icrc-21.idl';
 import {mockCanisterId} from '../mocks/icrc-accounts.mocks';
@@ -145,7 +146,7 @@ describe('icrc-21.canister.api', () => {
 
       // Assert that the CustomHttpAgent is created and passed to createActor
 
-      expect(agent.HttpAgentProvider.create).toHaveBeenCalledWith({
+      expect(httpAgentProvider.HttpAgentProvider.create).toHaveBeenCalledWith({
         identity: signerOptions.owner,
         host: signerOptions.host,
         shouldFetchRootKey: true
@@ -176,7 +177,7 @@ describe('icrc-21.canister.api', () => {
 
       // Ensure that the `CustomHttpAgent.create` is only called once
 
-      expect(agent.HttpAgentProvider.create).toHaveBeenCalledOnce();
+      expect(httpAgentProvider.HttpAgentProvider.create).toHaveBeenCalledOnce();
 
       // TODO: spyOn nor function does work with vitest and Actor.createActor. Not against a better idea than disabling eslint for next line.
 
@@ -203,11 +204,11 @@ describe('icrc-21.canister.api', () => {
 
     it('should return an instance of HttpAgentProvider from getDefaultAgent', async () => {
       // @ts-expect-error: accessing protected method for test
-      const httpAgentProvider = await canister.getDefaultAgent({
+      const agent = await canister.getDefaultAgent({
         ...signerOptions
       });
 
-      expect(httpAgentProvider).toBeInstanceOf(agent);
+      expect(agent).toBeInstanceOf(httpAgentProvider.HttpAgentProvider);
     });
   });
 });

--- a/src/api/icrc21-canister.api.spec.ts
+++ b/src/api/icrc21-canister.api.spec.ts
@@ -1,7 +1,7 @@
 import {Actor} from '@dfinity/agent';
 import {Ed25519KeyIdentity} from '@dfinity/identity';
 import {Principal} from '@dfinity/principal';
-import {CustomHttpAgent} from '../agent/custom-http-agent';
+import {HttpAgentProvider} from '../agent/http-agent-provider';
 import type {
   _SERVICE as Icrc21Actor,
   icrc21_consent_message_request,
@@ -13,35 +13,26 @@ import {mockCanisterId} from '../mocks/icrc-accounts.mocks';
 import type {SignerOptions} from '../types/signer-options';
 import {Icrc21Canister} from './icrc21-canister.api';
 
-vi.mock('@dfinity/agent', async (importOriginal) => {
-  const originalModule = await importOriginal<typeof import('@dfinity/agent')>();
-
+vi.mock('@dfinity/agent', () => {
   const mockActor = {test: 123};
 
   return {
-    ...originalModule,
     Actor: {
-      ...originalModule.Actor,
       createActor: vi.fn().mockResolvedValue(mockActor)
     },
     createSync: vi.fn()
   };
 });
 
-vi.mock('../agent/custom-http-agent', async (importOriginal) => {
-  const mockAgent = {test: 456};
-
-  const mockCustomAgent = {
-    get agent() {
-      return mockAgent;
-    }
-  };
+vi.mock('../agent/http-agent-provider', () => {
+  class MockHttpAgentProvider {
+    static create = vi.fn().mockResolvedValue({
+      agent: {test: 456}
+    });
+  }
 
   return {
-    ...(await importOriginal<typeof import('../agent/custom-http-agent')>()),
-    CustomHttpAgent: {
-      create: vi.fn().mockResolvedValue(mockCustomAgent)
-    }
+    HttpAgentProvider: MockHttpAgentProvider
   };
 });
 
@@ -148,7 +139,7 @@ describe('icrc-21.canister.api', () => {
 
       // Assert that the CustomHttpAgent is created and passed to createActor
 
-      expect(CustomHttpAgent.create).toHaveBeenCalledWith({
+      expect(HttpAgentProvider.create).toHaveBeenCalledWith({
         identity: signerOptions.owner,
         host: signerOptions.host,
         shouldFetchRootKey: true
@@ -179,7 +170,7 @@ describe('icrc-21.canister.api', () => {
 
       // Ensure that the `CustomHttpAgent.create` is only called once
 
-      expect(CustomHttpAgent.create).toHaveBeenCalledOnce();
+      expect(HttpAgentProvider.create).toHaveBeenCalledOnce();
 
       // TODO: spyOn nor function does work with vitest and Actor.createActor. Not against a better idea than disabling eslint for next line.
 

--- a/src/api/icrc21-canister.api.spec.ts
+++ b/src/api/icrc21-canister.api.spec.ts
@@ -6,7 +6,6 @@ import type {
   icrc21_consent_message_request,
   icrc21_consent_message_response
 } from '../declarations/icrc-21';
-// eslint-disable-next-line import/no-relative-parent-imports
 import * as httpAgentProvider from '../agent/http-agent-provider';
 // eslint-disable-next-line import/no-relative-parent-imports
 import {idlFactory} from '../declarations/icrc-21.idl';

--- a/src/api/icrc21-canister.api.spec.ts
+++ b/src/api/icrc21-canister.api.spec.ts
@@ -1,12 +1,12 @@
 import {Actor} from '@dfinity/agent';
 import {Ed25519KeyIdentity} from '@dfinity/identity';
 import {Principal} from '@dfinity/principal';
+import * as httpAgentProvider from '../agent/http-agent-provider';
 import type {
   _SERVICE as Icrc21Actor,
   icrc21_consent_message_request,
   icrc21_consent_message_response
 } from '../declarations/icrc-21';
-import * as httpAgentProvider from '../agent/http-agent-provider';
 // eslint-disable-next-line import/no-relative-parent-imports
 import {idlFactory} from '../declarations/icrc-21.idl';
 import {mockCanisterId} from '../mocks/icrc-accounts.mocks';

--- a/src/api/icrc21-canister.api.ts
+++ b/src/api/icrc21-canister.api.ts
@@ -65,7 +65,7 @@ export class Icrc21Canister extends AgentApi {
     canisterId: string | Principal;
     idlFactory: IDL.InterfaceFactory;
   } & SignerOptions): Promise<ActorSubclass<T>> {
-    const {agent} = await this.getCustomAgent({host, owner});
+    const {agent} = await this.getDefaultAgent({host, owner});
 
     return await Actor.createActor(idlFactory, {
       agent,


### PR DESCRIPTION
# Motivation

We needed to improve security by ensuring that a nonce is properly injected into ICRC-49 calls.
The nonce is arbitrary data (up to 32 bytes) that can be used to create distinct requests with otherwise identical fields.

# Changes

Added usage of defaultHttpAgent for icrc_21 call

# Tests

Adjusted tests