### PR TITLE
feat: revert "build: bump zod v4 (#607)"

### DIFF
--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -20,12 +20,12 @@
 				"@dfinity/principal": "^2.4.0",
 				"@dfinity/utils": "^2.13.1",
 				"buffer": "^6.0.3",
-				"zod": "^4.0.5"
+				"zod": "^3.25"
 			},
 			"devDependencies": {
 				"@dfinity/eslint-config-oisy-wallet": "^0.1.14",
-				"@junobuild/config": "^0.4.1",
-				"@junobuild/vite-plugin": "^4.1.1",
+				"@junobuild/config": "^0.4.0",
+				"@junobuild/vite-plugin": "^4.0.0",
 				"@rollup/plugin-inject": "^5.0.5",
 				"@sveltejs/adapter-static": "^3.0.8",
 				"@sveltejs/kit": "^2.22.2",
@@ -62,50 +62,46 @@
 			}
 		},
 		"node_modules/@babel/code-frame": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
-			"integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.7.tgz",
+			"integrity": "sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.27.1",
-				"js-tokens": "^4.0.0",
-				"picocolors": "^1.1.1"
+				"@babel/highlight": "^7.24.7",
+				"picocolors": "^1.0.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/compat-data": {
-			"version": "7.28.0",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.0.tgz",
-			"integrity": "sha512-60X7qkglvrap8mn1lh2ebxXdZYtUcpd7gsmy9kLaBJ4i/WdY8PqTSdxyA8qraikqKQK5C1KRBKXqznrVapyNaw==",
+			"version": "7.25.4",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.25.4.tgz",
+			"integrity": "sha512-+LGRog6RAsCJrrrg/IO6LGmpphNe5DiK30dGjCoxxeGv49B10/3XYGxPsAwrDlMFcFEvdAUavDT8r9k/hSyQqQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/core": {
-			"version": "7.28.0",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.0.tgz",
-			"integrity": "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==",
+			"version": "7.25.2",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.25.2.tgz",
+			"integrity": "sha512-BBt3opiCOxUr9euZ5/ro/Xv8/V7yJ5bjYMqG/C1YAo8MIKAnumZalCN+msbci3Pigy4lIQfPUpfMM27HMGaYEA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@ampproject/remapping": "^2.2.0",
-				"@babel/code-frame": "^7.27.1",
-				"@babel/generator": "^7.28.0",
-				"@babel/helper-compilation-targets": "^7.27.2",
-				"@babel/helper-module-transforms": "^7.27.3",
-				"@babel/helpers": "^7.27.6",
-				"@babel/parser": "^7.28.0",
-				"@babel/template": "^7.27.2",
-				"@babel/traverse": "^7.28.0",
-				"@babel/types": "^7.28.0",
+				"@babel/code-frame": "^7.24.7",
+				"@babel/generator": "^7.25.0",
+				"@babel/helper-compilation-targets": "^7.25.2",
+				"@babel/helper-module-transforms": "^7.25.2",
+				"@babel/helpers": "^7.25.0",
+				"@babel/parser": "^7.25.0",
+				"@babel/template": "^7.25.0",
+				"@babel/traverse": "^7.25.2",
+				"@babel/types": "^7.25.2",
 				"convert-source-map": "^2.0.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.2",
@@ -126,59 +122,64 @@
 			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
 			"dev": true,
 			"license": "ISC",
-			"peer": true,
 			"bin": {
 				"semver": "bin/semver.js"
 			}
 		},
 		"node_modules/@babel/generator": {
-			"version": "7.28.0",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.0.tgz",
-			"integrity": "sha512-lJjzvrbEeWrhB4P3QBsH7tey117PjLZnDbLiQEKjQ/fNJTjuq4HSqgFA+UNSwZT8D7dxxbnuSBMsa1lrWzKlQg==",
+			"version": "7.25.6",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.25.6.tgz",
+			"integrity": "sha512-VPC82gr1seXOpkjAAKoLhP50vx4vGNlF4msF64dSFq1P8RfB+QAuJWGHPXXPc8QyfVWwwB/TNNU4+ayZmHNbZw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
-				"@babel/parser": "^7.28.0",
-				"@babel/types": "^7.28.0",
-				"@jridgewell/gen-mapping": "^0.3.12",
-				"@jridgewell/trace-mapping": "^0.3.28",
-				"jsesc": "^3.0.2"
+				"@babel/types": "^7.25.6",
+				"@jridgewell/gen-mapping": "^0.3.5",
+				"@jridgewell/trace-mapping": "^0.3.25",
+				"jsesc": "^2.5.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-annotate-as-pure": {
-			"version": "7.27.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.27.3.tgz",
-			"integrity": "sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.24.7.tgz",
+			"integrity": "sha512-BaDeOonYvhdKw+JoMVkAixAAJzG2jVPIwWoKBPdYuY9b452e2rPuI9QPYh3KpofZ3pW2akOmwZLOiOsHMiqRAg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
-				"@babel/types": "^7.27.3"
+				"@babel/types": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-compilation-targets": {
-			"version": "7.27.2",
-			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
-			"integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
+			"version": "7.25.2",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.25.2.tgz",
+			"integrity": "sha512-U2U5LsSaZ7TAt3cfaymQ8WHh0pxvdHoEk6HVpaexxixjyEquMh0L0YNJNM6CTGKMXV1iksi0iZkGw4AcFkPaaw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
-				"@babel/compat-data": "^7.27.2",
-				"@babel/helper-validator-option": "^7.27.1",
-				"browserslist": "^4.24.0",
+				"@babel/compat-data": "^7.25.2",
+				"@babel/helper-validator-option": "^7.24.8",
+				"browserslist": "^4.23.1",
 				"lru-cache": "^5.1.1",
 				"semver": "^6.3.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+			"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"yallist": "^3.0.2"
 			}
 		},
 		"node_modules/@babel/helper-compilation-targets/node_modules/semver": {
@@ -187,25 +188,23 @@
 			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
 			"dev": true,
 			"license": "ISC",
-			"peer": true,
 			"bin": {
 				"semver": "bin/semver.js"
 			}
 		},
 		"node_modules/@babel/helper-create-class-features-plugin": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.27.1.tgz",
-			"integrity": "sha512-QwGAmuvM17btKU5VqXfb+Giw4JcN0hjuufz3DYnpeVDvZLAObloM77bhMXiqry3Iio+Ai4phVRDwl6WU10+r5A==",
+			"version": "7.25.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.25.4.tgz",
+			"integrity": "sha512-ro/bFs3/84MDgDmMwbcHgDa8/E6J3QKNTk4xJJnVeFtGE+tL0K26E3pNxhYz2b67fJpt7Aphw5XcploKXuCvCQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
-				"@babel/helper-annotate-as-pure": "^7.27.1",
-				"@babel/helper-member-expression-to-functions": "^7.27.1",
-				"@babel/helper-optimise-call-expression": "^7.27.1",
-				"@babel/helper-replace-supers": "^7.27.1",
-				"@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
-				"@babel/traverse": "^7.27.1",
+				"@babel/helper-annotate-as-pure": "^7.24.7",
+				"@babel/helper-member-expression-to-functions": "^7.24.8",
+				"@babel/helper-optimise-call-expression": "^7.24.7",
+				"@babel/helper-replace-supers": "^7.25.0",
+				"@babel/helper-skip-transparent-expression-wrappers": "^7.24.7",
+				"@babel/traverse": "^7.25.4",
 				"semver": "^6.3.1"
 			},
 			"engines": {
@@ -221,63 +220,49 @@
 			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
 			"dev": true,
 			"license": "ISC",
-			"peer": true,
 			"bin": {
 				"semver": "bin/semver.js"
 			}
 		},
