### PR TITLE
chore: apply vitest lint rule `padding-around-all`

### DIFF
--- a/src/agent/custom-http-agent.spec.ts
+++ b/src/agent/custom-http-agent.spec.ts
@@ -93,6 +93,7 @@ describe('CustomHttpAgent', () => {
     expect(agent).toBeInstanceOf(CustomHttpAgent);
 
     expect(spyCustomAddTransform).toHaveBeenCalledOnce();
+
     spyCustomAddTransform.mockRestore();
   });
 
@@ -113,6 +114,7 @@ describe('CustomHttpAgent', () => {
 
   it('should expose the wrapped agent', async () => {
     const customAgent = await CustomHttpAgent.create({});
+
     expect(customAgent.agent).toBeDefined();
     expect(customAgent.agent).toBeInstanceOf(httpAgent.HttpAgent);
   });
@@ -328,6 +330,7 @@ describe('CustomHttpAgent', () => {
 
       it('should throw an exception if the agent root key is not defined', async () => {
         vi.spyOn(agent.agent, 'rootKey', 'get').mockReturnValue(null);
+
         await expect(agent.request(mockRequestPayload)).rejects.toThrow(UndefinedRootKeyError);
       });
     });
@@ -476,6 +479,7 @@ describe('CustomHttpAgent', () => {
 
   it('should throw an error if the arguments are not well formatted', async () => {
     const agent = await CustomHttpAgent.create();
+
     await expect(
       agent.request({
         arg: 'base64-encoded-argument',

--- a/src/agent/http-agent-provider.spec.ts
+++ b/src/agent/http-agent-provider.spec.ts
@@ -46,6 +46,7 @@ describe('Http-Agent-Provider', () => {
     const agentOptions = {shouldFetchRootKey: true};
     const spyCreate = vi.spyOn(httpAgent.HttpAgent, 'create');
     const agent = await HttpAgentProvider.create(agentOptions);
+
     expect(spyCreate).toHaveBeenCalledWith(agentOptions);
     expect(agent).toBeInstanceOf(HttpAgentProvider);
   });
@@ -57,12 +58,14 @@ describe('Http-Agent-Provider', () => {
     };
     const spyCreate = vi.spyOn(httpAgent.HttpAgent, 'create');
     const agent = await HttpAgentProvider.create(agentOptions);
+
     expect(spyCreate).toHaveBeenCalledWith(agentOptions);
     expect(agent).toBeInstanceOf(HttpAgentProvider);
   });
 
   it('should expose the wrapped agent', async () => {
     const agent = await HttpAgentProvider.create({});
+
     expect(agent.agent).toBeDefined();
     expect(agent.agent).toBeInstanceOf(httpAgent.HttpAgent);
   });

--- a/src/api/icrc21-canister.api.spec.ts
+++ b/src/api/icrc21-canister.api.spec.ts
@@ -138,7 +138,7 @@ describe('icrc-21.canister.api', () => {
   });
 
   describe('Actors cache', () => {
-    it('should create a new actor when none exists ', async () => {
+    it('should create a new actor when none exists', async () => {
       const result = await canister['getIcrc21Actor']({
         canisterId: mockCanisterId,
         ...signerOptions

--- a/src/api/signer.api.spec.ts
+++ b/src/api/signer.api.spec.ts
@@ -80,6 +80,7 @@ describe('SignerApi', () => {
 
       expect(spy).toHaveBeenCalledWith(expect.objectContaining({nonce}));
     });
+
     it('should return an instance of CustomHttpAgent from getCustomAgent', async () => {
       // @ts-expect-error: accessing protected method for test
       const agent = await signerApi.getCustomAgent({
@@ -95,6 +96,7 @@ describe('SignerApi', () => {
       const ledgerCanisterMock = {
         metadata: () => Promise.resolve(mockIcrcLedgerMetadata)
       } as unknown as IcrcLedgerCanister;
+
       beforeEach(() => {
         vi.mock('../agent/http-agent-provider', () => {
           class HttpAgentProvider {
@@ -160,6 +162,7 @@ describe('SignerApi', () => {
 
         expect(result).toEqual(mockIcrcLedgerMetadata);
       });
+
       it('should return an instance of HttpAgentProvider from getDefaultAgent', async () => {
         // @ts-expect-error: accessing protected method for test
         const agent = await signerApi.getDefaultAgent({
@@ -181,8 +184,8 @@ describe('SignerApi', () => {
         vi.spyOn(IcrcLedgerCanister, 'create').mockImplementation(() => ledgerCanisterMock);
       });
 
-      it('should bubble error with metadata', () => {
-        expect(
+      it('should bubble error with metadata', async () => {
+        await expect(
           signerApi.ledgerMetadata({
             params: {
               canisterId: mockRequestPayload.canisterId

--- a/src/i18n/en.spec.ts
+++ b/src/i18n/en.spec.ts
@@ -4,6 +4,7 @@ import en from './en.json';
 describe('English translations', () => {
   it('should validate all keys against schema', () => {
     const result = i18Schema.safeParse(en);
+
     expect(result.success).toBe(true);
   });
 });

--- a/src/relying-party.spec.ts
+++ b/src/relying-party.spec.ts
@@ -1595,12 +1595,14 @@ describe('Relying Party', () => {
           ]);
 
           const result = await relyingParty.requestPermissionsNotGranted();
+
           expect(result).toEqual({allPermissionsGranted: true});
           expect(relyingParty.requestPermissions).not.toHaveBeenCalled();
         });
 
         it('should request only missing permissions if some are not granted', async () => {
           const result = await relyingParty.requestPermissionsNotGranted();
+
           expect(result).toEqual({allPermissionsGranted: true});
           expect(relyingParty.requestPermissions).toHaveBeenCalledWith({
             params: {scopes: [{method: ICRC49_CALL_CANISTER}]}
@@ -1614,6 +1616,7 @@ describe('Relying Party', () => {
           ]);
 
           const result = await relyingParty.requestPermissionsNotGranted();
+
           expect(result).toEqual({allPermissionsGranted: false});
         });
 

--- a/src/services/signer.services.spec.ts
+++ b/src/services/signer.services.spec.ts
@@ -473,6 +473,7 @@ describe('Signer services', () => {
 
                 if ('Err' in result) {
                   expect(true).toBeFalsy();
+
                   return;
                 }
 

--- a/src/signer.spec.ts
+++ b/src/signer.spec.ts
@@ -68,7 +68,9 @@ describe('Signer', () => {
 
   it('should init a signer', () => {
     const signer = Signer.init(signerOptions);
+
     expect(signer).toBeInstanceOf(Signer);
+
     signer.disconnect();
   });
 
@@ -76,7 +78,9 @@ describe('Signer', () => {
     const addEventListenerSpy = vi.spyOn(window, 'addEventListener');
 
     const signer = Signer.init(signerOptions);
+
     expect(addEventListenerSpy).toHaveBeenCalledWith('message', expect.any(Function));
+
     signer.disconnect();
   });
 

--- a/src/types/blob.spec.ts
+++ b/src/types/blob.spec.ts
@@ -5,13 +5,16 @@ describe('IcrcBlob', () => {
   it('should validate a Uint8Array binary data', () => {
     const validBlob = uint8ArrayToBase64(new Uint8Array([1, 2, 3, 4]));
     const result = IcrcBlobSchema.safeParse(validBlob);
+
     expect(result.success).toBe(true);
   });
 
   it('should fail validation for a non-Uint8Array object', () => {
     const invalidBlob = [1, 2, 3, 4];
     const result = IcrcBlobSchema.safeParse(invalidBlob);
+
     expect(result.success).toBe(false);
+
     if (!result.success) {
       expect(result.error.errors[0].message).toBe('Expected string, received array');
     }
@@ -20,7 +23,9 @@ describe('IcrcBlob', () => {
   it('should fail validation for a string', () => {
     const invalidBlob = 'string-instead-of-Uint8Array';
     const result = IcrcBlobSchema.safeParse(invalidBlob);
+
     expect(result.success).toBe(false);
+
     if (!result.success) {
       expect(result.error.errors[0].message).toBe('Invalid base64 string');
     }
@@ -29,7 +34,9 @@ describe('IcrcBlob', () => {
   it('should fail validation for a number', () => {
     const invalidBlob = 1234;
     const result = IcrcBlobSchema.safeParse(invalidBlob);
+
     expect(result.success).toBe(false);
+
     if (!result.success) {
       expect(result.error.errors[0].message).toBe('Expected string, received number');
     }
@@ -38,7 +45,9 @@ describe('IcrcBlob', () => {
   it('should fail validation for an object', () => {
     const invalidBlob = {key: 'value'};
     const result = IcrcBlobSchema.safeParse(invalidBlob);
+
     expect(result.success).toBe(false);
+
     if (!result.success) {
       expect(result.error.errors[0].message).toBe('Expected string, received object');
     }
@@ -47,13 +56,16 @@ describe('IcrcBlob', () => {
   it('should accept empty base64 string', () => {
     const emptyBlob = '';
     const result = IcrcBlobSchema.safeParse(emptyBlob);
+
     expect(result.success).toBe(true);
   });
 
   it('should fail validation for an incorrectly padded base64 string', () => {
     const invalidBlob = 'YWJjZA'; // Missing padding "=="
     const result = IcrcBlobSchema.safeParse(invalidBlob);
+
     expect(result.success).toBe(false);
+
     if (!result.success) {
       expect(result.error.errors[0].message).toBe('Invalid base64 string');
     }

--- a/src/types/hex-string.spec.ts
+++ b/src/types/hex-string.spec.ts
@@ -4,40 +4,47 @@ import {HexStringSchema} from './hex-string';
 describe('HexStringSchema', () => {
   it('should validate correct lowercase hex strings', () => {
     const validHex = 'abcdef1234567890';
+
     expect(HexStringSchema.safeParse(validHex).success).toBe(true);
   });
 
   it('should validate correct uppercase hex strings', () => {
     const validHexUpper = 'ABCDEF1234567890';
+
     expect(HexStringSchema.safeParse(validHexUpper).success).toBe(true);
   });
 
   it('should validate mixed-case hex strings', () => {
     const mixedHex = 'AbCdEf123456';
+
     expect(HexStringSchema.safeParse(mixedHex).success).toBe(true);
   });
 
   it('should invalidate strings containing non-hex characters', () => {
     const invalidHex = 'xyz123';
     const result = HexStringSchema.safeParse(invalidHex);
+
     expect(result.success).toBe(false);
   });
 
   it('should invalidate empty strings', () => {
     const emptyString = '';
     const result = HexStringSchema.safeParse(emptyString);
+
     expect(result.success).toBe(false);
   });
 
   it('should invalidate strings with special characters', () => {
     const invalidSpecial = '1234-abcd';
     const result = HexStringSchema.safeParse(invalidSpecial);
+
     expect(result.success).toBe(false);
   });
 
   it('should invalidate strings containing spaces', () => {
     const invalidSpaces = 'abc 123';
     const result = HexStringSchema.safeParse(invalidSpaces);
+
     expect(result.success).toBe(false);
   });
 });

--- a/src/types/icrc-accounts.spec.ts
+++ b/src/types/icrc-accounts.spec.ts
@@ -10,6 +10,7 @@ describe('ICRC accounts', () => {
         owner: mockPrincipalText
       };
       const result = IcrcAccountSchema.safeParse(validAccount);
+
       expect(result.success).toBe(true);
     });
 
@@ -19,6 +20,7 @@ describe('ICRC accounts', () => {
         subaccount: uint8ArrayToBase64(new Uint8Array(32))
       };
       const result = IcrcAccountSchema.safeParse(validAccount);
+
       expect(result.success).toBe(true);
     });
 
@@ -27,6 +29,7 @@ describe('ICRC accounts', () => {
         owner: Principal.anonymous().toText()
       };
       const result = IcrcAccountSchema.safeParse(validAccount);
+
       expect(result.success).toBe(true);
     });
 
@@ -35,7 +38,9 @@ describe('ICRC accounts', () => {
         owner: 'invalid-principal'
       };
       const result = IcrcAccountSchema.safeParse(invalidAccount);
+
       expect(result.success).toBe(false);
+
       if (!result.success) {
         expect(result.error.errors[0].message).toBe(
           'Invalid textual representation of a Principal.'
@@ -49,7 +54,9 @@ describe('ICRC accounts', () => {
         subaccount: uint8ArrayToBase64(new Uint8Array(31))
       };
       const result = IcrcAccountSchema.safeParse(invalidAccount);
+
       expect(result.success).toBe(false);
+
       if (!result.success) {
         expect(result.error.errors[0].message).toBe('Subaccount must be exactly 32 bytes long.');
       }
@@ -61,6 +68,7 @@ describe('ICRC accounts', () => {
         subaccount: 'invalid-subaccount'
       };
       const result = IcrcAccountSchema.safeParse(invalidAccount);
+
       expect(result.success).toBe(false);
     });
   });
@@ -69,6 +77,7 @@ describe('ICRC accounts', () => {
     it('should pass validation with a single valid account', () => {
       const validAccounts = [{owner: mockPrincipalText}];
       const result = IcrcAccountsSchema.safeParse(validAccounts);
+
       expect(result.success).toBe(true);
     });
 
@@ -78,12 +87,15 @@ describe('ICRC accounts', () => {
         {owner: Principal.anonymous().toText(), subaccount: uint8ArrayToBase64(new Uint8Array(32))}
       ];
       const result = IcrcAccountsSchema.safeParse(validAccounts);
+
       expect(result.success).toBe(true);
     });
 
     it('should fail validation with an empty array', () => {
       const result = IcrcAccountsSchema.safeParse([]);
+
       expect(result.success).toBe(false);
+
       if (!result.success) {
         expect(result.error.errors[0].message).toContain('at least 1 element(s)');
       }
@@ -95,7 +107,9 @@ describe('ICRC accounts', () => {
         {owner: 'invalid-principal'}
       ];
       const result = IcrcAccountsSchema.safeParse(invalidAccounts);
+
       expect(result.success).toBe(false);
+
       if (!result.success) {
         expect(result.error.errors[0].message).toBe(
           'Invalid textual representation of a Principal.'
@@ -108,7 +122,9 @@ describe('ICRC accounts', () => {
         {owner: mockPrincipalText, subaccount: uint8ArrayToBase64(new Uint8Array(31))}
       ];
       const result = IcrcAccountsSchema.safeParse(invalidAccounts);
+
       expect(result.success).toBe(false);
+
       if (!result.success) {
         expect(result.error.errors[0].message).toBe('Subaccount must be exactly 32 bytes long.');
       }
@@ -117,12 +133,14 @@ describe('ICRC accounts', () => {
     it('should pass validation with an account that has no subaccount (optional field)', () => {
       const validAccounts = [{owner: mockPrincipalText}];
       const result = IcrcAccountsSchema.safeParse(validAccounts);
+
       expect(result.success).toBe(true);
     });
 
     it('should fail validation when subaccount is not a blob', () => {
       const invalidAccounts = [{owner: mockPrincipalText, subaccount: 'invalid-subaccount'}];
       const result = IcrcAccountsSchema.safeParse(invalidAccounts);
+
       expect(result.success).toBe(false);
     });
   });

--- a/src/types/icrc-requests.spec.ts
+++ b/src/types/icrc-requests.spec.ts
@@ -46,6 +46,7 @@ describe('icrc-requests', () => {
           ]
         }
       };
+
       expect(() => IcrcRequestAnyPermissionsRequestSchema.parse(randomMethodRequest)).not.toThrow();
     });
 
@@ -56,6 +57,7 @@ describe('icrc-requests', () => {
           scopes: []
         }
       };
+
       expect(() => IcrcRequestAnyPermissionsRequestSchema.parse(invalidRequest)).toThrow();
     });
 
@@ -65,6 +67,7 @@ describe('icrc-requests', () => {
         // @ts-expect-error: we are testing this on purpose
         params: {}
       };
+
       expect(() => IcrcRequestAnyPermissionsRequestSchema.parse(invalidRequest)).toThrow();
     });
 
@@ -73,6 +76,7 @@ describe('icrc-requests', () => {
 
       // @ts-expect-error: we are testing this on purpose
       const invalidRequest: IcrcRequestAnyPermissionsRequest = rest;
+
       expect(() => IcrcRequestAnyPermissionsRequestSchema.parse(invalidRequest)).toThrow();
     });
 
@@ -82,6 +86,7 @@ describe('icrc-requests', () => {
         // @ts-expect-error: we are testing this on purpose
         method: 'test'
       };
+
       expect(() => IcrcRequestAnyPermissionsRequestSchema.parse(invalidRequest)).toThrow();
     });
 
@@ -89,6 +94,7 @@ describe('icrc-requests', () => {
       const {id: _, ...rest} = validRequest;
 
       const invalidRequest: Partial<IcrcRequestAnyPermissionsRequest> = rest;
+
       expect(() => IcrcRequestAnyPermissionsRequestSchema.parse(invalidRequest)).toThrow();
     });
 
@@ -96,6 +102,7 @@ describe('icrc-requests', () => {
       const {jsonrpc: _, ...rest} = validRequest;
 
       const invalidRequest: Partial<IcrcRequestAnyPermissionsRequest> = rest;
+
       expect(() => IcrcRequestAnyPermissionsRequestSchema.parse(invalidRequest)).toThrow();
     });
   });
@@ -117,6 +124,7 @@ describe('icrc-requests', () => {
         // @ts-expect-error: we are testing this on purpose
         params: {}
       };
+
       expect(() => IcrcPermissionsRequestSchema.parse(invalidRequest)).toThrow();
     });
 
@@ -126,6 +134,7 @@ describe('icrc-requests', () => {
         // @ts-expect-error: we are testing this on purpose
         method: 'test'
       };
+
       expect(() => IcrcPermissionsRequestSchema.parse(invalidRequest)).toThrow();
     });
 
@@ -133,6 +142,7 @@ describe('icrc-requests', () => {
       const {id: _, ...rest} = validRequest;
 
       const invalidRequest: Partial<IcrcPermissionsRequest> = rest;
+
       expect(() => IcrcPermissionsRequestSchema.parse(invalidRequest)).toThrow();
     });
 
@@ -140,6 +150,7 @@ describe('icrc-requests', () => {
       const {jsonrpc: _, ...rest} = validRequest;
 
       const invalidRequest: Partial<IcrcPermissionsRequest> = rest;
+
       expect(() => IcrcPermissionsRequestSchema.parse(invalidRequest)).toThrow();
     });
   });
@@ -165,6 +176,7 @@ describe('icrc-requests', () => {
         ...validRequest,
         params: {}
       };
+
       expect(() => schema.parse(invalidRequest)).toThrow();
     });
 
@@ -173,6 +185,7 @@ describe('icrc-requests', () => {
         ...validRequest,
         method: 'test'
       };
+
       expect(() => schema.parse(invalidRequest)).toThrow();
     });
 
@@ -180,6 +193,7 @@ describe('icrc-requests', () => {
       const {id: _, ...rest} = validRequest;
 
       const invalidRequest = rest;
+
       expect(() => schema.parse(invalidRequest)).toThrow();
     });
 
@@ -187,6 +201,7 @@ describe('icrc-requests', () => {
       const {jsonrpc: _, ...rest} = validRequest;
 
       const invalidRequest = rest;
+
       expect(() => schema.parse(invalidRequest)).toThrow();
     });
   });
@@ -208,6 +223,7 @@ describe('icrc-requests', () => {
         // @ts-expect-error: we are testing this on purpose
         params: {}
       };
+
       expect(() => IcrcAccountsRequestSchema.parse(invalidRequest)).toThrow();
     });
 
@@ -217,6 +233,7 @@ describe('icrc-requests', () => {
         // @ts-expect-error: we are testing this on purpose
         method: 'test'
       };
+
       expect(() => IcrcAccountsRequestSchema.parse(invalidRequest)).toThrow();
     });
 
@@ -224,6 +241,7 @@ describe('icrc-requests', () => {
       const {id: _, ...rest} = validRequest;
 
       const invalidRequest = rest;
+
       expect(() => IcrcAccountsRequestSchema.parse(invalidRequest)).toThrow();
     });
 
@@ -231,6 +249,7 @@ describe('icrc-requests', () => {
       const {jsonrpc: _, ...rest} = validRequest;
 
       const invalidRequest = rest;
+
       expect(() => IcrcAccountsRequestSchema.parse(invalidRequest)).toThrow();
     });
   });
@@ -255,6 +274,7 @@ describe('icrc-requests', () => {
           canisterId: 'invalid-principal'
         }
       };
+
       expect(() => IcrcCallCanisterRequestSchema.parse(invalidRequest)).toThrow();
     });
 
@@ -266,6 +286,7 @@ describe('icrc-requests', () => {
           sender: 'invalid-principal'
         }
       };
+
       expect(() => IcrcCallCanisterRequestSchema.parse(invalidRequest)).toThrow();
     });
 
@@ -277,6 +298,7 @@ describe('icrc-requests', () => {
           method: ''
         }
       };
+
       expect(() => IcrcCallCanisterRequestSchema.parse(invalidRequest)).toThrow();
     });
 
@@ -288,6 +310,7 @@ describe('icrc-requests', () => {
           arg: 'not-a-Uint8Array'
         }
       };
+
       expect(() => IcrcCallCanisterRequestSchema.parse(invalidRequest)).toThrow();
     });
 
@@ -299,6 +322,7 @@ describe('icrc-requests', () => {
           nonce: uint8ArrayToBase64(new Uint8Array(20))
         }
       };
+
       expect(() => IcrcCallCanisterRequestSchema.parse(validMemoRequest)).not.toThrow();
     });
 
@@ -310,6 +334,7 @@ describe('icrc-requests', () => {
           nonce: uint8ArrayToBase64(new Uint8Array(32))
         }
       };
+
       expect(() => IcrcCallCanisterRequestSchema.parse(validMemoRequest)).not.toThrow();
     });
 
@@ -321,6 +346,7 @@ describe('icrc-requests', () => {
           nonce: new Uint8Array(33)
         }
       };
+
       expect(() => IcrcCallCanisterRequestSchema.parse(invalidMemoRequest)).toThrow();
     });
 
@@ -328,6 +354,7 @@ describe('icrc-requests', () => {
       const {params: _, ...rest} = validRequest;
 
       const invalidRequest = rest;
+
       expect(() => IcrcCallCanisterRequestSchema.parse(invalidRequest)).toThrow();
     });
 
@@ -338,6 +365,7 @@ describe('icrc-requests', () => {
         ...rest,
         params: validRequest.params
       };
+
       expect(() => IcrcCallCanisterRequestSchema.parse(invalidRequest)).toThrow();
     });
 
@@ -348,6 +376,7 @@ describe('icrc-requests', () => {
         ...rest,
         params: validRequest.params
       };
+
       expect(() => IcrcCallCanisterRequestSchema.parse(invalidRequest)).toThrow();
     });
 
@@ -356,6 +385,7 @@ describe('icrc-requests', () => {
         ...validRequest,
         method: 'invalid_method'
       };
+
       expect(() => IcrcCallCanisterRequestSchema.parse(invalidRequest)).toThrow();
     });
   });
@@ -370,6 +400,7 @@ describe('icrc-requests', () => {
         ...mockCallCanisterParams,
         canisterId: 'invalid-principal'
       };
+
       expect(() => IcrcCallCanisterRequestParamsSchema.parse(invalidParams)).toThrow();
     });
 
@@ -378,6 +409,7 @@ describe('icrc-requests', () => {
         ...mockCallCanisterParams,
         sender: 'invalid-principal'
       };
+
       expect(() => IcrcCallCanisterRequestParamsSchema.parse(invalidParams)).toThrow();
     });
 
@@ -386,6 +418,7 @@ describe('icrc-requests', () => {
         ...mockCallCanisterParams,
         method: ''
       };
+
       expect(() => IcrcCallCanisterRequestParamsSchema.parse(invalidParams)).toThrow();
     });
 
@@ -394,6 +427,7 @@ describe('icrc-requests', () => {
         ...mockCallCanisterParams,
         arg: 'not-a-Uint8Array'
       };
+
       expect(() => IcrcCallCanisterRequestParamsSchema.parse(invalidParams)).toThrow();
     });
 
@@ -402,6 +436,7 @@ describe('icrc-requests', () => {
         ...mockCallCanisterParams,
         nonce: uint8ArrayToBase64(new Uint8Array(20))
       };
+
       expect(() => IcrcCallCanisterRequestParamsSchema.parse(validMemoParams)).not.toThrow();
     });
 
@@ -410,6 +445,7 @@ describe('icrc-requests', () => {
         ...mockCallCanisterParams,
         nonce: uint8ArrayToBase64(new Uint8Array(32))
       };
+
       expect(() => IcrcCallCanisterRequestParamsSchema.parse(validMemoParams)).not.toThrow();
     });
 
@@ -418,6 +454,7 @@ describe('icrc-requests', () => {
         ...mockCallCanisterParams,
         nonce: new Uint8Array(33)
       };
+
       expect(() => IcrcCallCanisterRequestParamsSchema.parse(invalidMemoParams)).toThrow();
     });
 

--- a/src/types/icrc-responses.spec.ts
+++ b/src/types/icrc-responses.spec.ts
@@ -60,6 +60,7 @@ describe('icrc-responses', () => {
           ]
         }
       };
+
       expect(() => schema.parse(invalidResponse)).toThrow();
     });
 
@@ -77,6 +78,7 @@ describe('icrc-responses', () => {
           ]
         }
       };
+
       expect(() => schema.parse(invalidResponse)).toThrow();
     });
 
@@ -94,6 +96,7 @@ describe('icrc-responses', () => {
           ]
         }
       };
+
       expect(() => schema.parse(invalidResponse)).toThrow();
     });
 
@@ -109,6 +112,7 @@ describe('icrc-responses', () => {
           ]
         }
       };
+
       expect(() => schema.parse(invalidResponse)).toThrow();
     });
 
@@ -123,6 +127,7 @@ describe('icrc-responses', () => {
           ]
         }
       };
+
       expect(() => schema.parse(invalidResponse)).toThrow();
     });
 
@@ -133,6 +138,7 @@ describe('icrc-responses', () => {
           scopes: [{}]
         }
       };
+
       expect(() => schema.parse(invalidResponse)).toThrow();
     });
 
@@ -378,6 +384,7 @@ describe('icrc-responses', () => {
           ]
         }
       };
+
       expect(() => IcrcSupportedStandardsResponseSchema.parse(invalidResponse)).toThrow();
     });
 
@@ -393,6 +400,7 @@ describe('icrc-responses', () => {
           ]
         }
       };
+
       expect(() => IcrcSupportedStandardsResponseSchema.parse(invalidResponse)).toThrow();
     });
 
