### PR TITLE
fix: reload ui demo on wallet url change

### DIFF
--- a/demo/src/relying_party_frontend/src/app.d.ts
+++ b/demo/src/relying_party_frontend/src/app.d.ts
@@ -16,7 +16,6 @@ declare module 'svelte/elements' {
 	interface HTMLAttributes<T> {
 		onoisyDemoReloadPermissions?: (event: CustomEvent<any>) => void;
 		onoisyDemoReloadBalance?: (event: CustomEvent<any>) => void;
-		onoisyDemoDisconnectWallet?: (event: CustomEvent<any>) => void;
 	}
 }
 

--- a/demo/src/relying_party_frontend/src/lib/components/ConnectAndRequestAccount.svelte
+++ b/demo/src/relying_party_frontend/src/lib/components/ConnectAndRequestAccount.svelte
@@ -6,7 +6,7 @@
 	import { walletUrlStore } from '$lib/stores/wallet.store';
 
 	interface Props {
-		account: IcrcAccount | undefined;
+		account: IcrcAccount | undefined | null;
 	}
 
 	let { account = $bindable() }: Props = $props();
@@ -40,11 +40,7 @@
 			await wallet?.disconnect();
 		}
 	};
-
-	const disconnect = () => wallet?.disconnect();
 </script>
-
-<svelte:window onoisyDemoDisconnectWallet={disconnect} />
 
 <button
 	{onclick}

--- a/demo/src/relying_party_frontend/src/lib/components/WalletUrl.svelte
+++ b/demo/src/relying_party_frontend/src/lib/components/WalletUrl.svelte
@@ -9,7 +9,6 @@
 		PROD,
 		WALLET_DEFAULT_URL
 	} from '$core/constants/app.constants';
-	import { emit } from '$core/utils/events.utils';
 	import { walletUrlStore } from '$lib/stores/wallet.store';
 
 	interface SelectUrl {
@@ -33,10 +32,6 @@
 
 	const onchange = () => {
 		walletUrlStore.set(walletUrl);
-
-		emit({
-			message: 'oisyDemoDisconnectWallet'
-		});
 	};
 </script>
 

--- a/demo/src/relying_party_frontend/src/routes/+page.svelte
+++ b/demo/src/relying_party_frontend/src/routes/+page.svelte
@@ -10,8 +10,16 @@
 	import SendICP from '$lib/components/SendICP.svelte';
 	import Wallet from '$lib/components/Wallet.svelte';
 	import WalletUrl from '$lib/components/WalletUrl.svelte';
+	import { walletUrlStore } from '$lib/stores/wallet.store';
 
-	let account = $state<IcrcAccount | undefined>(undefined);
+	let account = $state<IcrcAccount | undefined | null>(undefined);
+
+	const resetAccount = () => (account = null);
+
+	$effect(() => {
+		$walletUrlStore;
+		resetAccount();
+	});
 </script>
 
 <p class="dark:text-white mb-4">Transfer 0.05 ICP (minus fees) to and from your Oisy Wallet.</p>


### PR DESCRIPTION
# Motivation

There is still one small race condition - like when the user switch between url without waiting for success or timeout when connecting the wallet - but, at least this PR improves the UI by resetting the account when the URL change. This way the "Connect" button also appears again in case it was connected before.
