### PR TITLE
chore: release version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dfinity/oisy-wallet-signer",
-  "version": "0.2.4",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dfinity/oisy-wallet-signer",
-      "version": "0.2.4",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@dfinity/eslint-config-oisy-wallet": "^0.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/oisy-wallet-signer",
-  "version": "0.2.4",
+  "version": "0.3.0",
   "description": "A library designed to facilitate communication between a dApp and the OISY Wallet on the Internet Computer. ",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
# Motivation

There are actually no breaking changes per sé but, given the kind of changes we implemented - replacing the cbor library - I think it's worth to release it with a pseudo major/minor version.

# Changes

- Bump next version `v0.3.0` for release.

# Notes

I did some manual testing.

- New lib in relying party <> Old lib in OISY ✅
- New lib in relying party <> New lib in OISY ✅
- Old lib in relying party <> New lib in OISY ✅
- Identity kit demo <> New lib in OISY ✅

