### PR TITLE
feat: principal object schema

### DIFF
--- a/src/types/principal.spec.ts
+++ b/src/types/principal.spec.ts
@@ -1,0 +1,61 @@
+import {Principal} from '@dfinity/principal';
+import {mockPrincipalText} from '../mocks/icrc-accounts.mocks';
+import {PrincipalObjSchema} from './principal';
+
+describe('PrincipalObjSchema', () => {
+  it('parses a valid PrincipalObj and returns a Principal', () => {
+    const principal = Principal.fromText(mockPrincipalText);
+
+    const input = {
+      _isPrincipal: true,
+      _arr: principal.toUint8Array()
+    };
+
+    const result = PrincipalObjSchema.safeParse(input);
+
+    expect(result.success).toBeTruthy();
+    expect(result.data).toBeInstanceOf(Principal);
+    expect(result?.data?.toText()).toBe(principal.toText());
+  });
+
+  it('parses a valid Principal and returns a Principal', () => {
+    const principal = Principal.fromText(mockPrincipalText);
+
+    const result = PrincipalObjSchema.safeParse(principal);
+
+    expect(result.success).toBeTruthy();
+    expect(result.data).toBeInstanceOf(Principal);
+    expect(result?.data?.toText()).toBe(principal.toText());
+  });
+
+  it('fails if _isPrincipal is missing', () => {
+    const result = PrincipalObjSchema.safeParse({
+      _arr: new Uint8Array()
+    });
+
+    expect(result.success).toBeFalsy();
+    expect(result?.error?.issues[0].path).toEqual(['_isPrincipal']);
+  });
+
+  it('fails if _arr is not a Uint8Array', () => {
+    const result = PrincipalObjSchema.safeParse({
+      _isPrincipal: true,
+      _arr: [1, 2, 3]
+    });
+
+    expect(result.success).toBeFalsy();
+    expect(result?.error?.issues[0].path).toEqual(['_arr']);
+  });
+
+  it('fails if there are extra properties', () => {
+    const result = PrincipalObjSchema.safeParse({
+      _isPrincipal: true,
+      _arr: new Uint8Array(),
+      extra: 'nope'
+    });
+
+    expect(result.success).toBeFalsy();
+    expect(result?.error?.issues[0].code).toBe('unrecognized_keys');
+    expect(result?.error?.issues[0].path).toEqual([]);
+  });
+});

--- a/src/types/principal.ts
+++ b/src/types/principal.ts
@@ -1,0 +1,9 @@
+import {Principal} from '@dfinity/principal';
+import {z} from 'zod/v4';
+
+export const PrincipalObjSchema = z
+  .strictObject({
+    _isPrincipal: z.literal(true),
+    _arr: z.instanceof(Uint8Array)
+  })
+  .transform((value) => Principal.from(value));


### PR DESCRIPTION
# Motivation

To migrate to the new cbor library in #620, we will need a custom replacer for the encoding. Parts of it has to do with handling Principals which cannot be identified as instance of such but, only as object. That's is why we need a new Zod schema to assert those types and parse them to valid Principal.

# Changes

- New `PrincipalObjSchema` that assert an object is a principal and map it
