### PR TITLE
chore: add `expect` assertion for tests in Signer builders

### DIFF
--- a/src/builders/signer.builders.spec.ts
+++ b/src/builders/signer.builders.spec.ts
@@ -138,7 +138,7 @@ s3oqv-3j7id-xjhbm-3owbe-fvwly-oso6u-vej6n-bexck-koyu2-bxb6y-wae
         token
       });
 
-      expect('Ok' in result);
+      expect('Ok' in result).toBeTruthy();
 
       const {Ok} = result as SignerBuildersResultOk;
 
@@ -157,7 +157,7 @@ s3oqv-3j7id-xjhbm-3owbe-fvwly-oso6u-vej6n-bexck-koyu2-bxb6y-wae
         token
       });
 
-      expect('Ok' in result);
+      expect('Ok' in result).toBeTruthy();
 
       const {Ok} = result as SignerBuildersResultOk;
 
@@ -336,7 +336,7 @@ ${encodeIcrcAccount({owner: rawArgs.to.owner, subaccount: fromNullable(rawArgs.t
         token
       });
 
-      expect('Ok' in result);
+      expect('Ok' in result).toBeTruthy();
 
       const {Ok} = result as SignerBuildersResultOk;
 
@@ -350,7 +350,7 @@ ${encodeIcrcAccount({owner: rawArgs.to.owner, subaccount: fromNullable(rawArgs.t
         token
       });
 
-      expect('Ok' in result);
+      expect('Ok' in result).toBeTruthy();
 
       const {Ok} = result as SignerBuildersResultOk;
 
@@ -635,7 +635,7 @@ ${encodeIcrcAccount({owner: owner.getPrincipal()})}`
         token
       });
 
-      expect('Ok' in result);
+      expect('Ok' in result).toBeTruthy();
 
       const {Ok} = result as SignerBuildersResultOk;
 
@@ -649,7 +649,7 @@ ${encodeIcrcAccount({owner: owner.getPrincipal()})}`
         token
       });
 
-      expect('Ok' in result);
+      expect('Ok' in result).toBeTruthy();
 
       const {Ok} = result as SignerBuildersResultOk;
 


### PR DESCRIPTION
# Motivation

It does not change the effectiveness of the tests, but just for consistency, we add statement assertions to the expect statements in the test-suite for Signer builders.
