### PR TITLE
feat: migrate to TypeScript v5.8.3 and its breaking change Uint8Array<ArrayBufferLike>

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "jsdom": "^26.0.0",
         "prettier": "^3.5.3",
         "prettier-plugin-organize-imports": "^4.1.0",
-        "typescript": "^5.4.5",
+        "typescript": "^5.8.3",
         "vitest": "^3.0.9"
       },
       "engines": {
@@ -6531,9 +6531,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
-      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "jsdom": "^26.0.0",
     "prettier": "^3.5.3",
     "prettier-plugin-organize-imports": "^4.1.0",
-    "typescript": "^5.4.5",
+    "typescript": "^5.8.3",
     "vitest": "^3.0.9"
   },
   "engines": {

--- a/src/agent/agentjs-cbor-copy.ts
+++ b/src/agent/agentjs-cbor-copy.ts
@@ -135,7 +135,8 @@ export function decode<T>(input: ArrayBuffer): T {
   });
 
   try {
-    return decoder.decodeFirst(uint8ToBuf(buffer));
+    // @ts-ignore incorrect types - Uint8Array excepted by decodeFirst
+    return decoder.decodeFirst(buffer);
   } catch (e: unknown) {
     throw new Error(`Failed to decode CBOR: ${e}, input: ${toHex(uint8ToBuf(buffer))}`);
   }

--- a/src/agent/agentjs-cbor-copy.ts
+++ b/src/agent/agentjs-cbor-copy.ts
@@ -117,7 +117,7 @@ class Uint8ArrayDecoder extends borc.Decoder {
       return new ArrayBuffer(0);
     }
 
-    // @ts-ignore TS2740: Type Uint8Array<any> is missing the following properties from type ArrayBuffe
+    // @ts-ignore TS2740: Type Uint8Array<any> is missing the following properties from type ArrayBuffer
     return new Uint8Array((this as any)._heap.slice(start, end));
   }
 }

--- a/src/agent/agentjs-cbor-copy.ts
+++ b/src/agent/agentjs-cbor-copy.ts
@@ -8,7 +8,7 @@
 
 // This file is based on:
 // https://github.com/dfinity-lab/dfinity/blob/9bca65f8edd65701ea6bdb00e0752f9186bbc893/docs/spec/public/index.adoc#cbor-encoding-of-requests-and-responses
-import {concat, fromHex, toHex} from '@dfinity/agent';
+import {concat, fromHex, toHex, uint8ToBuf} from '@dfinity/agent';
 import {Principal} from '@dfinity/principal';
 import borc from 'borc';
 import * as cbor from 'simple-cbor';
@@ -34,7 +34,7 @@ class PrincipalEncoder implements CborEncoder<Principal> {
   }
 
   public encode(v: Principal): cbor.CborValue {
-    return cbor.value.bytes(v.toUint8Array());
+    return cbor.value.bytes(uint8ToBuf(v.toUint8Array()));
   }
 }
 
@@ -52,7 +52,7 @@ class BufferEncoder implements CborEncoder<ArrayBuffer> {
   }
 
   public encode(v: ArrayBuffer): cbor.CborValue {
-    return cbor.value.bytes(new Uint8Array(v));
+    return cbor.value.bytes(v);
   }
 }
 
@@ -117,6 +117,7 @@ class Uint8ArrayDecoder extends borc.Decoder {
       return new ArrayBuffer(0);
     }
 
+    // @ts-ignore TS2740: Type Uint8Array<any> is missing the following properties from type ArrayBuffe
     return new Uint8Array((this as any)._heap.slice(start, end));
   }
 }
@@ -134,8 +135,8 @@ export function decode<T>(input: ArrayBuffer): T {
   });
 
   try {
-    return decoder.decodeFirst(buffer);
+    return decoder.decodeFirst(uint8ToBuf(buffer));
   } catch (e: unknown) {
-    throw new Error(`Failed to decode CBOR: ${e}, input: ${toHex(buffer)}`);
+    throw new Error(`Failed to decode CBOR: ${e}, input: ${toHex(uint8ToBuf(buffer))}`);
   }
 }

--- a/src/agent/custom-http-agent.spec.ts
+++ b/src/agent/custom-http-agent.spec.ts
@@ -1,5 +1,5 @@
-import type {RequestId, SubmitResponse} from '@dfinity/agent';
 import * as httpAgent from '@dfinity/agent';