@@ -408,6 +416,7 @@ describe('icrc-responses', () => {
           ]
         }
       };
+
       expect(() => IcrcSupportedStandardsResponseSchema.parse(invalidResponse)).toThrow();
     });
 
@@ -423,6 +432,7 @@ describe('icrc-responses', () => {
           ]
         }
       };
+
       expect(() => IcrcSupportedStandardsResponseSchema.parse(invalidResponse)).toThrow();
     });
 
@@ -438,6 +448,7 @@ describe('icrc-responses', () => {
           ]
         }
       };
+
       expect(() => IcrcSupportedStandardsResponseSchema.parse(invalidResponse)).toThrow();
     });
 
@@ -448,6 +459,7 @@ describe('icrc-responses', () => {
           supportedStandards: []
         }
       };
+
       expect(() => IcrcSupportedStandardsResponseSchema.parse(invalidResponse)).toThrow();
     });
 
@@ -505,6 +517,7 @@ describe('icrc-responses', () => {
         // @ts-expect-error: we are testing this on purpose
         result: 'test'
       };
+
       expect(() => IcrcReadyResponseSchema.parse(invalidResponse)).toThrow();
     });
 
@@ -516,6 +529,7 @@ describe('icrc-responses', () => {
           hello: 'world'
         }
       };
