### PR TITLE
chore: apply vitest lint rule `no-identical-title`

### DIFF
--- a/src/handlers/relying-party.handlers.spec.ts
+++ b/src/handlers/relying-party.handlers.spec.ts
@@ -245,7 +245,7 @@ describe('Relying Party handlers', () => {
     });
   });
 
-  describe('Request accounts', () => {
+  describe('Request call canister', () => {
     it('should send the correct message to the popup', () => {
       requestCallCanister({id: testId, popup, origin: testOrigin, params: mockCallCanisterParams});
 

--- a/src/sessions/signer.sessions.spec.ts
+++ b/src/sessions/signer.sessions.spec.ts
@@ -284,7 +284,7 @@ describe('Signer sessions', () => {
       expect(state).toBe(ICRC25_PERMISSION_ASK_ON_USE);
     });
 
-    it('should return ask on use if the requested method does not exist', () => {
+    it('should return ask on use if the requested method is not supported', () => {
       const state = sessionScopeState({
         owner,
         origin,

--- a/src/signer.spec.ts
+++ b/src/signer.spec.ts
@@ -517,7 +517,7 @@ describe('Signer', () => {
           });
         });
 
-        it('should not handle with busy', async () => {
+        it('should not handle with busy even if the answer to the status message has been notified', async () => {
           const handleWithBusySpy = vi.spyOn(
             signer as unknown as {handleWithBusy: () => void},
             'handleWithBusy'

--- a/src/types/icrc-responses.spec.ts
+++ b/src/types/icrc-responses.spec.ts
@@ -396,7 +396,7 @@ describe('icrc-responses', () => {
       expect(() => IcrcSupportedStandardsResponseSchema.parse(invalidResponse)).toThrow();
     });
 
-    it('should throw if response has no valid url', () => {
+    it('should throw if response has no url', () => {
       const invalidResponse: IcrcSupportedStandardsResponse = {
         ...validResponse,
         result: {


### PR DESCRIPTION
# Motivation

With the update of the lint library in PR https://github.com/dfinity/oisy-wallet-signer/pull/554, there are some rules that require manual intervention.

In this specific case the rule `vitest/no-identical-title` enforces the usage of different titles for tests in the same context.
