### PR TITLE
build: bump dfinity-utils v.2.13.0 demo

### DIFF
--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -18,7 +18,7 @@
 				"@dfinity/ledger-icp": "^2.6.11",
 				"@dfinity/ledger-icrc": "^2.7.6",
 				"@dfinity/principal": "^2.4.0",
-				"@dfinity/utils": "^2.11.0",
+				"@dfinity/utils": "^2.13.0",
 				"buffer": "^6.0.3",
 				"zod": "^3.24.2"
 			},
@@ -770,9 +770,9 @@
 			}
 		},
 		"node_modules/@dfinity/utils": {
-			"version": "2.11.0",
-			"resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.11.0.tgz",
-			"integrity": "sha512-meQSoCO/r0oEndAQ0LtWUnDXUHbju9K8UP18tDTMaoEMcMus5qQgZqxeKm7zs5XIpCiymqKSketJKvlhdkdsYQ==",
+			"version": "2.13.0",
+			"resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-2.13.0.tgz",
+			"integrity": "sha512-q2s7Qi2W7K8TD7d/d/99lUNV6bHiQfcMaOJOT91dupGY75yrMhao7wA6WPoSRRGOx9+8592FVBL4KpJsxIo4Kg==",
 			"license": "Apache-2.0",
 			"peerDependencies": {
 				"@dfinity/agent": "^2.0.0",

--- a/demo/package.json
+++ b/demo/package.json
@@ -57,7 +57,7 @@
 		"@dfinity/ledger-icp": "^2.6.11",
 		"@dfinity/ledger-icrc": "^2.7.6",
 		"@dfinity/principal": "^2.4.0",
-		"@dfinity/utils": "^2.11.0",
+		"@dfinity/utils": "^2.13.0",
 		"buffer": "^6.0.3",
 		"zod": "^3.24.2"
 	},


### PR DESCRIPTION
# Motivation

Utils [v.2.13.0](https://github.com/dfinity/ic-js/releases/tag/v69) contains an improvement - Added hashObject utility to generate a SHA-256 hash from the given object. To be used to generateHash.

# Changes

Bump utils demo.