-		"node_modules/@babel/helper-globals": {
-			"version": "7.28.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-			"integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
 		"node_modules/@babel/helper-member-expression-to-functions": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.27.1.tgz",
-			"integrity": "sha512-E5chM8eWjTp/aNoVpcbfM7mLxu9XGLWYise2eBKGQomAk/Mb4XoxyqXTZbuTohbsl8EKqdlMhnDI2CCLfcs9wA==",
+			"version": "7.24.8",
+			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.24.8.tgz",
+			"integrity": "sha512-LABppdt+Lp/RlBxqrh4qgf1oEH/WxdzQNDJIu5gC/W1GyvPVrOBiItmmM8wan2fm4oYqFuFfkXmlGpLQhPY8CA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
-				"@babel/traverse": "^7.27.1",
-				"@babel/types": "^7.27.1"
+				"@babel/traverse": "^7.24.8",
+				"@babel/types": "^7.24.8"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-module-imports": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
-			"integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.24.7.tgz",
+			"integrity": "sha512-8AyH3C+74cgCVVXow/myrynrAGv+nTVg5vKu2nZph9x7RcRwzmh0VFallJuFTZ9mx6u4eSdXZfcOzSqTUm0HCA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
-				"@babel/traverse": "^7.27.1",
-				"@babel/types": "^7.27.1"
+				"@babel/traverse": "^7.24.7",
+				"@babel/types": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-module-transforms": {
-			"version": "7.27.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.27.3.tgz",
-			"integrity": "sha512-dSOvYwvyLsWBeIRyOeHXp5vPj5l1I011r52FM1+r1jCERv+aFXYk4whgQccYEGYxK2H3ZAIA8nuPkQ0HaUo3qg==",
+			"version": "7.25.2",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.25.2.tgz",
+			"integrity": "sha512-BjyRAbix6j/wv83ftcVJmBt72QtHI56C7JXZoG2xATiLpmoC7dpd8WnkikExHDVPpi/3qCmO6WY1EaXOluiecQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
-				"@babel/helper-module-imports": "^7.27.1",
-				"@babel/helper-validator-identifier": "^7.27.1",
-				"@babel/traverse": "^7.27.3"
+				"@babel/helper-module-imports": "^7.24.7",
+				"@babel/helper-simple-access": "^7.24.7",
+				"@babel/helper-validator-identifier": "^7.24.7",
+				"@babel/traverse": "^7.25.2"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -287,41 +272,38 @@
 			}
 		},
 		"node_modules/@babel/helper-optimise-call-expression": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.27.1.tgz",
