### PR TITLE
test: fix expiry comparison

### DIFF
--- a/src/utils/cbor.utils.spec.ts
+++ b/src/utils/cbor.utils.spec.ts
@@ -85,9 +85,7 @@ describe('cbor.utils', () => {
       const result = contentMapReplacer(expiry, undefined);
 
       expect(result instanceof Expiry).toBeTruthy();
-      expect((result as unknown as {_value: bigint})._value).toBe(
-        (expiry as unknown as {_value: bigint})._value
-      );
+      expect((result as Expiry).toBigInt()).toBe(expiry.toBigInt());
     });
 
     it('returns original Expiry if misspelled ingress_expiry key', () => {
@@ -95,9 +93,7 @@ describe('cbor.utils', () => {
       const result = contentMapReplacer(expiry, 'ingress_expiryy');
 
       expect(result instanceof Expiry).toBeTruthy();
-      expect((result as unknown as {_value: bigint})._value).toBe(
-        (expiry as unknown as {_value: bigint})._value
-      );
+      expect((result as Expiry).toBigInt()).toBe(expiry.toBigInt());
     });
   });
 });


### PR DESCRIPTION
# Motivation

While reviewing the "Expiry" topic I noticed that two tests were relying on `_value` internal proprety which has been deprecated. The tests were still passing because they compared "undefined ==== undefined".

# Changes

- Replace inner value for test with function `toBigInt` exposed by object `Expiry`.