+
       expect(() => IcrcReadyResponseSchema.parse(invalidResponse)).toThrow();
     });
 
@@ -568,6 +582,7 @@ describe('icrc-responses', () => {
           ]
         }
       };
+
       expect(() => IcrcAccountsResponseSchema.parse(invalidResponse)).toThrow();
     });
 
@@ -583,6 +598,7 @@ describe('icrc-responses', () => {
           ]
         }
       };
+
       expect(() => IcrcAccountsResponseSchema.parse(invalidResponse)).toThrow();
     });
 
@@ -598,6 +614,7 @@ describe('icrc-responses', () => {
           ]
         }
       };
+
       expect(() => IcrcAccountsResponseSchema.parse(invalidResponse)).toThrow();
     });
 
@@ -668,6 +685,7 @@ describe('icrc-responses', () => {
           ...validResponse.result,
           contentMap: 'invalid-content'
         };
+
         expect(() => IcrcCallCanisterResultSchema.parse(invalidPayload)).toThrow();
       });
 
@@ -676,16 +694,19 @@ describe('icrc-responses', () => {
           ...validResponse.result,
           certificate: 'invalid-certificate'
         };
+
         expect(() => IcrcCallCanisterResultSchema.parse(invalidPayload)).toThrow();
       });
 
       it('should throw if contentMap is missing', () => {
         const {contentMap: _, ...rest} = validResponse.result;
+
         expect(() => IcrcCallCanisterResultSchema.parse(rest)).toThrow();
       });
 
       it('should throw if certificate is missing', () => {
         const {certificate: _, ...rest} = validResponse.result;
+
         expect(() => IcrcCallCanisterResultSchema.parse(rest)).toThrow();
       });
 
