### PR TITLE
chore: apply lint rule `consistent-type-imports`

### DIFF
--- a/src/agent/custom-http-agent.spec.ts
+++ b/src/agent/custom-http-agent.spec.ts
@@ -30,7 +30,7 @@ import {
 import * as transformAgent from './custom-transform-agent';
 
 vi.mock('@dfinity/agent', async (importOriginal) => {
-  const originalModule = await importOriginal<typeof import('@dfinity/agent')>();
+  const originalModule = await importOriginal<typeof httpAgent>();
 
   class MockHttpAgent {
     call = vi.fn();

--- a/src/agent/custom-transform-agent.spec.ts
+++ b/src/agent/custom-transform-agent.spec.ts
@@ -5,7 +5,7 @@ import {createMockRequest, mockRequestPayload} from '../mocks/custom-http-agent.
 import {customAddTransform} from './custom-transform-agent';
 
 vi.mock('@dfinity/agent', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@dfinity/agent')>();
+  const actual = await importOriginal<typeof httpAgent>();
 
   class MockHttpAgent {
     addTransform = vi.fn();

--- a/src/agent/http-agent-provider.spec.ts
+++ b/src/agent/http-agent-provider.spec.ts
@@ -8,7 +8,7 @@ import {
 import {HttpAgentProvider} from './http-agent-provider';
 
 vi.mock('@dfinity/agent', async (importOriginal) => {
-  const originalModule = await importOriginal<typeof import('@dfinity/agent')>();
+  const originalModule = await importOriginal<typeof httpAgent>();
 
   class MockHttpAgent {
     call = vi.fn();

--- a/src/api/icrc21-canister.api.spec.ts
+++ b/src/api/icrc21-canister.api.spec.ts
@@ -1,3 +1,4 @@
+import type * as agent from '@dfinity/agent';
 import {Actor} from '@dfinity/agent';
 import {Ed25519KeyIdentity} from '@dfinity/identity';
 import {Principal} from '@dfinity/principal';
@@ -14,7 +15,7 @@ import type {SignerOptions} from '../types/signer-options';
 import {Icrc21Canister} from './icrc21-canister.api';
 
 vi.mock('@dfinity/agent', async (importOriginal) => {
-  const originalModule = await importOriginal<typeof import('@dfinity/agent')>();
+  const originalModule = await importOriginal<typeof agent>();
 
   const mockActor = {test: 123};
 

--- a/src/icp-wallet.spec.ts
+++ b/src/icp-wallet.spec.ts
@@ -1,3 +1,4 @@
+import type * as agent from '@dfinity/agent';
 import {Ed25519KeyIdentity} from '@dfinity/identity';
 import {Icrc1TransferRequest, Icrc2ApproveRequest} from '@dfinity/ledger-icp';
 import {toNullable} from '@dfinity/utils';
@@ -26,7 +27,7 @@ import * as callUtils from './utils/call.utils';
 const mocks = vi.hoisted(() => ({getRootKey: vi.fn()}));
 
 vi.mock('@dfinity/agent', async (importOriginal) => {
-  const originalModule = await importOriginal<typeof import('@dfinity/agent')>();
+  const originalModule = await importOriginal<typeof agent>();
 
   class MockHttpAgent {
     call = vi.fn();

--- a/src/icrc-wallet.spec.ts
+++ b/src/icrc-wallet.spec.ts
@@ -1,3 +1,4 @@
+import type * as agent from '@dfinity/agent';
 import {Ed25519KeyIdentity} from '@dfinity/identity';
 import {ApproveParams, TransferFromParams, TransferParams} from '@dfinity/ledger-icrc';
 import {toNullable} from '@dfinity/utils';
@@ -30,7 +31,7 @@ import * as callUtils from './utils/call.utils';
 const mocks = vi.hoisted(() => ({getRootKey: vi.fn()}));
 
 vi.mock('@dfinity/agent', async (importOriginal) => {
-  const originalModule = await importOriginal<typeof import('@dfinity/agent')>();
+  const originalModule = await importOriginal<typeof agent>();
 
   class MockHttpAgent {
     call = vi.fn();

--- a/src/utils/call.utils.spec.ts
+++ b/src/utils/call.utils.spec.ts
@@ -15,7 +15,7 @@ import * as callUtils from './call.assert.utils';
 import {assertCallResponse, decodeResponse} from './call.utils';
 
 vi.mock('@dfinity/agent', async (importOriginal) => {
-  const originalModule = await importOriginal<typeof import('@dfinity/agent')>();
+  const originalModule = await importOriginal<typeof agent>();
 
   class MockHttpAgent {
     call = vi.fn();


### PR DESCRIPTION
# Motivation

With the update of the lint library in PR https://github.com/dfinity/oisy-wallet-signer/pull/554, there are some rules that require manual intervention.

In this specific case the rule `@typescript-eslint/consistent-type-imports` enforces that `import()` type annotations are forbidden.
