### PR TITLE
chore: release v0.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dfinity/oisy-wallet-signer",
-  "version": "0.1.8",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dfinity/oisy-wallet-signer",
-      "version": "0.1.8",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@dfinity/eslint-config-oisy-wallet": "^0.1.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/oisy-wallet-signer",
-  "version": "0.1.8",
+  "version": "0.2.0",
   "description": "A library designed to facilitate communication between a dApp and the OISY Wallet on the Internet Computer. ",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
# Motivation

Since we noticed that mixing Zod v3 and v4 isn't a good idea, I propose that we release the version as a breaking change.

PS.: Maybe we should bump v1.0.0 some day.

# Changes

- Tag release `v0.2.0`