@@ -694,6 +715,7 @@ describe('icrc-responses', () => {
           ...validResponse.result,
           extraField: 'unexpected'
         };
+
         expect(() => IcrcCallCanisterResultSchema.parse(invalidPayload)).toThrow();
       });
     });
@@ -711,6 +733,7 @@ describe('icrc-responses', () => {
             contentMap: 'invalid-content'
           }
         };
+
         expect(() => IcrcCallCanisterResponseSchema.parse(invalidResponse)).toThrow();
       });
 
@@ -722,6 +745,7 @@ describe('icrc-responses', () => {
             certificate: 'invalid-certificate'
           }
         };
+
         expect(() => IcrcCallCanisterResponseSchema.parse(invalidResponse)).toThrow();
       });
 
@@ -732,6 +756,7 @@ describe('icrc-responses', () => {
           ...validResponse,
           result: rest
         };
+
         expect(() => IcrcCallCanisterResponseSchema.parse(invalidResponse)).toThrow();
       });
 
@@ -742,6 +767,7 @@ describe('icrc-responses', () => {
           ...validResponse,
           result: rest
         };
+
         expect(() => IcrcCallCanisterResponseSchema.parse(invalidResponse)).toThrow();
       });
 
@@ -753,6 +779,7 @@ describe('icrc-responses', () => {
             extraField: 'unexpected'
           }
         };
