### PR TITLE
fix: demo Option types and disable eslint rule

### DIFF
--- a/demo/eslint.config.mjs
+++ b/demo/eslint.config.mjs
@@ -20,5 +20,10 @@ export default [
 			'**/playwright-report',
 			'**/coverage'
 		]
+	},
+	{
+		rules: {
+			"use-option-type-wrapper": "off"
+		}
 	}
 ];

--- a/demo/eslint.config.mjs
+++ b/demo/eslint.config.mjs
@@ -23,7 +23,7 @@ export default [
 	},
 	{
 		rules: {
-			"use-option-type-wrapper": "off"
+			'use-option-type-wrapper': 'off'
 		}
 	}
 ];

--- a/demo/eslint.config.mjs
+++ b/demo/eslint.config.mjs
@@ -23,7 +23,7 @@ export default [
 	},
 	{
 		rules: {
-			'use-option-type-wrapper': 'off'
+			'local-rules/use-option-type-wrapper': ['off']
 		}
 	}
 ];

--- a/demo/src/core/components/Balance.svelte
+++ b/demo/src/core/components/Balance.svelte
@@ -8,14 +8,14 @@
 	import { DEV, LOCAL_REPLICA_URL } from '$core/constants/app.constants';
 
 	interface Props {
-		owner: Option<Principal>;
+		owner: Principal | undefined | null;
 	}
 
 	let { owner }: Props = $props();
 
 	let balance = $state(0n);
 
-	const loadBalance = async (owner: Option<Principal>) => {
+	const loadBalance = async (owner: Principal | undefined | null) => {
 		if (isNullish(owner)) {
 			balance = 0n;
 			return;

--- a/demo/src/core/components/Balance.svelte
+++ b/demo/src/core/components/Balance.svelte
@@ -8,14 +8,14 @@
 	import { DEV, LOCAL_REPLICA_URL } from '$core/constants/app.constants';
 
 	interface Props {
-		owner: Principal | undefined | null;
+		owner: Option<Principal>;
 	}
 
 	let { owner }: Props = $props();
 
 	let balance = $state(0n);
 
-	const loadBalance = async (owner: Principal | undefined | null) => {
+	const loadBalance = async (owner: Option<Principal>) => {
 		if (isNullish(owner)) {
 			balance = 0n;
 			return;

--- a/demo/src/core/stores/alert.store.ts
+++ b/demo/src/core/stores/alert.store.ts
@@ -6,7 +6,7 @@ export interface Alert {
 	duration?: number;
 }
 
-export type AlertData = Option<Alert>;
+export type AlertData = Alert | undefined | null;
 
 export interface AlertStore extends Readable<AlertData> {
 	set: (alert: Alert) => void;

--- a/demo/src/core/stores/alert.store.ts
+++ b/demo/src/core/stores/alert.store.ts
@@ -6,7 +6,7 @@ export interface Alert {
 	duration?: number;
 }
 
-export type AlertData = Alert | undefined | null;
+export type AlertData = Option<Alert>;
 
 export interface AlertStore extends Readable<AlertData> {
 	set: (alert: Alert) => void;

--- a/demo/src/core/stores/auth.store.ts
+++ b/demo/src/core/stores/auth.store.ts
@@ -16,7 +16,7 @@ export interface AuthStoreData {
 	identity: OptionIdentity;
 }
 
-let authClient: Option<AuthClient>;
+let authClient: AuthClient | undefined | null;
 
 export interface AuthSignInParams {
 	domain?: 'ic0.app' | 'internetcomputer.org';

--- a/demo/src/core/stores/auth.store.ts
+++ b/demo/src/core/stores/auth.store.ts
@@ -16,7 +16,7 @@ export interface AuthStoreData {
 	identity: OptionIdentity;
 }
 
-let authClient: AuthClient | undefined | null;
+let authClient: Option<AuthClient>;
 
 export interface AuthSignInParams {
 	domain?: 'ic0.app' | 'internetcomputer.org';

--- a/demo/src/core/types/identity.ts
+++ b/demo/src/core/types/identity.ts
@@ -1,3 +1,3 @@
 import type { Identity } from '@dfinity/agent';
 
-export type OptionIdentity = Option<Identity>;
+export type OptionIdentity = Identity | undefined | null;

--- a/demo/src/core/types/identity.ts
+++ b/demo/src/core/types/identity.ts
@@ -1,3 +1,3 @@
 import type { Identity } from '@dfinity/agent';
 
-export type OptionIdentity = Identity | undefined | null;
+export type OptionIdentity = Option<Identity>;

--- a/demo/src/core/types/identity.ts
+++ b/demo/src/core/types/identity.ts
@@ -1,3 +1,4 @@
 import type { Identity } from '@dfinity/agent';
 
-export type OptionIdentity = Option<Identity>;
+export type OptionIdentity = Identity | undefined | null;
+

--- a/demo/src/core/types/identity.ts
+++ b/demo/src/core/types/identity.ts
@@ -1,4 +1,3 @@
 import type { Identity } from '@dfinity/agent';
 
 export type OptionIdentity = Identity | undefined | null;
-


### PR DESCRIPTION
# Motivation

The demo incorrectly uses unknown `Option<...>` since we introduced the eslint rule library in #359.

# Changes

- Remove usage of Option and disable rule

# Error

Example


<img width="1536" height="1031" alt="Capture d’écran 2025-07-10 à 19 12 23" src="https://github.com/user-attachments/assets/96f5850a-ef33-47d9-ba67-2cf4b07cd20c" />