-			"integrity": "sha512-URMGH08NzYFhubNSGJrpUEphGKQwMQYBySzat5cAByY1/YgIRkULnIy3tAMeszlL/so2HbeilYloUmSpd7GdVw==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.24.7.tgz",
+			"integrity": "sha512-jKiTsW2xmWwxT1ixIdfXUZp+P5yURx2suzLZr5Hi64rURpDYdMW0pv+Uf17EYk2Rd428Lx4tLsnjGJzYKDM/6A==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
-				"@babel/types": "^7.27.1"
+				"@babel/types": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-plugin-utils": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz",
-			"integrity": "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==",
+			"version": "7.24.8",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.8.tgz",
+			"integrity": "sha512-FFWx5142D8h2Mgr/iPVGH5G7w6jDn4jUSpZTyDnQO0Yn7Ks2Kuz6Pci8H6MPCoUJegd/UZQ3tAvfLCxQSnWWwg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-replace-supers": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.27.1.tgz",
-			"integrity": "sha512-7EHz6qDZc8RYS5ElPoShMheWvEgERonFCs7IAonWLLUTXW59DP14bCZt89/GKyreYn8g3S83m21FelHKbeDCKA==",
+			"version": "7.25.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.25.0.tgz",
+			"integrity": "sha512-q688zIvQVYtZu+i2PsdIu/uWGRpfxzr5WESsfpShfZECkO+d2o+WROWezCi/Q6kJ0tfPa5+pUGUlfx2HhrA3Bg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
-				"@babel/helper-member-expression-to-functions": "^7.27.1",
-				"@babel/helper-optimise-call-expression": "^7.27.1",
-				"@babel/traverse": "^7.27.1"
+				"@babel/helper-member-expression-to-functions": "^7.24.8",
+				"@babel/helper-optimise-call-expression": "^7.24.7",
+				"@babel/traverse": "^7.25.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -330,78 +312,180 @@
 				"@babel/core": "^7.0.0"
 			}
 		},