+
         expect(() => IcrcCallCanisterResponseSchema.parse(invalidResponse)).toThrow();
       });
 
@@ -760,6 +787,7 @@ describe('icrc-responses', () => {
         const {result: _, ...rest} = validResponse;
 
         const invalidResponse = rest;
+
         expect(() => IcrcCallCanisterResponseSchema.parse(invalidResponse)).toThrow();
       });
 
@@ -767,6 +795,7 @@ describe('icrc-responses', () => {
         const {id: _, ...rest} = validResponse;
 
         const invalidResponse = rest;
+
         expect(() => IcrcCallCanisterResponseSchema.parse(invalidResponse)).toThrow();
       });
 
@@ -774,6 +803,7 @@ describe('icrc-responses', () => {
         const {jsonrpc: _, ...rest} = validResponse;
 
         const invalidResponse = rest;
+
         expect(() => IcrcCallCanisterResponseSchema.parse(invalidResponse)).toThrow();
       });
     });

--- a/src/types/post-message.spec.ts
+++ b/src/types/post-message.spec.ts
@@ -4,24 +4,28 @@ describe('post-message', () => {
   it('should validate a correct origin', () => {
     const validUrl = 'https://test.com';
     const result = OriginSchema.safeParse(validUrl);
+
     expect(result.success).toBe(true);
   });
 
   it('should invalidate an incorrect origin', () => {
     const invalidUrl = 'invalid-origin';
     const result = OriginSchema.safeParse(invalidUrl);
+
     expect(result.success).toBe(false);
   });
 
   it('should invalidate an empty origin string', () => {
     const emptyUrl = '';
     const result = OriginSchema.safeParse(emptyUrl);
+
     expect(result.success).toBe(false);
   });
 
   it('should invalidate a non-string origin', () => {
     const nonStringValue = 12345;
     const result = OriginSchema.safeParse(nonStringValue);
+
     expect(result.success).toBe(false);
   });
 });

