### PR TITLE
feat: extract bigint to Expiry

### DIFF
--- a/src/utils/agentjs-cbor-copy.utils.ts
+++ b/src/utils/agentjs-cbor-copy.utils.ts
@@ -1,16 +1,9 @@
-import {Expiry, JSON_KEY_EXPIRY, type CallRequest} from '@dfinity/agent';
+import {type CallRequest} from '@dfinity/agent';
 import {decode} from '@dfinity/cbor';
 import {Principal} from '@dfinity/principal';
 import {base64ToUint8Array} from '@dfinity/utils';
 import type {IcrcBlob} from '../types/blob';
-
-// Expiry doesn't have a fromBigInt static method yet.
-// `@dfinity/agent` is planning to add a Expiry.fromBigInt method, so we can use it once it's released.
-// TODO: extract to utils and test it
-const bigIntToExpiry = (val: bigint) => {
-  const jsonExpiry = JSON.stringify({[JSON_KEY_EXPIRY]: val.toString()});
-  return Expiry.fromJSON(jsonExpiry);
-};
+import {bigIntToExpiry} from './expiry.utils';
 
 export const decodeCallRequest = (contentMap: IcrcBlob): CallRequest => {
   type CborCallRequest = Omit<CallRequest, 'ingress_expiry' | 'canister_id' | 'sender'> & {

--- a/src/utils/expiry.utils.spec.ts
+++ b/src/utils/expiry.utils.spec.ts
@@ -1,0 +1,31 @@
+import {Expiry, JSON_KEY_EXPIRY} from '@dfinity/agent';
+
+import {bigIntToExpiry} from './expiry.utils';
+
+describe('bigIntToExpiry', () => {
+  it('should convert bigint to Expiry using fromJSON', () => {
+    const mockFromJSON = vi.spyOn(Expiry, 'fromJSON');
+
+    const value = 123789n;
+    const expectedJson = JSON.stringify({[JSON_KEY_EXPIRY]: value.toString()});
+
+    bigIntToExpiry(value);
+
+    expect(mockFromJSON).toHaveBeenCalledWith(expectedJson);
+  });
+
+  it('should return an instance of Expiry', () => {
+    const value = 9874321n;
+    const result = bigIntToExpiry(value);
+
+    expect(result).toBeInstanceOf(Expiry);
+  });
+
+  it('should return a value Expiry object', () => {
+    const value = 555554321n;
+    const result = bigIntToExpiry(value);
+
+    expect(result instanceof Expiry).toBeTruthy();
+    expect(result.toBigInt()).toBe(value);
+  });
+});

--- a/src/utils/expiry.utils.ts
+++ b/src/utils/expiry.utils.ts
@@ -1,0 +1,8 @@
+import {Expiry, JSON_KEY_EXPIRY} from '@dfinity/agent';
+
+// Expiry doesn't have a fromBigInt static method yet.
+// TODO: `@dfinity/agent` is planning to add a Expiry.fromBigInt method, so we can use it once it's released.
+export const bigIntToExpiry = (val: bigint): Expiry => {
+  const jsonExpiry = JSON.stringify({[JSON_KEY_EXPIRY]: val.toString()});
+  return Expiry.fromJSON(jsonExpiry);
+};


### PR DESCRIPTION
# Motivation

This PR extract a resusable function to convert `bigint` to `Expiry`. In the future we will be able to replace it with a native function provided by the agent.

# Changes

- Extract function and add test.
