### PR TITLE
chore: bump for release version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dfinity/oisy-wallet-signer",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dfinity/oisy-wallet-signer",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "license": "Apache-2.0",
       "devDependencies": {
         "@dfinity/eslint-config-oisy-wallet": "^0.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/oisy-wallet-signer",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "A library designed to facilitate communication between a dApp and the OISY Wallet on the Internet Computer. ",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
# Motivation

We want to release a version with the improvements for calling canisters using a nonce. 

# Changes

- Bump version v0.1.8