### PR TITLE
build: bump dfinity-utils v.2.13.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "@dfinity/ledger-icp": "^2",
         "@dfinity/ledger-icrc": "^2",
         "@dfinity/principal": "^2.4.0",
-        "@dfinity/utils": "^2",
+        "@dfinity/utils": "^2.13.0",
         "@dfinity/zod-schemas": "*",
         "borc": "^2.1.1",
         "simple-cbor": "^0.4.1",
@@ -402,9 +402,9 @@
       }
     },
     "node_modules/@dfinity/utils": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.10.0.tgz",
-      "integrity": "sha512-KDCYpIAkgAE4hK5VTe0XAlDeYxh2fWA5pWkUAD3pe9be0UYbrbojC1M7FoueV228OB9ObBytYKG46kFlKjkumA==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.13.0.tgz",
+      "integrity": "sha512-q2s7Qi2W7K8TD7d/d/99lUNV6bHiQfcMaOJOT91dupGY75yrMhao7wA6WPoSRRGOx9+8592FVBL4KpJsxIo4Kg==",
       "license": "Apache-2.0",
       "peer": true,
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "@dfinity/ledger-icp": "^2",
     "@dfinity/ledger-icrc": "^2",
     "@dfinity/principal": "^2.4.0",
-    "@dfinity/utils": "^2",
+    "@dfinity/utils": "^2.13.0",
     "@dfinity/zod-schemas": "*",
     "borc": "^2.1.1",
     "simple-cbor": "^0.4.1",


### PR DESCRIPTION
# Motivation

Utils [v.2.13.0](https://github.com/dfinity/ic-js/releases/tag/v69) contains an improvement - Added hashObject utility to generate a SHA-256 hash from the given object. To be used to generateHash.

# Changes

Bump utils lib.
