### PR TITLE
feat: custom cbor replacer for contentMap

### DIFF
--- a/src/utils/cbor.utils.spec.ts
+++ b/src/utils/cbor.utils.spec.ts
@@ -1,0 +1,51 @@
+import {Expiry} from '@dfinity/agent';
+import {Principal} from '@dfinity/principal';
+import {mockPrincipalText} from '../mocks/icrc-accounts.mocks';
+import {contentMapReplacer} from './cbor.utils';
+
+describe('cbor.utils', () => {
+  describe('contentMapReplacer', () => {
+    it('replaces ingress_expiry with bigint from Expiry', () => {
+      const expiry = new Expiry(5 * 60 * 1000);
+      const result = contentMapReplacer(expiry, 'ingress_expiry');
+
+      expect(result).toBe((expiry as unknown as {_value: bigint})._value);
+    });
+
+    it('replaces sender key with Uint8Array if valid Principal', () => {
+      const principal = Principal.fromText(mockPrincipalText);
+      const result = contentMapReplacer(principal, 'sender');
+
+      expect(result).toBeInstanceOf(Uint8Array);
+      expect(principal.toText()).toBe(Principal.fromUint8Array(result as Uint8Array).toText());
+    });
+
+    it('replaces canister_id key with Uint8Array if valid Principal', () => {
+      const principal = Principal.fromText(mockPrincipalText);
+      const result = contentMapReplacer(principal, 'canister_id');
+
+      expect(result).toBeInstanceOf(Uint8Array);
+      expect(principal.toText()).toBe(Principal.fromUint8Array(result as Uint8Array).toText());
+    });
+
+    it('returns original value for unrelated keys', () => {
+      const value = 'some value';
+      const result = contentMapReplacer(value, 'other_key');
+
+      expect(result).toBe(value);
+    });
+
+    it('returns original value if sender/canister_id value is not a Principal', () => {
+      const value = 'not a principal';
+      const result = contentMapReplacer(value, 'sender');
+
+      expect(result).toBe(value);
+    });
+
+    it('returns undefined if no value provided', () => {
+      const result = contentMapReplacer(undefined, 'sender');
+
+      expect(result).toBe(undefined);
+    });
+  });
+});

--- a/src/utils/cbor.utils.ts
+++ b/src/utils/cbor.utils.ts
@@ -1,0 +1,21 @@
+import {Expiry} from '@dfinity/agent';
+import type {CborValue} from '@dfinity/cbor/dist/cbor-value';
+import {nonNullish} from '@dfinity/utils';
+import {PrincipalObjSchema} from '../types/principal';
+
+// eslint-disable-next-line local-rules/prefer-object-params
+export const contentMapReplacer = <T>(value?: CborValue<T>, key?: string): CborValue<T> => {
+  if (key === 'ingress_expiry' && nonNullish(value) && value instanceof Expiry) {
+    return (value as {_value: bigint})._value;
+  }
+
+  if (['sender', 'canister_id'].includes(key ?? '')) {
+    const {success, data} = PrincipalObjSchema.safeParse(value);
+
+    if (success) {
+      return data.toUint8Array();
+    }
+  }
+
+  return value;
+};


### PR DESCRIPTION
# Motivation

To migrate to the new `@dfinity/cbor` library in #620, we need a custom replacer to encode the content map. This to comply with the spec but, also to preserve the backwards compatibility of the signer with existing clients.

# Changes

- Add a function `contentMapReplacer` that parses `Expiry` and selected `Principal` fields.
