### PR TITLE
build: accept ledger-icp v3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
       "peerDependencies": {
         "@dfinity/agent": "^2.4.0",
         "@dfinity/candid": "^2.4.0",
-        "@dfinity/ledger-icp": "^2",
+        "@dfinity/ledger-icp": ">=2",
         "@dfinity/ledger-icrc": "^2",
         "@dfinity/principal": "^2.4.0",
         "@dfinity/utils": "^2.13.0",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
   "peerDependencies": {
     "@dfinity/agent": "^2.4.0",
     "@dfinity/candid": "^2.4.0",
-    "@dfinity/ledger-icp": "^2",
+    "@dfinity/ledger-icp": ">=2",
     "@dfinity/ledger-icrc": "^2",
     "@dfinity/principal": "^2.4.0",
     "@dfinity/utils": "^2.13.0",


### PR DESCRIPTION
# Motivation

We need ic-js@next in OISY which contains a breaking change - not affecting the signer - in `ledger-icp` v3.

# Changes

- Accept >= 2 version of ledger-icp