-		"node_modules/@babel/helper-skip-transparent-expression-wrappers": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.27.1.tgz",
-			"integrity": "sha512-Tub4ZKEXqbPjXgWLl2+3JpQAYBJ8+ikpQ2Ocj/q/r0LwE3UhENh7EUabyHjz2kCEsrRY83ew2DQdHluuiDQFzg==",
+		"node_modules/@babel/helper-simple-access": {
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.24.7.tgz",
+			"integrity": "sha512-zBAIvbCMh5Ts+b86r/CjU+4XGYIs+R1j951gxI3KmmxBMhCg4oQMsv6ZXQ64XOm/cvzfU1FmoCyt6+owc5QMYg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
-				"@babel/traverse": "^7.27.1",
-				"@babel/types": "^7.27.1"
+				"@babel/traverse": "^7.24.7",
+				"@babel/types": "^7.24.7"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/helper-skip-transparent-expression-wrappers": {
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.24.7.tgz",
+			"integrity": "sha512-IO+DLT3LQUElMbpzlatRASEyQtfhSE0+m465v++3jyyXeBTBUjtVZg28/gHeV5mrTJqvEKhKroBGAvhW+qPHiQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/traverse": "^7.24.7",
+				"@babel/types": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-string-parser": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-			"integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+			"version": "7.24.8",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.24.8.tgz",
+			"integrity": "sha512-pO9KhhRcuUyGnJWwyEgnRJTSIZHiT+vMD0kPeD+so0l7mxkMT19g3pjY9GTnHySck/hDzq+dtW/4VgnMkippsQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-validator-identifier": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
-			"integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.7.tgz",
+			"integrity": "sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-validator-option": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-			"integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+			"version": "7.24.8",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.24.8.tgz",
+			"integrity": "sha512-xb8t9tD1MHLungh/AIoWYN+gVHaB9kwlu8gffXGSt3FFEIT7RjS+xWbc2vUD1UTZdIpKj/ab3rdqJ7ufngyi2Q==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helpers": {
-			"version": "7.27.6",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.6.tgz",
-			"integrity": "sha512-muE8Tt8M22638HU31A3CgfSUciwz1fhATfoVai05aPXGor//CdWDCbnlY1yvBPo07njuVOCNGCSp/GTt12lIug==",
+			"version": "7.25.6",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.25.6.tgz",
+			"integrity": "sha512-Xg0tn4HcfTijTwfDwYlvVCl43V6h4KyVVX2aEm4qdO/PC6L2YvzLHFdmxhoeSA3eslcE6+ZVXHgWwopXYLNq4Q==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
-				"@babel/template": "^7.27.2",
-				"@babel/types": "^7.27.6"
+				"@babel/template": "^7.25.0",
+				"@babel/types": "^7.25.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
-		"node_modules/@babel/parser": {
-			"version": "7.28.0",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.0.tgz",
-			"integrity": "sha512-jVZGvOxOuNSsuQuLRTh13nU0AogFlw32w/MT+LV6D3sP5WdbW61E77RnkbaO2dUvmPAYrBDJXGn5gGS6tH4j8g==",
+		"node_modules/@babel/highlight": {
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.7.tgz",
+			"integrity": "sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
-				"@babel/types": "^7.28.0"
+				"@babel/helper-validator-identifier": "^7.24.7",
+				"chalk": "^2.4.2",
+				"js-tokens": "^4.0.0",
+				"picocolors": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@babel/highlight/node_modules/ansi-styles": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-convert": "^1.9.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/@babel/highlight/node_modules/chalk": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/@babel/highlight/node_modules/color-convert": {
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-name": "1.1.3"
+			}
+		},
+		"node_modules/@babel/highlight/node_modules/color-name": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@babel/highlight/node_modules/escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.8.0"
+			}
+		},
+		"node_modules/@babel/highlight/node_modules/has-flag": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/@babel/highlight/node_modules/supports-color": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"has-flag": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/@babel/parser": {
+			"version": "7.25.6",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.6.tgz",
+			"integrity": "sha512-trGdfBdbD0l1ZPmcJ83eNxB9rbEax4ALFTF7fN386TMYbeCQbyme5cOEXQhbGXKebwGaB/J52w1mrklMcbgy6Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/types": "^7.25.6"
 			},
 			"bin": {
 				"parser": "bin/babel-parser.js"
@@ -411,14 +495,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-syntax-jsx": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.27.1.tgz",
-			"integrity": "sha512-y8YTNIeKoyhGd9O0Jiyzyyqk8gdjnumGTQPsz0xOZOQ2RmkVJeZ1vmmfIvFEKqucBG6axJGBZDE/7iI5suUI/w==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.24.7.tgz",
+			"integrity": "sha512-6ddciUPe/mpMnOKv/U+RSd2vvVy+Yw/JfBB0ZHYjEZt9NLHmCUylNYlsbqCCS1Bffjlb0fCwC9Vqz+sBz6PsiQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.27.1"
+				"@babel/helper-plugin-utils": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -428,14 +511,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-syntax-typescript": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.27.1.tgz",
-			"integrity": "sha512-xfYCBMxveHrRMnAWl1ZlPXOZjzkN82THFvLhQhFXFt81Z5HnN+EtUkZhv/zcKpmT3fzmWZB0ywiBrbC3vogbwQ==",
+			"version": "7.25.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.25.4.tgz",
+			"integrity": "sha512-uMOCoHVU52BsSWxPOMVv5qKRdeSlPuImUCB2dlPuBSU+W2/ROE7/Zg8F2Kepbk+8yBa68LlRKxO+xgEVWorsDg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.27.1"
+				"@babel/helper-plugin-utils": "^7.24.8"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -445,15 +527,15 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-modules-commonjs": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.27.1.tgz",
-			"integrity": "sha512-OJguuwlTYlN0gBZFRPqwOGNWssZjfIUdS7HMYtN8c1KmwpwHFBwTeFZrg9XZa+DFTitWOW5iTAG7tyCUPsCCyw==",
+			"version": "7.24.8",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.24.8.tgz",
+			"integrity": "sha512-WHsk9H8XxRs3JXKWFiqtQebdh9b/pTk4EgueygFzYlTKAg0Ud985mSevdNjdXdFBATSKVJGQXP1tv6aGbssLKA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
-				"@babel/helper-module-transforms": "^7.27.1",
-				"@babel/helper-plugin-utils": "^7.27.1"
+				"@babel/helper-module-transforms": "^7.24.8",
+				"@babel/helper-plugin-utils": "^7.24.8",
+				"@babel/helper-simple-access": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -463,18 +545,17 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-typescript": {
-			"version": "7.28.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.28.0.tgz",
-			"integrity": "sha512-4AEiDEBPIZvLQaWlc9liCavE0xRM0dNca41WtBeM3jgFptfUOSG9z0uteLhq6+3rq+WB6jIvUwKDTpXEHPJ2Vg==",
+			"version": "7.25.2",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.25.2.tgz",
+			"integrity": "sha512-lBwRvjSmqiMYe/pS0+1gggjJleUJi7NzjvQ1Fkqtt69hBa/0t1YuW/MLQMAPixfwaQOHUXsd6jeU3Z+vdGv3+A==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
-				"@babel/helper-annotate-as-pure": "^7.27.3",
-				"@babel/helper-create-class-features-plugin": "^7.27.1",
-				"@babel/helper-plugin-utils": "^7.27.1",
-				"@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
-				"@babel/plugin-syntax-typescript": "^7.27.1"
+				"@babel/helper-annotate-as-pure": "^7.24.7",
+				"@babel/helper-create-class-features-plugin": "^7.25.0",
+				"@babel/helper-plugin-utils": "^7.24.8",
+				"@babel/helper-skip-transparent-expression-wrappers": "^7.24.7",
+				"@babel/plugin-syntax-typescript": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -484,18 +565,17 @@
 			}
 		},
 		"node_modules/@babel/preset-typescript": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.27.1.tgz",
