### PR TITLE
build: temporary install deps with --force flag in ci

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -17,5 +17,5 @@ runs:
         registry-url: 'https://registry.npmjs.org'
     - name: Install dependencies
       shell: bash
-      run: npm ci
+      run: npm ci --force
       working-directory: ${{ inputs.folder }}


### PR DESCRIPTION
# Motivation

There’s currently no clean way to install the unreleased dependencies required for #618 without using `--force` — it’s a pain. As a temporary workaround, we’ve configured the CI to use this flag.

⚠️ This PR must be reverted before publishing any new release.

# Changes

- `--force` in CI prepare.
