### PR TITLE
chore: update @dfinity/internet-identity-playwright v2.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@dfinity/eslint-config-oisy-wallet": "^0.1.8",
         "@dfinity/identity": "^2.4.0",
-        "@dfinity/internet-identity-playwright": "^0.0.5",
+        "@dfinity/internet-identity-playwright": "^2.0.0",
         "@playwright/test": "^1.51.1",
         "@types/jest": "^29.5.14",
         "@types/node": "^22.13.13",
@@ -354,16 +354,16 @@
       }
     },
     "node_modules/@dfinity/internet-identity-playwright": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/@dfinity/internet-identity-playwright/-/internet-identity-playwright-0.0.5.tgz",
-      "integrity": "sha512-tCmjsX7ui4Qw2s7Ufoh1xJayLUHFbXaSsybrTfYtv3uZlYtMM+dU24lnNv1IPKh19dalXMxi+IWuY5ePGR9KZQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/internet-identity-playwright/-/internet-identity-playwright-2.0.0.tgz",
+      "integrity": "sha512-8dqxxKEqNhM+dozEHFB3Dn54lXsFMjuDKy4qT4ALWypWDM61Ey1KFfvI34gyn70xWLLTLxEiWb6CrDnzJu3NGQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=22"
       },
       "peerDependencies": {
-        "@playwright/test": "^1.44.1"
+        "@playwright/test": "^1.52.0"
       }
     },
     "node_modules/@dfinity/ledger-icp": {

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
   "devDependencies": {
     "@dfinity/eslint-config-oisy-wallet": "^0.1.8",
     "@dfinity/identity": "^2.4.0",
-    "@dfinity/internet-identity-playwright": "^0.0.5",
+    "@dfinity/internet-identity-playwright": "^2.0.0",
     "@playwright/test": "^1.51.1",
     "@types/jest": "^29.5.14",
     "@types/node": "^22.13.13",


### PR DESCRIPTION
# Motivation

Juno Docker has been updated with latest version of Internet Identity to resolve an issue reported by a dev of the community regarding using the Playwright plugin with the latest version of II (https://github.com/dfinity/internet-identity-playwright/issues/56). For the same reason, we patched and released a new version of the plugin.

# Changes

- Bump latest `@dfinity/internet-identity-playwright@2.0.0`