--- a/src/types/relying-party-options.spec.ts
+++ b/src/types/relying-party-options.spec.ts
@@ -17,6 +17,7 @@ describe('RelyingPartyOptions', () => {
     };
 
     const result = RelyingPartyOptionsSchema.safeParse(validData);
+
     expect(result.success).toBe(true);
   });
 
@@ -29,6 +30,7 @@ describe('RelyingPartyOptions', () => {
     };
 
     const result = RelyingPartyOptionsSchema.safeParse(invalidData);
+
     expect(result.success).toBe(false);
   });
 
@@ -41,6 +43,7 @@ describe('RelyingPartyOptions', () => {
     };
 
     const result = RelyingPartyOptionsSchema.safeParse(invalidData);
+
     expect(result.success).toBe(false);
   });
 
@@ -53,6 +56,7 @@ describe('RelyingPartyOptions', () => {
     };
 
     const result = RelyingPartyOptionsSchema.safeParse(invalidData);
+
     expect(result.success).toBe(false);
   });
 
@@ -65,6 +69,7 @@ describe('RelyingPartyOptions', () => {
     };
 
     const result = RelyingPartyOptionsSchema.safeParse(invalidData);
+
     expect(result.success).toBe(false);
   });
 
@@ -75,6 +80,7 @@ describe('RelyingPartyOptions', () => {
     };
 
     const result = RelyingPartyOptionsSchema.safeParse(validData);
+
     expect(result.success).toBe(true);
   });
 
@@ -84,6 +90,7 @@ describe('RelyingPartyOptions', () => {
     };
 
     const result = RelyingPartyOptionsSchema.safeParse(invalidData);
+
     expect(result.success).toBe(false);
   });
 
@@ -98,6 +105,7 @@ describe('RelyingPartyOptions', () => {
     };
 
     const result = RelyingPartyOptionsSchema.safeParse(invalidData);
+
     expect(result.success).toBe(false);
   });
 
@@ -112,6 +120,7 @@ describe('RelyingPartyOptions', () => {
     };
 
     const result = RelyingPartyOptionsSchema.safeParse(invalidData);
+
     expect(result.success).toBe(false);
   });
 
@@ -126,6 +135,7 @@ describe('RelyingPartyOptions', () => {
     };
 
     const result = RelyingPartyOptionsSchema.safeParse(invalidData);
+
     expect(result.success).toBe(false);
   });
 
@@ -140,6 +150,7 @@ describe('RelyingPartyOptions', () => {
     };
 
     const result = RelyingPartyOptionsSchema.safeParse(validData);
+
     expect(result.success).toBe(true);
   });
 
@@ -152,6 +163,7 @@ describe('RelyingPartyOptions', () => {
     };
 
     const result = RelyingPartyOptionsSchema.safeParse(invalidData);
+
     expect(result.success).toBe(false);
   });
 
@@ -161,6 +173,7 @@ describe('RelyingPartyOptions', () => {
     };
 
     const result = RelyingPartyOptionsSchema.safeParse(validData);
+
     expect(result.success).toBe(true);
   });
 
@@ -173,6 +186,7 @@ describe('RelyingPartyOptions', () => {
     };
 
     const result = RelyingPartyOptionsSchema.safeParse(validData);
+
     expect(result.success).toBe(true);
   });
 
@@ -183,6 +197,7 @@ describe('RelyingPartyOptions', () => {
     };
 
     const result = RelyingPartyOptionsSchema.safeParse(invalidData);
+
     expect(result.success).toBe(false);
   });
 
@@ -196,6 +211,7 @@ describe('RelyingPartyOptions', () => {
         ...validData,
         host: 'http://localhost:4943'
       });
+
       expect(result.success).toBe(true);
     });
 
@@ -204,6 +220,7 @@ describe('RelyingPartyOptions', () => {
         ...validData,
         host: 'https://localhost:4943'
       });
+
       expect(result.success).toBe(true);
     });
 
@@ -212,6 +229,7 @@ describe('RelyingPartyOptions', () => {
         ...validData,
         host: 'https://example.com'
       });
+
       expect(result.success).toBe(true);
     });
 
@@ -220,6 +238,7 @@ describe('RelyingPartyOptions', () => {
         ...validData,
         host: 'http://example.com'
       });
+
       expect(result.success).toBe(false);
       expect(result.error?.errors[0]?.message).toBe('Invalid URL.');
     });
@@ -228,6 +247,7 @@ describe('RelyingPartyOptions', () => {
       const result = RelyingPartyOptionsSchema.safeParse({
         ...validData
       });
+
       expect(result.success).toBe(true);
     });
 
@@ -236,6 +256,7 @@ describe('RelyingPartyOptions', () => {
         ...validData,
         host: 'not-a-url'
       });
+
       expect(result.success).toBe(false);
       expect(result.error?.errors[0]?.message).toBe('Invalid url');
     });

--- a/src/types/relying-party-request.spec.ts
+++ b/src/types/relying-party-request.spec.ts
@@ -8,6 +8,7 @@ describe('RelyingPartyRequests', () => {
       };
 
       const result = RelyingPartyRequestOptionsSchema.safeParse(validData);
+
       expect(result.success).toBe(true);
     });
 
@@ -15,6 +16,7 @@ describe('RelyingPartyRequests', () => {
       const validData = {};
 
       const result = RelyingPartyRequestOptionsSchema.safeParse(validData);
+
       expect(result.success).toBe(true);
     });
 