-			"integrity": "sha512-l7WfQfX0WK4M0v2RudjuQK4u99BS6yLHYEmdtVPP7lKV013zr9DygFuWNlnbvQ9LR+LS0Egz/XAvGx5U9MX0fQ==",
+			"version": "7.24.7",
+			"resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.24.7.tgz",
+			"integrity": "sha512-SyXRe3OdWwIwalxDg5UtJnJQO+YPcTfwiIY2B0Xlddh9o7jpWLvv8X1RthIeDOxQ+O1ML5BLPCONToObyVQVuQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.27.1",
-				"@babel/helper-validator-option": "^7.27.1",
-				"@babel/plugin-syntax-jsx": "^7.27.1",
-				"@babel/plugin-transform-modules-commonjs": "^7.27.1",
-				"@babel/plugin-transform-typescript": "^7.27.1"
+				"@babel/helper-plugin-utils": "^7.24.7",
+				"@babel/helper-validator-option": "^7.24.7",
+				"@babel/plugin-syntax-jsx": "^7.24.7",
+				"@babel/plugin-transform-modules-commonjs": "^7.24.7",
+				"@babel/plugin-transform-typescript": "^7.24.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -505,51 +585,59 @@
 			}
 		},
 		"node_modules/@babel/template": {
-			"version": "7.27.2",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
-			"integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
+			"version": "7.25.0",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.0.tgz",
+			"integrity": "sha512-aOOgh1/5XzKvg1jvVz7AVrx2piJ2XBi227DHmbY6y+bM9H2FlN+IfecYu4Xl0cNiiVejlsCri89LUsbj8vJD9Q==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
-				"@babel/code-frame": "^7.27.1",
-				"@babel/parser": "^7.27.2",
-				"@babel/types": "^7.27.1"
+				"@babel/code-frame": "^7.24.7",
+				"@babel/parser": "^7.25.0",
+				"@babel/types": "^7.25.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/traverse": {
-			"version": "7.28.0",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.0.tgz",
-			"integrity": "sha512-mGe7UK5wWyh0bKRfupsUchrQGqvDbZDbKJw+kcRGSmdHVYrv+ltd0pnpDTVpiTqnaBru9iEvA8pz8W46v0Amwg==",
+			"version": "7.25.6",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.6.tgz",
+			"integrity": "sha512-9Vrcx5ZW6UwK5tvqsj0nGpp/XzqthkT0dqIc9g1AdtygFToNtTF67XzYS//dm+SAK9cp3B9R4ZO/46p63SCjlQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
-				"@babel/code-frame": "^7.27.1",
-				"@babel/generator": "^7.28.0",
-				"@babel/helper-globals": "^7.28.0",
-				"@babel/parser": "^7.28.0",
-				"@babel/template": "^7.27.2",
-				"@babel/types": "^7.28.0",
-				"debug": "^4.3.1"
+				"@babel/code-frame": "^7.24.7",
+				"@babel/generator": "^7.25.6",
+				"@babel/parser": "^7.25.6",
+				"@babel/template": "^7.25.0",
+				"@babel/types": "^7.25.6",
+				"debug": "^4.3.1",
+				"globals": "^11.1.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
-		"node_modules/@babel/types": {
-			"version": "7.28.1",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.1.tgz",
-			"integrity": "sha512-x0LvFTekgSX+83TI28Y9wYPUfzrnl2aT5+5QLnO6v7mSJYtEEevuDRN0F0uSHRk1G1IWZC43o00Y0xDDrpBGPQ==",
+		"node_modules/@babel/traverse/node_modules/globals": {
+			"version": "11.12.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/@babel/types": {
+			"version": "7.25.6",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.6.tgz",
+			"integrity": "sha512-/l42B1qxpG6RdfYf343Uw1vmDjeNhneUXtzhojE7pDgfpEypmRhI6j1kr17XCVv4Cgl9HdAiQY2x0GwKm7rWCw==",
+			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-string-parser": "^7.27.1",
-				"@babel/helper-validator-identifier": "^7.27.1"
+				"@babel/helper-string-parser": "^7.24.8",
+				"@babel/helper-validator-identifier": "^7.24.7",
+				"to-fast-properties": "^2.0.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -694,15 +782,15 @@
 			}
 		},
 		"node_modules/@dfinity/zod-schemas": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@dfinity/zod-schemas/-/zod-schemas-2.0.0.tgz",
-			"integrity": "sha512-mvgiYCwGXgT+iFdvTFWh5Da0HCsF8VIFTIsY+uQifaf4duc3+K1nb16O7+tCzFD7Vs4ZmjImCNi+lO5GqjplNA==",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@dfinity/zod-schemas/-/zod-schemas-1.0.0.tgz",
+			"integrity": "sha512-5ApkpRO8hqTb7B9GH4H8FljY/r6hh3zpA/HFeeozIHieyebAzB748+4T9/oL6T7udkvlfWPMulbmjSHerm3B9A==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"peer": true,
 			"peerDependencies": {
 				"@dfinity/principal": "^2.0.0",
-				"zod": "^4"
+				"zod": "^3.25"
 			}
 		},
 		"node_modules/@esbuild/aix-ppc64": {
@@ -1385,20 +1473,34 @@
 			}
 		},
 		"node_modules/@jridgewell/gen-mapping": {
-			"version": "0.3.12",
-			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.12.tgz",
-			"integrity": "sha512-OuLGC46TjB5BbN1dH8JULVVZY4WTdkF7tV9Ys6wLL1rubZnCMstOhNHueU5bLCrnRuDhKPDM4g6sw4Bel5Gzqg==",
+			"version": "0.3.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
+			"integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jridgewell/sourcemap-codec": "^1.5.0",
+				"@jridgewell/set-array": "^1.2.1",
+				"@jridgewell/sourcemap-codec": "^1.4.10",
 				"@jridgewell/trace-mapping": "^0.3.24"
+			},
+			"engines": {
+				"node": ">=6.0.0"
 			}
 		},
 		"node_modules/@jridgewell/resolve-uri": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
 			"integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@jridgewell/set-array": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+			"integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -1413,9 +1515,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@jridgewell/trace-mapping": {
-			"version": "0.3.29",
-			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.29.tgz",
-			"integrity": "sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ==",
+			"version": "0.3.25",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+			"integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1424,47 +1526,65 @@
 			}
 		},
 		"node_modules/@junobuild/config": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/@junobuild/config/-/config-0.4.1.tgz",
