### PR TITLE
docs: fix commands to run pseudo wallet

### DIFF
--- a/README.md
+++ b/README.md
@@ -558,12 +558,20 @@ If you're building a relying party (client) application—regardless of which li
 
 This pseudo wallet implements all the features provided by the signer, allowing you to test account listing, permission requests, and canister calls entirely in your local environment.
 
-1. Install the demo
+1. Clone the repository and install the library dependencies:
 
 ```bash
 git clone https://github.com/dfinity/oisy-wallet-signer
-cd oisy-wallet-signer/demo
+cd oisy-wallet-signer
 npm ci
+```
+
+2. Navigate to the demo directory and prepare the environment:
+
+```bash
+cd demo
+npm ci
+npm run sync:all
 ```
 
 2. Adapt port (if needed)


### PR DESCRIPTION
# Motivation

When freshly cloned, it requires two more commands to run the pseudo wallet locally.

# Changes

- Fix list of commands to make `npm run dev:wallet` works.