@@ -24,6 +26,7 @@ describe('RelyingPartyRequests', () => {
       };
 
       const result = RelyingPartyRequestOptionsSchema.safeParse(invalidData);
+
       expect(result.success).toBe(false);
     });
 
@@ -33,6 +36,7 @@ describe('RelyingPartyRequests', () => {
       };
 
       const result = RelyingPartyRequestOptionsSchema.safeParse(invalidData);
+
       expect(result.success).toBe(false);
     });
 
@@ -42,6 +46,7 @@ describe('RelyingPartyRequests', () => {
       };
 
       const result = RelyingPartyRequestOptionsSchema.safeParse(invalidData);
+
       expect(result.success).toBe(false);
     });
   });

--- a/src/types/rpc.spec.ts
+++ b/src/types/rpc.spec.ts
@@ -17,6 +17,7 @@ describe('rpc', () => {
         jsonrpc: JSON_RPC_VERSION_2,
         method: 'test'
       };
+
       expect(() => RpcNotificationSchema.parse(validRpcNotification)).not.toThrow();
     });
 
@@ -28,6 +29,7 @@ describe('rpc', () => {
           hello: 'world'
         }
       };
+
       expect(() => RpcNotificationSchema.parse(validRpcNotification)).not.toThrow();
     });
 
@@ -55,6 +57,7 @@ describe('rpc', () => {
         method: 'test',
         hello: 'world'
       };
+
       expect(() => RpcNotificationSchema.parse(invalidRpcNotification)).toThrow();
     });
 
@@ -75,6 +78,7 @@ describe('rpc', () => {
           id: 1,
           method: 'test'
         };
+
         expect(() => RpcRequestSchema.parse(validRpcRequest)).not.toThrow();
       });
 
@@ -85,6 +89,7 @@ describe('rpc', () => {
           method: 'test',
           hello: 'world'
         };
+
         expect(() => RpcRequestSchema.parse(invalidRpcRequest)).toThrow();
       });
 
@@ -94,6 +99,7 @@ describe('rpc', () => {
           method: 'test',
           params: {hello: 123}
         };
+
         expect(() => RpcRequestSchema.parse(invalidRpcRequest)).toThrow();
       });
 
@@ -103,6 +109,7 @@ describe('rpc', () => {
           method: 'test',
           params: {hello: 123}
         };
+
         expect(() => RpcRequestSchema.parse(invalidRpcRequest)).toThrow();
       });
 
@@ -112,6 +119,7 @@ describe('rpc', () => {
           id: 123,
           params: {hello: 123}
         };
+
         expect(() => RpcRequestSchema.parse(invalidRpcRequest)).toThrow();
       });
     });
@@ -125,6 +133,7 @@ describe('rpc', () => {
           id: 1,
           method: 'test'
         };
+
         expect(() => RpcCustomRequest.parse(validRpcRequest)).not.toThrow();
       });
 
@@ -135,6 +144,7 @@ describe('rpc', () => {
           method: 'test',
           hello: 'world'
         };
+
         expect(() => RpcCustomRequest.parse(invalidRpcRequest)).toThrow();
       });
 
@@ -144,6 +154,7 @@ describe('rpc', () => {
           method: 'test',
           params: {hello: 123}
         };
+
         expect(() => RpcCustomRequest.parse(invalidRpcRequest)).toThrow();
       });
 
@@ -153,6 +164,7 @@ describe('rpc', () => {
           method: 'test',
           params: {hello: 123}
         };
+
         expect(() => RpcCustomRequest.parse(invalidRpcRequest)).toThrow();
       });
 
@@ -162,6 +174,7 @@ describe('rpc', () => {
           id: 123,
           params: {hello: 123}
         };
+
         expect(() => RpcCustomRequest.parse(invalidRpcRequest)).toThrow();
       });
     });
@@ -180,6 +193,7 @@ describe('rpc', () => {
           method: 'test',
           params: {hello: 'world'}
         };
+
         expect(() => RpcCustomRequest.parse(validRpcRequest)).not.toThrow();
       });
 
@@ -190,6 +204,7 @@ describe('rpc', () => {
           method: 'test',
           params: {hello: 123}
         };
+
         expect(() => RpcCustomRequest.parse(invalidRpcRequest)).toThrow();
       });
 
@@ -199,6 +214,7 @@ describe('rpc', () => {
           id: 1,
           method: 'test'
         };
+
         expect(() => RpcCustomRequest.parse(invalidRpcRequest)).toThrow();
       });
 
@@ -208,6 +224,7 @@ describe('rpc', () => {
           method: 'test',
           params: {hello: 123}
         };
+
         expect(() => RpcCustomRequest.parse(invalidRpcRequest)).toThrow();
       });
 
@@ -218,6 +235,7 @@ describe('rpc', () => {
           method: 'test-invalid',
           params: {hello: 'world'}
         };
+
         expect(() => RpcCustomRequest.parse(invalidRpcRequest)).toThrow();
       });
 
@@ -227,6 +245,7 @@ describe('rpc', () => {
           method: 'test',
           params: {hello: 123}
         };
+
         expect(() => RpcCustomRequest.parse(invalidRpcRequest)).toThrow();
       });
 
@@ -236,6 +255,7 @@ describe('rpc', () => {
           id: 123,
           params: {hello: 123}
         };
+
         expect(() => RpcCustomRequest.parse(invalidRpcRequest)).toThrow();
       });
     });
@@ -248,6 +268,7 @@ describe('rpc', () => {
         id: 1,
         result: {success: true}
       };
+
       expect(() => RpcResponseWithResultOrErrorSchema.parse(validRpcResponse)).not.toThrow();
     });
 
@@ -260,6 +281,7 @@ describe('rpc', () => {
           message: 'An internal error occurred'
         }
       };
+
       expect(() => RpcResponseWithResultOrErrorSchema.parse(validRpcResponse)).not.toThrow();
     });
 
@@ -272,6 +294,7 @@ describe('rpc', () => {
           message: 'A custom application error occurred'
         }
       };
+
       expect(() => RpcResponseWithResultOrErrorSchema.parse(validRpcResponse)).not.toThrow();
     });
 
@@ -280,6 +303,7 @@ describe('rpc', () => {
         jsonrpc: JSON_RPC_VERSION_2,
         id: 1
       };
+
       expect(() => RpcResponseWithResultOrErrorSchema.parse(invalidRpcResponse)).toThrow(
         'Either result or error should be provided.'
       );
@@ -290,6 +314,7 @@ describe('rpc', () => {
         jsonrpc: JSON_RPC_VERSION_2,
         result: {success: true}
       };
+
       expect(() => RpcResponseWithResultOrErrorSchema.parse(validRpcResponse)).toThrow();
     });
 