+import {type RequestId, type SubmitResponse, uint8ToBuf} from '@dfinity/agent';
 import {Ed25519KeyIdentity} from '@dfinity/identity';
 import {base64ToUint8Array, nonNullish} from '@dfinity/utils';
 import type {MockInstance} from 'vitest';
@@ -170,7 +170,7 @@ describe('CustomHttpAgent', () => {
 
           expect(spyCall).toHaveBeenCalledOnce();
           expect(spyCall).toHaveBeenCalledWith(mockCanisterId, {
-            arg: base64ToUint8Array(mockRequestPayload.arg),
+            arg: uint8ToBuf(base64ToUint8Array(mockRequestPayload.arg)),
             effectiveCanisterId: mockCanisterId,
             methodName: mockRequestMethod
           });
@@ -185,7 +185,7 @@ describe('CustomHttpAgent', () => {
 
           expect(spyCall).toHaveBeenCalledOnce();
           expect(spyCall).toHaveBeenCalledWith(mockCanisterId, {
-            arg: base64ToUint8Array(mockRequestPayload.arg),
+            arg: uint8ToBuf(base64ToUint8Array(mockRequestPayload.arg)),
             effectiveCanisterId: mockCanisterId,
             methodName: mockRequestMethod,
             nonce: mockedNonce
@@ -364,7 +364,7 @@ describe('CustomHttpAgent', () => {
 
             expect(spyCall).toHaveBeenCalledOnce();
             expect(spyCall).toHaveBeenCalledWith(mockCanisterId, {
-              arg: base64ToUint8Array(mockRequestPayload.arg),
+              arg: uint8ToBuf(base64ToUint8Array(mockRequestPayload.arg)),
               effectiveCanisterId: mockCanisterId,
               methodName: mockRequestMethod
             });
@@ -379,7 +379,7 @@ describe('CustomHttpAgent', () => {
 
             expect(spyCall).toHaveBeenCalledOnce();
             expect(spyCall).toHaveBeenCalledWith(mockCanisterId, {
-              arg: base64ToUint8Array(mockRequestPayload.arg),
+              arg: uint8ToBuf(base64ToUint8Array(mockRequestPayload.arg)),
               effectiveCanisterId: mockCanisterId,
               methodName: mockRequestMethod,
               nonce: mockedNonce

--- a/src/agent/custom-http-agent.ts
+++ b/src/agent/custom-http-agent.ts
@@ -4,6 +4,7 @@ import {
   defaultStrategy,
   lookupResultToBuffer,
   pollForResponse as pollForResponseAgent,
+  uint8ToBuf,
   type CallRequest,
   type HttpAgentOptions,
   type SubmitResponse
@@ -46,7 +47,7 @@ export class CustomHttpAgent extends HttpAgentProvider {
   }: Omit<IcrcCallCanisterRequestParams, 'sender'>): Promise<CustomHttpAgentResponse> => {
     const {requestDetails, ...restResponse} = await this._agent.call(canisterId, {
       methodName,
-      arg: base64ToUint8Array(arg),
+      arg: uint8ToBuf(base64ToUint8Array(arg)),
       // effectiveCanisterId is optional but, actually mandatory according SDK team.
       effectiveCanisterId: canisterId,
       nonce: nonNullish(nonce) ? base64ToUint8Array(nonce) : undefined
@@ -147,7 +148,7 @@ export class CustomHttpAgent extends HttpAgentProvider {
   }: {certificate: Certificate} & Pick<SubmitResponse, 'requestId'>): {
     result: 'valid' | 'invalid' | 'rejected' | 'empty';
   } {
-    const path = [new TextEncoder().encode('request_status'), requestId];
+    const path = [uint8ToBuf(new TextEncoder().encode('request_status')), requestId];
 
     const status = new TextDecoder().decode(
       lookupResultToBuffer(certificate.lookup([...path, 'status']))

--- a/src/builders/signer.builders.spec.ts
+++ b/src/builders/signer.builders.spec.ts
@@ -1,4 +1,5 @@
 /* eslint-disable vitest/expect-expect -- This test suite uses functions with nested `expect` statements */
+import {uint8ToBuf} from '@dfinity/agent';
 import {IDL} from '@dfinity/candid';
 import {Ed25519KeyIdentity} from '@dfinity/identity';
 import {encodeIcrcAccount} from '@dfinity/ledger-icrc';
@@ -74,7 +75,7 @@ describe('Signer builders', () => {
     });
 
     const result = await fn({
-      arg: base64ToUint8Array(arg),
+      arg: uint8ToBuf(base64ToUint8Array(arg)),
       owner: owner.getPrincipal(),
       token
     });
@@ -104,7 +105,7 @@ describe('Signer builders', () => {
 
     it('should build a consent message for a defined arg (without fee)', async () => {
       const result = await buildContentMessageIcrc1Transfer({
-        arg: base64ToUint8Array(mockIcrcLocalCallParams.arg),
+        arg: uint8ToBuf(base64ToUint8Array(mockIcrcLocalCallParams.arg)),
         owner: Principal.fromText(mockPrincipalText),
         token
       });
@@ -134,7 +135,7 @@ s3oqv-3j7id-xjhbm-3owbe-fvwly-oso6u-vej6n-bexck-koyu2-bxb6y-wae
       });
 
       const result = await buildContentMessageIcrc1Transfer({
-        arg: base64ToUint8Array(arg),
+        arg: uint8ToBuf(base64ToUint8Array(arg)),
         owner: owner.getPrincipal(),
         token
       });
@@ -153,7 +154,7 @@ s3oqv-3j7id-xjhbm-3owbe-fvwly-oso6u-vej6n-bexck-koyu2-bxb6y-wae
       });
 
       const result = await buildContentMessageIcrc1Transfer({
-        arg: base64ToUint8Array(arg),
+        arg: uint8ToBuf(base64ToUint8Array(arg)),
         owner: owner.getPrincipal(),
         token
       });
@@ -177,7 +178,7 @@ s3oqv-3j7id-xjhbm-3owbe-fvwly-oso6u-vej6n-bexck-koyu2-bxb6y-wae
       });
 
       const result = await buildContentMessageIcrc1Transfer({
-        arg: base64ToUint8Array(arg),
+        arg: uint8ToBuf(base64ToUint8Array(arg)),
         owner: owner.getPrincipal(),
         token
       });
@@ -215,7 +216,7 @@ ${encodeIcrcAccount({owner: rawArgs.to.owner, subaccount: fromNullable(rawArgs.t
       });
 
       const result = await buildContentMessageIcrc1Transfer({
-        arg: base64ToUint8Array(arg),
+        arg: uint8ToBuf(base64ToUint8Array(arg)),
         owner: owner.getPrincipal(),
         token
       });
@@ -250,7 +251,7 @@ ${encodeIcrcAccount({owner: rawArgs.to.owner, subaccount})}
       });
 
       const result = await buildContentMessageIcrc1Transfer({
-        arg: base64ToUint8Array(arg),
+        arg: uint8ToBuf(base64ToUint8Array(arg)),
         owner: owner.getPrincipal(),
         token
       });
@@ -278,7 +279,7 @@ PUPT`
 
     it('should not build a consent message for invalid arg', async () => {
       const result = await buildContentMessageIcrc1Transfer({
-        arg: base64ToUint8Array(mockCallCanisterParams.arg),
+        arg: uint8ToBuf(base64ToUint8Array(mockCallCanisterParams.arg)),
         owner: owner.getPrincipal(),
         token
       });
@@ -301,7 +302,7 @@ PUPT`
       });
 
       const result = await buildContentMessageIcrc1Transfer({
-        arg: base64ToUint8Array(arg),
+        arg: uint8ToBuf(base64ToUint8Array(arg)),
         owner: owner.getPrincipal(),
         token
       });
@@ -332,7 +333,7 @@ ${encodeIcrcAccount({owner: rawArgs.to.owner, subaccount: fromNullable(rawArgs.t
   describe('icrc2_approve', () => {
     it('should build a consent message in english', async () => {
       const result = await buildContentMessageIcrc2Approve({
-        arg: base64ToUint8Array(mockIcrcApproveArg),
+        arg: uint8ToBuf(base64ToUint8Array(mockIcrcApproveArg)),
         owner: owner.getPrincipal(),
         token
       });
@@ -346,7 +347,7 @@ ${encodeIcrcAccount({owner: rawArgs.to.owner, subaccount: fromNullable(rawArgs.t
 
     it('should build a consent message with no utc time information', async () => {
       const result = await buildContentMessageIcrc2Approve({
-        arg: base64ToUint8Array(mockIcrcApproveArg),
+        arg: uint8ToBuf(base64ToUint8Array(mockIcrcApproveArg)),
         owner: owner.getPrincipal(),
         token
       });
@@ -360,7 +361,7 @@ ${encodeIcrcAccount({owner: rawArgs.to.owner, subaccount: fromNullable(rawArgs.t
 
     it('should build a consent message for owner', async () => {
       const result = await buildContentMessageIcrc2Approve({
-        arg: base64ToUint8Array(mockIcrcApproveArg),
+        arg: uint8ToBuf(base64ToUint8Array(mockIcrcApproveArg)),
         owner: owner.getPrincipal(),
         token
       });
@@ -403,7 +404,7 @@ ${encodeIcrcAccount({owner: owner.getPrincipal()})}`
       });
 
       const result = await buildContentMessageIcrc2Approve({
-        arg: base64ToUint8Array(arg),
+        arg: uint8ToBuf(base64ToUint8Array(arg)),
         owner: owner.getPrincipal(),
         token
       });
@@ -446,7 +447,7 @@ ${encodeIcrcAccount({owner: owner.getPrincipal(), subaccount})}`
       });
 
       const result = await buildContentMessageIcrc2Approve({
-        arg: base64ToUint8Array(arg),
+        arg: uint8ToBuf(base64ToUint8Array(arg)),
         owner: owner.getPrincipal(),
         token
       });
@@ -482,7 +483,7 @@ PUPT`
 
     it('should not build a consent message for invalid arg', async () => {
       const result = await buildContentMessageIcrc2Approve({
-        arg: base64ToUint8Array(mockCallCanisterParams.arg),
+        arg: uint8ToBuf(base64ToUint8Array(mockCallCanisterParams.arg)),
         owner: owner.getPrincipal(),
         token
       });
@@ -505,7 +506,7 @@ PUPT`
       });
 
       const result = await buildContentMessageIcrc2Approve({
-        arg: base64ToUint8Array(arg),
+        arg: uint8ToBuf(base64ToUint8Array(arg)),
         owner: owner.getPrincipal(),
         token
       });
@@ -548,7 +549,7 @@ ${encodeIcrcAccount({owner: owner.getPrincipal()})}`
       });
 
       const result = await buildContentMessageIcrc2Approve({
-        arg: base64ToUint8Array(arg),
+        arg: uint8ToBuf(base64ToUint8Array(arg)),
         owner: owner.getPrincipal(),
         token
       });
@@ -592,7 +593,7 @@ ${encodeIcrcAccount({owner: owner.getPrincipal()})}`
       });
 
       const result = await buildContentMessageIcrc2Approve({
-        arg: base64ToUint8Array(arg),
+        arg: uint8ToBuf(base64ToUint8Array(arg)),
         owner: owner.getPrincipal(),
         token
       });
@@ -631,7 +632,7 @@ ${encodeIcrcAccount({owner: owner.getPrincipal()})}`
   describe('icrc2_transfer_from', () => {
     it('should build a consent message in english', async () => {
       const result = await buildContentMessageIcrc2TransferFrom({
-        arg: base64ToUint8Array(mockIcrcTransferFromArg),
+        arg: uint8ToBuf(base64ToUint8Array(mockIcrcTransferFromArg)),
         owner: owner.getPrincipal(),
         token
       });
@@ -645,7 +646,7 @@ ${encodeIcrcAccount({owner: owner.getPrincipal()})}`
 
     it('should build a consent message with no utc time information', async () => {
       const result = await buildContentMessageIcrc2TransferFrom({
-        arg: base64ToUint8Array(mockIcrcTransferFromArg),
+        arg: uint8ToBuf(base64ToUint8Array(mockIcrcTransferFromArg)),
         owner: owner.getPrincipal(),
         token
       });
@@ -659,7 +660,7 @@ ${encodeIcrcAccount({owner: owner.getPrincipal()})}`
 
     it('should build a consent message for owner', async () => {
       const result = await buildContentMessageIcrc2TransferFrom({
-        arg: base64ToUint8Array(mockIcrcTransferFromArg),
+        arg: uint8ToBuf(base64ToUint8Array(mockIcrcTransferFromArg)),
         owner: owner.getPrincipal(),
         token
       });
@@ -697,7 +698,7 @@ ${encodeIcrcAccount({owner: mockIcrcTransferFromRawArgs.to.owner, subaccount: fr
       });
 
       const result = await buildContentMessageIcrc2TransferFrom({
-        arg: base64ToUint8Array(arg),
+        arg: uint8ToBuf(base64ToUint8Array(arg)),
         owner: owner.getPrincipal(),
         token
       });
@@ -738,7 +739,7 @@ ${encodeIcrcAccount({owner: mockIcrcTransferFromRawArgs.to.owner, subaccount: fr
       });
 
       const result = await buildContentMessageIcrc2TransferFrom({
-        arg: base64ToUint8Array(arg),
+        arg: uint8ToBuf(base64ToUint8Array(arg)),
         owner: owner.getPrincipal(),
         token
       });
@@ -779,7 +780,7 @@ ${encodeIcrcAccount({owner: mockIcrcTransferFromRawArgs.to.owner, subaccount: fr
       });
 
       const result = await buildContentMessageIcrc2TransferFrom({
-        arg: base64ToUint8Array(arg),
+        arg: uint8ToBuf(base64ToUint8Array(arg)),
         owner: owner.getPrincipal(),
         token
       });
@@ -817,7 +818,7 @@ ${encodeIcrcAccount({owner: mockIcrcTransferFromRawArgs.to.owner, subaccount})}
       });
 
       const result = await buildContentMessageIcrc2TransferFrom({
-        arg: base64ToUint8Array(arg),
+        arg: uint8ToBuf(base64ToUint8Array(arg)),
         owner: owner.getPrincipal(),
         token
       });
@@ -848,7 +849,7 @@ PUPT`
 
     it('should not build a consent message for invalid arg', async () => {
       const result = await buildContentMessageIcrc2TransferFrom({
-        arg: base64ToUint8Array(mockCallCanisterParams.arg),
+        arg: uint8ToBuf(base64ToUint8Array(mockCallCanisterParams.arg)),
         owner: owner.getPrincipal(),
         token
       });
@@ -871,7 +872,7 @@ PUPT`
       });
 
       const result = await buildContentMessageIcrc2TransferFrom({
-        arg: base64ToUint8Array(arg),
+        arg: uint8ToBuf(base64ToUint8Array(arg)),
         owner: owner.getPrincipal(),
         token
       });

--- a/src/mocks/custom-http-agent.mocks.ts
+++ b/src/mocks/custom-http-agent.mocks.ts
@@ -22,11 +22,13 @@ export const mockRequestPayloadWithNonce: Omit<IcrcCallCanisterRequestParams, 's
 };
 
 export const mockRequestDetails: CallRequest = {
+  // TODO: This is corrected in next version of the agent.
+  // @ts-expect-error arg is currently incorrectly typed in Agent-js. Instead of an ArrayBuffer it actually uses and provides an Uint8Array.
   arg: new Uint8Array([68, 73, 68, 76, 6, 109, 123, 110, 0, 108]),
   canister_id: Principal.fromText(mockCanisterId),
   ingress_expiry: new Expiry(5 * 60 * 1000),
   method_name: mockRequestMethod,
-  nonce: new Uint8Array([1, 2, 3]).buffer as Nonce,
+  nonce: new Uint8Array([1, 2, 3]).buffer as unknown as Nonce,
   request_type: SubmitRequestType.Call,
   sender: Principal.fromText(mockPrincipalText)
 };

--- a/src/services/signer.service.ts
+++ b/src/services/signer.service.ts
@@ -1,3 +1,4 @@
+import {uint8ToBuf} from '@dfinity/agent';
 import {mapTokenMetadata} from '@dfinity/ledger-icrc';
 import {Principal} from '@dfinity/principal';
 import {base64ToUint8Array, isNullish, notEmptyString} from '@dfinity/utils';
@@ -312,7 +313,7 @@ export class SignerService {
       }
 
       const result = await fn({
-        arg: base64ToUint8Array(arg),
+        arg: uint8ToBuf(base64ToUint8Array(arg)),
         token,
         owner: owner.getPrincipal()
       });

--- a/src/services/signer.services.spec.ts
+++ b/src/services/signer.services.spec.ts
@@ -1,3 +1,4 @@
+import {uint8ToBuf} from '@dfinity/agent';
 import {Ed25519KeyIdentity} from '@dfinity/identity';
 import {mapTokenMetadata, type IcrcTokenMetadata} from '@dfinity/ledger-icrc';
 import {assertNonNullish, base64ToUint8Array} from '@dfinity/utils';
@@ -466,7 +467,7 @@ describe('Signer services', () => {
                 assertNonNullish(fn);
 
                 const result = await fn({
-                  arg: base64ToUint8Array(arg),
+                  arg: uint8ToBuf(base64ToUint8Array(arg)),
                   token: mapTokenMetadata(mockIcrcLedgerMetadata) as IcrcTokenMetadata,
                   owner: owner.getPrincipal()
                 });

--- a/src/utils/agentjs-cbor-copy.utils.spec.ts
+++ b/src/utils/agentjs-cbor-copy.utils.spec.ts
@@ -20,7 +20,7 @@ describe('agentjs-cbor-copy.utils', () => {
 
     expect(callRequest.nonce).toBeInstanceOf(Uint8Array);
     expect(callRequest.nonce).toEqual(
-      arrayBufferToUint8Array(mockRequestDetails.nonce as ArrayBuffer)
+      arrayBufferToUint8Array(mockRequestDetails.nonce as unknown as ArrayBuffer)
     );
 
     expect(callRequest.request_type).toEqual(mockRequestDetails.request_type);

--- a/src/utils/agentjs-cbor-copy.utils.ts
+++ b/src/utils/agentjs-cbor-copy.utils.ts
@@ -1,4 +1,4 @@
-import type {CallRequest, Expiry} from '@dfinity/agent';
+import {type CallRequest, type Expiry, uint8ToBuf} from '@dfinity/agent';
 import {Principal} from '@dfinity/principal';
 import {base64ToUint8Array} from '@dfinity/utils';
 import type {BigNumber} from 'bignumber.js';
@@ -14,7 +14,7 @@ export const decodeCallRequest = (contentMap: IcrcBlob): CallRequest => {
   // The decode function copied from agent-js is buggy or does not support decoding the ingress_expiry to BigInt or Expiry. It seems that the value is a BigNumber. That's why we have to strip it from the response and convert it manually.
   // It does not parse Principal neither.
   const {ingress_expiry, canister_id, ...callRequestRest} = decode<CborCallRequest>(
-    base64ToUint8Array(contentMap)
+    uint8ToBuf(base64ToUint8Array(contentMap))
   );
 
   return {

--- a/src/utils/call.assert.utils.spec.ts
+++ b/src/utils/call.assert.utils.spec.ts
@@ -1,3 +1,4 @@
+import {uint8ToBuf} from '@dfinity/agent';
 import {Principal} from '@dfinity/principal';
 import {uint8ArrayToBase64} from '@dfinity/utils';
 import {mockCanisterId, mockPrincipalText} from '../mocks/icrc-accounts.mocks';
@@ -35,7 +36,7 @@ describe('call.assert.utils', () => {
       expect(() =>
         assertCallArg({
           requestArg: requestArgBlob,
-          responseArg
+          responseArg: uint8ToBuf(responseArg)
         })
       ).not.toThrow();
     });
@@ -47,7 +48,7 @@ describe('call.assert.utils', () => {
       expect(() =>
         assertCallArg({
           requestArg: requestArgBlob,
-          responseArg
+          responseArg: uint8ToBuf(responseArg)
         })
       ).toThrow('The response does not contain the request arguments.');
     });

--- a/src/utils/call.utils.ts
+++ b/src/utils/call.utils.ts
@@ -3,7 +3,8 @@ import {
   Certificate,
   HttpAgent,
   lookupResultToBuffer,
-  requestIdOf
+  requestIdOf,
+  uint8ToBuf
 } from '@dfinity/agent';
 import type {RecordClass, VariantClass} from '@dfinity/candid/lib/cjs/idl';
 import {Principal} from '@dfinity/principal';
@@ -84,14 +85,14 @@ export const decodeResponse = async <T>({
   );
 
   const certificate = await Certificate.create({
-    certificate: base64ToUint8Array(cert),
+    certificate: uint8ToBuf(base64ToUint8Array(cert)),
     rootKey: agent.rootKey,
     canisterId: Principal.fromText(canisterId)
   });
 
   const requestId = requestIdOf(callRequest);
 
-  const path = [new TextEncoder().encode('request_status'), requestId];
+  const path = [uint8ToBuf(new TextEncoder().encode('request_status')), requestId];
 
   const reply = lookupResultToBuffer(certificate.lookup([...path, 'reply']));
 


### PR DESCRIPTION
# Motivation

TypeScript [v5.7](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-7.html) ships a breaking changes regarding the `Uint8Array` and `ArrayBufferLike`. As a result, in addition to bumping TS, the code should be adapted as well.

# Changes

- Bump latest TypeScript
- Use utility `uint8ToBuf` of `agent-js` for data handling. Which happens to be necessary in parts of the code where agent-js is overwritten as features are not built-in, so makes sense.
- Add few `@ts-ignore` exceptions because Agent-js currently except ArrayBuffer which are Uint8array or the contrary. I think this will be fixed in their next version, few types are already improved and the cbor encoder will change anyway - i.e. we'll also have to update the code.
