### PR TITLE
build: pin zod-schemas to v1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "@dfinity/ledger-icrc": "^2",
         "@dfinity/principal": "^2.4.0",
         "@dfinity/utils": "^2.13.0",
-        "@dfinity/zod-schemas": "^1.0.0",
+        "@dfinity/zod-schemas": "1.0.0",
         "borc": "^2.1.1",
         "simple-cbor": "^0.4.1",
         "zod": "^3.25"

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "@dfinity/ledger-icrc": "^2",
     "@dfinity/principal": "^2.4.0",
     "@dfinity/utils": "^2.13.0",
-    "@dfinity/zod-schemas": "^1.0.0",
+    "@dfinity/zod-schemas": "1.0.0",
     "borc": "^2.1.1",
     "simple-cbor": "^0.4.1",
     "zod": "^3.25"


### PR DESCRIPTION
# Motivation

A dev faced an issue today while trying to use the library ([forum](https://forum.dfinity.org/t/connecting-oisy-wallet-signer-uncaught-typeerror-void-0-is-not-a-function/53711)). I think this was due to the fact they used the zod-schemas v2 while the lib still requires v1. That's why I propose to pin to exactly v1.

# Changes

- Set dependency to `1.0.0` instead of `^1.0.0`.