-			"integrity": "sha512-HGh/diplU4Q2z4pdUsPF6q14ecv03AAiNLmweHvZe5qOxuT5TrqbZ/I3r+QVmHHUONioA7VH3vMZbEn/q6KBZw==",
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/@junobuild/config/-/config-0.4.0.tgz",
+			"integrity": "sha512-v5fDjooKQMV93RA3d6X6/a0ftU+0QXCw/LjFgECTomlyRSsvR7oMEewrO20lFyUYUcjyjmtUPHRe3hF66DVMHg==",
 			"dev": true,
 			"license": "MIT",
 			"peerDependencies": {
-				"@dfinity/zod-schemas": "^2",
-				"zod": "^4"
+				"@dfinity/zod-schemas": "^1.0.0",
+				"zod": "^3.25"
 			}
 		},
 		"node_modules/@junobuild/config-loader": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/@junobuild/config-loader/-/config-loader-0.3.0.tgz",
-			"integrity": "sha512-MvxXclngEpU7nYOW7BW7tKc/pyoN2+Ma8Dk4pXLh2jmQKhhxqXlnB+ZqkHdpAzynJRJNQlxCJjJn0WLoH0GCUw==",
+			"version": "0.0.5",
+			"resolved": "https://registry.npmjs.org/@junobuild/config-loader/-/config-loader-0.0.5.tgz",
+			"integrity": "sha512-983Kzl9KTaGD//bWml+RdyeG9kHQgXHyrtEg3Ps9sod0f93OYlZ8oFe8e7lrHuZcl6jhSRUfdoxukAyc3BFWrA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/core": "^7.24.6",
+				"@babel/plugin-transform-modules-commonjs": "^7.24.6",
+				"@babel/preset-typescript": "^7.24.6"
+			},
+			"peerDependencies": {
+				"@junobuild/config": "*",
+				"@junobuild/utils": "*"
+			}
+		},
+		"node_modules/@junobuild/plugin-tools": {
+			"version": "0.0.9",
+			"resolved": "https://registry.npmjs.org/@junobuild/plugin-tools/-/plugin-tools-0.0.9.tgz",
+			"integrity": "sha512-4k9nf4Ere+3c6xFjn+wHjpFMfjVRrb/9s8QtkjVEh81Ktrv5B/JhgTRYQVTLDogELU9NaPWi8CYId62qHjTakA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@junobuild/config": "^0.0.14",
+				"@junobuild/config-loader": "^0.0.5"
+			}
+		},
+		"node_modules/@junobuild/plugin-tools/node_modules/@junobuild/config": {
+			"version": "0.0.14",
+			"resolved": "https://registry.npmjs.org/@junobuild/config/-/config-0.0.14.tgz",
+			"integrity": "sha512-LMhPpXW3X1c+XyNREMrfhi4mEk/AkLX0RxEbi6uKuyXd0/IsTHSB/sfFEgsTAvt4W4KmjrELcNyI1SFbpQEDAA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@junobuild/utils": {
+			"version": "0.0.25",
+			"resolved": "https://registry.npmjs.org/@junobuild/utils/-/utils-0.0.25.tgz",
+			"integrity": "sha512-hKvSeyREVy7YoJoXWSs4Q1xp8I4tlZ9c9KVVPNLdJ/vl8ad8/EEfcvuobNdNZ860h9DqG5LXhqam+Mf/blU33w==",
 			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"peerDependencies": {
-				"@babel/core": "^7.26.10",
-				"@babel/plugin-transform-modules-commonjs": "^7.26.3",
-				"@babel/preset-typescript": "^7.26.0",
-				"@junobuild/config": "*"
-			}
-		},
-		"node_modules/@junobuild/plugin-tools": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/@junobuild/plugin-tools/-/plugin-tools-4.1.1.tgz",
-			"integrity": "sha512-XlIADnD4i8F+kVlY9oiLVecTF3VUnG8A0rFrnPe4A6h6O2oJ8OEyo9+yEbcICqAHlujJmA8Wz1RXG/ZSh9O2wQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@junobuild/config": "^0.4"
-			},
-			"peerDependencies": {
-				"@junobuild/config-loader": "^0.3"
+				"@dfinity/principal": "^2.0.0"
 			}
 		},
 		"node_modules/@junobuild/vite-plugin": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/@junobuild/vite-plugin/-/vite-plugin-4.1.1.tgz",
-			"integrity": "sha512-mYGmPGemqoa9UM6XU9jGBKdW7cpnZqyt+mpZFi35Xfv+KkjNDcnQqyibYsNLI1ITBoj1h8TdcnX+hAMZp/Hc2Q==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@junobuild/vite-plugin/-/vite-plugin-4.0.0.tgz",
+			"integrity": "sha512-LjXmI2kqYaHUXCEAb1dYeJb30J2CCm6B1NBqBrSMe0IHpg577IgHzRqXfkZKsVEjsTd5zFT8QTmJ8R67+MmZoQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3738,8 +3858,7 @@
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
 			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cookie": {
 			"version": "0.7.2",
@@ -5097,7 +5216,6 @@
 			"integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -5910,8 +6028,7 @@
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
 			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/js-yaml": {
 			"version": "4.1.0",
@@ -5928,17 +6045,16 @@
 			}
 		},
 		"node_modules/jsesc": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
