### PR TITLE
build: add new cbor peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
       "peerDependencies": {
         "@dfinity/agent": "^2.4.0",
         "@dfinity/candid": "^2.4.0",
+        "@dfinity/cbor": "^0.2.2",
         "@dfinity/ledger-icp": ">=4",
         "@dfinity/ledger-icrc": "^2",
         "@dfinity/principal": "^2.4.0",
@@ -214,6 +215,13 @@
       "peerDependencies": {
         "@dfinity/principal": "^2.4.0"
       }
+    },
+    "node_modules/@dfinity/cbor": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@dfinity/cbor/-/cbor-0.2.2.tgz",
+      "integrity": "sha512-GPJpH73kDEKbUBdUjY80lz7cq9l0vm1h/7ppejPV6O0ZTqCLrYspssYvqjRmK4aNnJ/SKXsP0rg9LYX7zpegaA==",
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/@dfinity/eslint-config-oisy-wallet": {
       "version": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
   "peerDependencies": {
     "@dfinity/agent": "^2.4.0",
     "@dfinity/candid": "^2.4.0",
+    "@dfinity/cbor": "^0.2.2",
     "@dfinity/ledger-icp": ">=4",
     "@dfinity/ledger-icrc": "^2",
     "@dfinity/principal": "^2.4.0",


### PR DESCRIPTION
# Motivation

This PR adds the new `@dfinity/cbor` library as a peer dependency. The migration to the new encoding and decoding will be implemented in #624 and #620.

# Changes

- `npm i @dfinity/cbor --save-peer`
