### PR TITLE
build: bump vite (GHSA-356w-63v5-8wf4)

### DIFF
--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -43,7 +43,7 @@
 				"tailwindcss": "^4.0.17",
 				"tslib": "^2.8.1",
 				"typescript": "^5.7.3",
-				"vite": "^6.2.5",
+				"vite": "^6.2.6",
 				"vitest": "^3.1.1"
 			}
 		},
@@ -8104,9 +8104,9 @@
 			"license": "MIT"
 		},
 		"node_modules/vite": {
-			"version": "6.2.5",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-6.2.5.tgz",
-			"integrity": "sha512-j023J/hCAa4pRIUH6J9HemwYfjB5llR2Ps0CWeikOtdR8+pAURAk0DoJC5/mm9kd+UgdnIy7d6HE4EAvlYhPhA==",
+			"version": "6.2.6",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-6.2.6.tgz",
+			"integrity": "sha512-9xpjNl3kR4rVDZgPNdTL0/c6ao4km69a/2ihNQbcANz8RuCOK3hQBmLSJf3bRKVQjVMda+YvizNE8AwvogcPbw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/demo/package.json
+++ b/demo/package.json
@@ -46,7 +46,7 @@
 		"tailwindcss": "^4.0.17",
 		"tslib": "^2.8.1",
 		"typescript": "^5.7.3",
-		"vite": "^6.2.5",
+		"vite": "^6.2.6",
 		"vitest": "^3.1.1"
 	},
 	"type": "module",


### PR DESCRIPTION
# Motivation

Resolve another Vite server vunerability ([GHSA-356w-63v5-8wf4](https://github.com/vitejs/vite/security/advisories/GHSA-356w-63v5-8wf4))

# Changes

- Bump vite v6.2.6