-			"integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"jsesc": "bin/jsesc"
 			},
 			"engines": {
-				"node": ">=6"
+				"node": ">=4"
 			}
 		},
 		"node_modules/json-buffer": {
@@ -5980,7 +6096,6 @@
 			"integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"json5": "lib/cli.js"
 			},
@@ -6330,17 +6445,6 @@
 			"integrity": "sha512-wJzkKwJrheKtknCOKNEtDK4iqg/MxmZheEMtSTYvnzRdEYaZzmgH976nenp8WdJRdx5Vc1X/9MO0Oszl6ezeXg==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/lru-cache": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-			"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-			"dev": true,
-			"license": "ISC",
-			"peer": true,
-			"dependencies": {
-				"yallist": "^3.0.2"
-			}
 		},
 		"node_modules/magic-string": {
 			"version": "0.30.17",
@@ -8065,6 +8169,16 @@
 				"node": ">=14.0.0"
 			}
 		},
+		"node_modules/to-fast-properties": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+			"integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/to-regex-range": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -8735,8 +8849,7 @@
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
 			"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
 			"dev": true,
-			"license": "ISC",
-			"peer": true
+			"license": "ISC"
 		},
 		"node_modules/yaml": {
 			"version": "2.7.0",
@@ -8775,9 +8888,9 @@
 			"license": "MIT"
 		},
 		"node_modules/zod": {
-			"version": "4.0.5",
-			"resolved": "https://registry.npmjs.org/zod/-/zod-4.0.5.tgz",
-			"integrity": "sha512-/5UuuRPStvHXu7RS+gmvRf4NXrNxpSllGwDnCBcJZtQsKrviYXm54yDGV2KYNLT5kq0lHGcl7lqWJLgSaG+tgA==",
+			"version": "3.25.67",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
+			"integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"

--- a/demo/package.json
+++ b/demo/package.json
@@ -27,8 +27,8 @@
 	},
 	"devDependencies": {
 		"@dfinity/eslint-config-oisy-wallet": "^0.1.14",
-		"@junobuild/config": "^0.4.1",
-		"@junobuild/vite-plugin": "^4.1.1",
+		"@junobuild/config": "^0.4.0",
+		"@junobuild/vite-plugin": "^4.0.0",
 		"@rollup/plugin-inject": "^5.0.5",
 		"@sveltejs/adapter-static": "^3.0.8",
 		"@sveltejs/kit": "^2.22.2",
@@ -59,7 +59,7 @@
 		"@dfinity/principal": "^2.4.0",
 		"@dfinity/utils": "^2.13.1",
 		"buffer": "^6.0.3",
-		"zod": "^4.0.5"
+		"zod": "^3.25"
 	},
 	"overrides": {
 		"cookie": "^0.7.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,10 +32,10 @@
         "@dfinity/ledger-icrc": "^2",
         "@dfinity/principal": "^2.4.0",
         "@dfinity/utils": "^2.13.0",
-        "@dfinity/zod-schemas": "^2",
+        "@dfinity/zod-schemas": "^1.0.0",
         "borc": "^2.1.1",
         "simple-cbor": "^0.4.1",
-        "zod": "^4"
+        "zod": "^3.25"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -322,14 +322,14 @@
       }
     },
     "node_modules/@dfinity/zod-schemas": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@dfinity/zod-schemas/-/zod-schemas-2.0.0.tgz",
-      "integrity": "sha512-mvgiYCwGXgT+iFdvTFWh5Da0HCsF8VIFTIsY+uQifaf4duc3+K1nb16O7+tCzFD7Vs4ZmjImCNi+lO5GqjplNA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/zod-schemas/-/zod-schemas-1.0.0.tgz",
+      "integrity": "sha512-5ApkpRO8hqTb7B9GH4H8FljY/r6hh3zpA/HFeeozIHieyebAzB748+4T9/oL6T7udkvlfWPMulbmjSHerm3B9A==",
       "license": "Apache-2.0",
       "peer": true,
       "peerDependencies": {
         "@dfinity/principal": "^2.0.0",
-        "zod": "^4"
+        "zod": "^3.25"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -7383,9 +7383,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.0.5.tgz",
-      "integrity": "sha512-/5UuuRPStvHXu7RS+gmvRf4NXrNxpSllGwDnCBcJZtQsKrviYXm54yDGV2KYNLT5kq0lHGcl7lqWJLgSaG+tgA==",
+      "version": "3.25.67",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
+      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
       "license": "MIT",
       "peer": true,
       "funding": {

--- a/package.json
+++ b/package.json
@@ -93,9 +93,9 @@
     "@dfinity/ledger-icrc": "^2",
     "@dfinity/principal": "^2.4.0",
     "@dfinity/utils": "^2.13.0",
-    "@dfinity/zod-schemas": "^2",
+    "@dfinity/zod-schemas": "^1.0.0",
     "borc": "^2.1.1",
     "simple-cbor": "^0.4.1",
-    "zod": "^4"
+    "zod": "^3.25"
   }
 }