@@ -301,6 +326,7 @@ describe('rpc', () => {
           message: 'An internal error occurred'
         }
       };
+
       expect(() => RpcResponseWithResultOrErrorSchema.parse(validRpcResponse)).toThrow();
     });
 
@@ -309,6 +335,7 @@ describe('rpc', () => {
         id: 1,
         result: {success: true}
       };
+
       expect(() => RpcResponseWithResultOrErrorSchema.parse(validRpcResponse)).toThrow();
     });
 
@@ -320,6 +347,7 @@ describe('rpc', () => {
           message: 'An internal error occurred'
         }
       };
+
       expect(() => RpcResponseWithResultOrErrorSchema.parse(validRpcResponse)).toThrow();
     });
 
@@ -330,6 +358,7 @@ describe('rpc', () => {
         result: {success: true},
         hello: 'world'
       };
+
       expect(() => RpcResponseWithResultOrErrorSchema.parse(invalidRpcResponse)).toThrow();
     });
   });
@@ -344,6 +373,7 @@ describe('rpc', () => {
           message: 'An internal error occurred'
         }
       };
+
       expect(() => RpcResponseWithErrorSchema.parse(validRpcResponseWithError)).not.toThrow();
     });
 
@@ -356,6 +386,7 @@ describe('rpc', () => {
           message: 'A custom error occurred'
         }
       };
+
       expect(() => RpcResponseWithErrorSchema.parse(validRpcResponseWithError)).not.toThrow();
     });
 
@@ -367,6 +398,7 @@ describe('rpc', () => {
           message: 'An error occurred without a code'
         }
       };
+
       expect(() => RpcResponseWithErrorSchema.parse(invalidRpcResponseWithError)).toThrow();
     });
 
@@ -378,6 +410,7 @@ describe('rpc', () => {
           code: RpcErrorCode.INTERNAL_ERROR
         }
       };
+
       expect(() => RpcResponseWithErrorSchema.parse(invalidRpcResponseWithError)).toThrow();
     });
 
@@ -389,6 +422,7 @@ describe('rpc', () => {
           message: 'An internal error occurred'
         }
       };
+
       expect(() => RpcResponseWithErrorSchema.parse(invalidRpcResponseWithError)).toThrow();
     });
 
@@ -400,6 +434,7 @@ describe('rpc', () => {
           message: 'An internal error occurred'
         }
       };
+
       expect(() => RpcResponseWithErrorSchema.parse(invalidRpcResponseWithError)).toThrow();
     });
 
@@ -413,6 +448,7 @@ describe('rpc', () => {
         },
         additionalField: 'not allowed'
       };
+
       expect(() => RpcResponseWithErrorSchema.parse(invalidRpcResponseWithError)).toThrow();
     });
   });

--- a/src/types/signer-options.spec.ts
+++ b/src/types/signer-options.spec.ts
@@ -58,6 +58,7 @@ describe('SignerOptions', () => {
       };
 
       const result = SignerOptionsSchema.parse(validSignerOptions);
+
       expect(result.host).toBeUndefined();
     });
 
@@ -98,6 +99,7 @@ describe('SignerOptions', () => {
       };
 
       const result = SignerOptionsSchema.parse(validSignerOptions);
+
       expect(result.sessionOptions).toBeUndefined();
     });
 

--- a/src/types/signer-sessions.spec.ts
+++ b/src/types/signer-sessions.spec.ts
@@ -26,6 +26,7 @@ describe('Signer-sessions', () => {
     };
 
     const parsedData = SessionPermissionsSchema.parse(validData);
+
     expect(parsedData).toEqual(validData);
   });
 
@@ -203,6 +204,7 @@ describe('Signer-sessions', () => {
     };
 
     const parsedData = SessionPermissionsSchema.parse(validData);
+
     expect(parsedData).toEqual(validData);
   });
 });

--- a/src/utils/format.utils.spec.ts
+++ b/src/utils/format.utils.spec.ts
@@ -41,24 +41,28 @@ describe('format.utils', () => {
     it('formats a valid date correctly', () => {
       const input = 1704032400000000000n;
       const result = formatDate(input);
+
       expect(result).toBe('Sun, Dec 31, 2023, 14:20:00 UTC');
     });
 
     it('formats a different valid date correctly', () => {
       const input = 1693526400000000000n;
       const result = formatDate(input);
+
       expect(result).toBe('Fri, Sep 1, 2023, 00:00:00 UTC');
     });
 
     it('handles zero timestamp (epoch)', () => {
       const input = 0n;
       const result = formatDate(input);
+
       expect(result).toBe('Thu, Jan 1, 1970, 00:00:00 UTC');
     });
 
     it('handles large timestamps correctly', () => {
       const input = 253402300799000000000n;
       const result = formatDate(input);
+
       expect(result).toBe('Fri, Dec 31, 9999, 23:59:59 UTC');
     });
   });

--- a/src/utils/icrc-21.utils.spec.ts
+++ b/src/utils/icrc-21.utils.spec.ts
@@ -11,6 +11,7 @@ describe('icrc-21.utils', () => {
         }
       };
       const result = mapIcrc21ErrorToString(error);
+
       expect(result).toBe('Error: Something went wrong (Code: 1001)');
     });
 
@@ -21,6 +22,7 @@ describe('icrc-21.utils', () => {
         }
       };
       const result = mapIcrc21ErrorToString(error);
+
       expect(result).toBe('Insufficient Payment: Not enough funds');
     });
 
@@ -31,6 +33,7 @@ describe('icrc-21.utils', () => {
         }
       };
       const result = mapIcrc21ErrorToString(error);
+
       expect(result).toBe('Unsupported Canister Call: Canister call is not supported');
     });
 
@@ -41,12 +44,14 @@ describe('icrc-21.utils', () => {
         }
       };
       const result = mapIcrc21ErrorToString(error);
+
       expect(result).toBe('Consent Message Unavailable: Consent message is not available');
     });
 
     it('should return "Unknown error" for an unrecognized error type', () => {
       const error = {} as unknown as icrc21_error;
       const result = mapIcrc21ErrorToString(error);
+
       expect(result).toBe('Unknown error');
     });
   });


### PR DESCRIPTION
# Motivation

With the update of the lint library in PR https://github.com/dfinity/oisy-wallet-signer/pull/554, there are some rules that require manual intervention.

In this specific case the rule `vitest/padding-around-all` enforces a padding around test statements.