--- a/src/types/blob.ts
+++ b/src/types/blob.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod';
+import * as z from 'zod/v4';
 
 export const IcrcBlobSchema = z.string().refine(
   (val) => {

--- a/src/types/hex-string.ts
+++ b/src/types/hex-string.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod';
+import * as z from 'zod/v4';
 
 export const HexStringSchema = z.string().regex(/^[0-9a-f]+$/i);
 export type HexString = z.infer<typeof HexStringSchema>;

--- a/src/types/i18n.ts
+++ b/src/types/i18n.ts
@@ -1,5 +1,5 @@
 // Auto-generated definitions file ("npm run i18n")
-import * as z from 'zod';
+import * as z from 'zod/v4';
 
 export const i18nCoreSchema = z
   .object({

--- a/src/types/icrc-accounts.ts
+++ b/src/types/icrc-accounts.ts
@@ -1,6 +1,6 @@
 import {base64ToUint8Array} from '@dfinity/utils';
 import {PrincipalTextSchema} from '@dfinity/zod-schemas';
-import * as z from 'zod';
+import * as z from 'zod/v4';
 import {IcrcBlobSchema} from './blob';
 
 const IcrcSubaccountSchema = IcrcBlobSchema.refine(

--- a/src/types/icrc-requests.ts
+++ b/src/types/icrc-requests.ts
@@ -1,6 +1,6 @@
 import {base64ToUint8Array, isNullish} from '@dfinity/utils';
 import {PrincipalTextSchema} from '@dfinity/zod-schemas';
-import * as z from 'zod';
+import * as z from 'zod/v4';
 import {
   ICRC25_PERMISSIONS,
   ICRC25_REQUEST_PERMISSIONS,

--- a/src/types/icrc-responses.ts
+++ b/src/types/icrc-responses.ts
@@ -1,5 +1,5 @@
 import {UrlSchema} from '@dfinity/zod-schemas';
-import * as z from 'zod';
+import * as z from 'zod/v4';
 import {IcrcBlobSchema} from './blob';
 import {IcrcAccountsSchema} from './icrc-accounts';
 import {

--- a/src/types/icrc-standards.ts
+++ b/src/types/icrc-standards.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod';
+import * as z from 'zod/v4';
 import {
   ICRC21,
   ICRC21_CALL_CONSENT_MESSAGE,

--- a/src/types/post-message.ts
+++ b/src/types/post-message.ts
@@ -1,5 +1,5 @@
 import {UrlSchema} from '@dfinity/zod-schemas';
-import type * as z from 'zod';
+import type * as z from 'zod/v4';
 
 export const OriginSchema = UrlSchema;
 

--- a/src/types/relying-party-options.ts
+++ b/src/types/relying-party-options.ts
@@ -1,5 +1,5 @@
 import {UrlSchema} from '@dfinity/zod-schemas';
-import * as z from 'zod';
+import * as z from 'zod/v4';
 import {createFunctionSchema} from '../utils/zod.utils';
 
 const ConnectionOptionsSchema = z.object({

--- a/src/types/relying-party-requests.ts
+++ b/src/types/relying-party-requests.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod';
+import * as z from 'zod/v4';
 import {RpcIdSchema} from './rpc';
 
 export const RelyingPartyRequestOptionsTimeoutSchema = z.object({

--- a/src/types/relying-party.ts
+++ b/src/types/relying-party.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod';
+import * as z from 'zod/v4';
 import {IcrcScopesSchema, IcrcSupportedStandardsSchema} from './icrc-responses';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/src/types/rpc.spec.ts
+++ b/src/types/rpc.spec.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod';
+import * as z from 'zod/v4';
 import {
   JSON_RPC_VERSION_2,
   RpcErrorCode,

--- a/src/types/rpc.ts
+++ b/src/types/rpc.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod';
+import * as z from 'zod/v4';
 
 // JSON-RPC 2.0 Specification
 // https://www.jsonrpc.org/specification

--- a/src/types/signer-handlers.ts
+++ b/src/types/signer-handlers.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod';
+import * as z from 'zod/v4';
 import {RpcIdSchema} from './rpc';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/src/types/signer-options.ts
+++ b/src/types/signer-options.ts
@@ -1,7 +1,7 @@
 import type {Identity} from '@dfinity/agent';
 import {isNullish} from '@dfinity/utils';
 import {UrlSchema} from '@dfinity/zod-schemas';
-import * as z from 'zod';
+import * as z from 'zod/v4';
 
 const IdentitySchema = z.custom<Identity>((value: unknown): boolean => {
   if (isNullish(value)) {

--- a/src/types/signer-prompts.ts
+++ b/src/types/signer-prompts.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod';
+import * as z from 'zod/v4';
 import {
   ICRC21_CALL_CONSENT_MESSAGE,
   ICRC25_REQUEST_PERMISSIONS,

--- a/src/types/signer-sessions.ts
+++ b/src/types/signer-sessions.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod';
+import * as z from 'zod/v4';
 import {IcrcScopeSchema} from './icrc-responses';
 
 export const SessionTimestampsSchema = z.object({

--- a/src/types/signer.ts
+++ b/src/types/signer.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod';
+import * as z from 'zod/v4';
 import {
   IcrcAccountsRequestSchema,
   IcrcPermissionsRequestSchema,

--- a/src/utils/zod.utils.ts
+++ b/src/utils/zod.utils.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod';
+import * as z from 'zod/v4';
 
 /**
  * In Zod v4, functions are no longer treated as standard Zod schemas (see: https://zod.dev/v4/changelog?id=zfunction).


### PR DESCRIPTION
# Motivation

This PR revert the use of Zod v4 library We do so because we are unable to use the v4 release in OISY (see https://github.com/dfinity/oisy-wallet/issues/7788).

# Changes

- Revert PR #607.
