### PR TITLE
build: bump released ic-js and latest agent-js v3

### DIFF
--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -1,24 +1,24 @@
 {
 	"name": "@dfinity/oisy-wallet-signer-demo",
-	"version": "0.0.1",
+	"version": "0.4.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@dfinity/oisy-wallet-signer-demo",
-			"version": "0.0.1",
+			"version": "0.4.0",
 			"workspaces": [
 				"src/relying_party_frontend",
 				"src/wallet_frontend"
 			],
 			"dependencies": {
-				"@dfinity/agent": "^3.2.0",
-				"@dfinity/auth-client": "^3.2.0",
-				"@dfinity/candid": "^3.2.0",
-				"@dfinity/ledger-icp": "^5.0.0-next-2025-08-14",
-				"@dfinity/ledger-icrc": "^3.0.0-next-2025-08-14",
-				"@dfinity/principal": "^3.2.0",
-				"@dfinity/utils": "3.0.0-beta-2025-08-13",
+				"@dfinity/agent": "^3.2.4",
+				"@dfinity/auth-client": "^3.2.4",
+				"@dfinity/candid": "^3.2.4",
+				"@dfinity/ledger-icp": "^5.0.0",
+				"@dfinity/ledger-icrc": "^3.0.0",
+				"@dfinity/principal": "^3.2.4",
+				"@dfinity/utils": "^3.0.1",
 				"@dfinity/zod-schemas": "^1.1.0",
 				"zod": "^3.25"
 			},
@@ -526,41 +526,41 @@
 			}
 		},
 		"node_modules/@dfinity/agent": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-3.2.0.tgz",
-			"integrity": "sha512-GIobACWPxhjdnFMKR7GS4nMqlq1rMYEImYvSWfNAtPbAAwNqfNk7Sgr6/2qLt4XWxiRhbShk65w+hLJGor0xlw==",
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-3.2.4.tgz",
+			"integrity": "sha512-2TpFyaInmdRemQ8QlP4yZusO+6Dqe98SBvSSGOWcCL2zQ7u/dgKA1jXwXb7tdHHMXvdC1bXFjeyBGqpqTG6avA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@dfinity/cbor": "^0.2.2",
 				"@noble/curves": "^1.9.2"
 			},
 			"peerDependencies": {
-				"@dfinity/candid": "3.2.0",
-				"@dfinity/principal": "3.2.0",
+				"@dfinity/candid": "3.2.4",
+				"@dfinity/principal": "3.2.4",
 				"@noble/hashes": "^1.8.0"
 			}
 		},
 		"node_modules/@dfinity/auth-client": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/@dfinity/auth-client/-/auth-client-3.2.0.tgz",
-			"integrity": "sha512-aYDevfOkFaDdliRzUiqLfGTVevRJK/lwrIausCasA4uua2myRVMTnlz7yXDMLmdLbtgL9a9XpGxMh3k/eBDcUQ==",
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/@dfinity/auth-client/-/auth-client-3.2.4.tgz",
+			"integrity": "sha512-BDY1wnQok6FJ8yqFHqY+v4iqdRV4isDFemApPgCF6oF12RllacixjadeqfBWAqjt5zNXUKPllJzZWlR96ymamg==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"idb": "^7.0.2"
 			},
 			"peerDependencies": {
-				"@dfinity/agent": "3.2.0",
-				"@dfinity/identity": "3.2.0",
-				"@dfinity/principal": "3.2.0"
+				"@dfinity/agent": "3.2.4",
+				"@dfinity/identity": "3.2.4",
+				"@dfinity/principal": "3.2.4"
 			}
 		},
 		"node_modules/@dfinity/candid": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-3.2.0.tgz",
-			"integrity": "sha512-HbyXp1QGHU/xa2lBSL9GjoHFAGbPiFrgJwabK0/VZzrcjQPKjv7G/krMKCIMm4pfaGl3ChWan9FyV9Ax/an3/g==",
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-3.2.4.tgz",
+			"integrity": "sha512-VpzY4mFHmm/F4iuqW3AMehKEsTeFbM5CDkRqp0IHS2gqxBm0XDkreJhIyv5S4P93NxGx1QzPCN1wzO5wPuH8OA==",
 			"license": "Apache-2.0",
 			"peerDependencies": {
-				"@dfinity/principal": "3.2.0"
+				"@dfinity/principal": "3.2.4"
 			}
 		},
 		"node_modules/@dfinity/cbor": {
@@ -599,41 +599,41 @@
 			}
 		},
 		"node_modules/@dfinity/identity": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/@dfinity/identity/-/identity-3.2.0.tgz",
-			"integrity": "sha512-sZ4130KIxcqguK1heS+BPHCdN8Pnaisz6qYJoI+mEH3g7EmE8l/5GlxlZHmhX12KMloHIDd5UFHBSXlLL96vJw==",
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/@dfinity/identity/-/identity-3.2.4.tgz",
+			"integrity": "sha512-+QUvC0rbWh0zRcHyqpYdbyJ2sfBLcwBKATsOWmQFoyMofgfFZTR+21ITqX+J8rcrHdj3XzSKSSYnq+8zRgF6ow==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"peerDependencies": {
-				"@dfinity/agent": "3.2.0",
-				"@dfinity/candid": "3.2.0",
-				"@dfinity/principal": "3.2.0",
+				"@dfinity/agent": "3.2.4",
+				"@dfinity/candid": "3.2.4",
+				"@dfinity/principal": "3.2.4",
 				"@noble/curves": "^1.9.2",
 				"@noble/hashes": "^1.8.0"
 			}
 		},
 		"node_modules/@dfinity/ledger-icp": {
-			"version": "5.0.0-next-2025-08-14",
-			"resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-5.0.0-next-2025-08-14.tgz",
-			"integrity": "sha512-leIBAgY/iDLKH8sxuYoyT2ojdo734DYRm9WWkeTGAUHuIqBS+SPHAYPkxIcoDoDNhL56SZM78hMpcCUoGMXeQA==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-5.0.0.tgz",
+			"integrity": "sha512-WlYS+WuvHqxNLkKpk22WXbfVeecYxcKLmj6HooXzKmaimjuO5QglEEva7jyXaydWa/5eMFpehaer+Rg7/b7aPg==",
 			"license": "Apache-2.0",
 			"peerDependencies": {
-				"@dfinity/agent": "*",
-				"@dfinity/candid": "*",
-				"@dfinity/principal": "*",
-				"@dfinity/utils": "*"
+				"@dfinity/agent": "^3",
+				"@dfinity/candid": "^3",
+				"@dfinity/principal": "^3",
+				"@dfinity/utils": "^3"
 			}
 		},
 		"node_modules/@dfinity/ledger-icrc": {
-			"version": "3.0.0-next-2025-08-14",
-			"resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-3.0.0-next-2025-08-14.tgz",
-			"integrity": "sha512-pIusjXeid4Z4JqMfK7tKR1TOkK1PZ101FWSAfsdNlwMX4IS1LsOtS82H2bH+K3MkuS3uvz5cXOIOThv5++jCjQ==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-3.0.0.tgz",
+			"integrity": "sha512-2T5JQ198vnhUv3o08SS4T2Je70QsKuZ2RkKw4Sm7GW1lEFc0228/rzcAMguwoOh9+CoYpUbnh645ZGs+gOHzSg==",
 			"license": "Apache-2.0",
 			"peerDependencies": {
-				"@dfinity/agent": "*",
-				"@dfinity/candid": "*",
-				"@dfinity/principal": "*",
-				"@dfinity/utils": "*"
+				"@dfinity/agent": "^3",
+				"@dfinity/candid": "^3",
+				"@dfinity/principal": "^3",
+				"@dfinity/utils": "^3"
 			}
 		},
 		"node_modules/@dfinity/oisy-wallet-signer-demo-relying-party-frontend": {
@@ -645,23 +645,23 @@
 			"link": true
 		},
 		"node_modules/@dfinity/principal": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-3.2.0.tgz",
-			"integrity": "sha512-2VY3dLKLCxiZdJmgj+5LPZxb5DeJ0EJABUXGeYitAx6EikRpNYnpZUOXpb6TjPOUT67AednA7aLAP6xnXNV3nA==",
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-3.2.4.tgz",
+			"integrity": "sha512-7qTjDb9k/J/55k0/ZnD8s2+L+IgfG6K1lC7iywhQQL/4Qe0UIljUTasDk85kooY2QeNvWSl7MsLWp69LPBiYjw==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@noble/hashes": "^1.8.0"
 			}
 		},
 		"node_modules/@dfinity/utils": {
-			"version": "3.0.0-beta-2025-08-13",
-			"resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-3.0.0-beta-2025-08-13.tgz",
-			"integrity": "sha512-GMZe/XMix1LiWrh66emIZLvtND75oy0LPARzNUPB18gZ0qhoUZ399J9l8sd1zQzLOmbzDfTsRRQglQJ9fiC/3Q==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-3.0.1.tgz",
+			"integrity": "sha512-C1YS9tvqSsYRXS09FtAKvqt+QDwFFePomAHfzCFj/HM52NW/rHGZh2qhNs44bh8m/LHNUDlZxf7daZTxnUeInA==",
 			"license": "Apache-2.0",
 			"peerDependencies": {
-				"@dfinity/agent": "*",
-				"@dfinity/candid": "*",
-				"@dfinity/principal": "*"
+				"@dfinity/agent": "^3",
+				"@dfinity/candid": "^3",
+				"@dfinity/principal": "^3"
 			}
 		},
 		"node_modules/@dfinity/zod-schemas": {

--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -1,24 +1,24 @@
 {
 	"name": "@dfinity/oisy-wallet-signer-demo",
-	"version": "0.0.1",
+	"version": "0.4.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@dfinity/oisy-wallet-signer-demo",
-			"version": "0.0.1",
+			"version": "0.4.0",
 			"workspaces": [
 				"src/relying_party_frontend",
 				"src/wallet_frontend"
 			],
 			"dependencies": {
-				"@dfinity/agent": "^3.2.0",
-				"@dfinity/auth-client": "^3.2.0",
-				"@dfinity/candid": "^3.2.0",
-				"@dfinity/ledger-icp": "5.0.0-beta-2025-08-13",
-				"@dfinity/ledger-icrc": "3.0.0-beta-2025-08-13",
-				"@dfinity/principal": "^3.2.0",
-				"@dfinity/utils": "3.0.0-beta-2025-08-13",
+				"@dfinity/agent": "^3.2.4",
+				"@dfinity/auth-client": "^3.2.4",
+				"@dfinity/candid": "^3.2.4",
+				"@dfinity/ledger-icp": "^5.0.0",
+				"@dfinity/ledger-icrc": "^3.0.0",
+				"@dfinity/principal": "^3.2.4",
+				"@dfinity/utils": "^3.0.1",
 				"@dfinity/zod-schemas": "^1.1.0",
 				"zod": "^3.25"
 			},
@@ -522,41 +522,41 @@
 			}
 		},
 		"node_modules/@dfinity/agent": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-3.2.0.tgz",
-			"integrity": "sha512-GIobACWPxhjdnFMKR7GS4nMqlq1rMYEImYvSWfNAtPbAAwNqfNk7Sgr6/2qLt4XWxiRhbShk65w+hLJGor0xlw==",
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-3.2.4.tgz",
+			"integrity": "sha512-2TpFyaInmdRemQ8QlP4yZusO+6Dqe98SBvSSGOWcCL2zQ7u/dgKA1jXwXb7tdHHMXvdC1bXFjeyBGqpqTG6avA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@dfinity/cbor": "^0.2.2",
 				"@noble/curves": "^1.9.2"
 			},
 			"peerDependencies": {
-				"@dfinity/candid": "3.2.0",
-				"@dfinity/principal": "3.2.0",
+				"@dfinity/candid": "3.2.4",
+				"@dfinity/principal": "3.2.4",
 				"@noble/hashes": "^1.8.0"
 			}
 		},
 		"node_modules/@dfinity/auth-client": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/@dfinity/auth-client/-/auth-client-3.2.0.tgz",
-			"integrity": "sha512-aYDevfOkFaDdliRzUiqLfGTVevRJK/lwrIausCasA4uua2myRVMTnlz7yXDMLmdLbtgL9a9XpGxMh3k/eBDcUQ==",
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/@dfinity/auth-client/-/auth-client-3.2.4.tgz",
+			"integrity": "sha512-BDY1wnQok6FJ8yqFHqY+v4iqdRV4isDFemApPgCF6oF12RllacixjadeqfBWAqjt5zNXUKPllJzZWlR96ymamg==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"idb": "^7.0.2"
 			},
 			"peerDependencies": {
-				"@dfinity/agent": "3.2.0",
-				"@dfinity/identity": "3.2.0",
-				"@dfinity/principal": "3.2.0"
+				"@dfinity/agent": "3.2.4",
+				"@dfinity/identity": "3.2.4",
+				"@dfinity/principal": "3.2.4"
 			}
 		},
 		"node_modules/@dfinity/candid": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-3.2.0.tgz",
-			"integrity": "sha512-HbyXp1QGHU/xa2lBSL9GjoHFAGbPiFrgJwabK0/VZzrcjQPKjv7G/krMKCIMm4pfaGl3ChWan9FyV9Ax/an3/g==",
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-3.2.4.tgz",
+			"integrity": "sha512-VpzY4mFHmm/F4iuqW3AMehKEsTeFbM5CDkRqp0IHS2gqxBm0XDkreJhIyv5S4P93NxGx1QzPCN1wzO5wPuH8OA==",
 			"license": "Apache-2.0",
 			"peerDependencies": {
-				"@dfinity/principal": "3.2.0"
+				"@dfinity/principal": "3.2.4"
 			}
 		},
 		"node_modules/@dfinity/cbor": {
@@ -595,41 +595,41 @@
 			}
 		},
 		"node_modules/@dfinity/identity": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/@dfinity/identity/-/identity-3.2.0.tgz",
-			"integrity": "sha512-sZ4130KIxcqguK1heS+BPHCdN8Pnaisz6qYJoI+mEH3g7EmE8l/5GlxlZHmhX12KMloHIDd5UFHBSXlLL96vJw==",
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/@dfinity/identity/-/identity-3.2.4.tgz",
+			"integrity": "sha512-+QUvC0rbWh0zRcHyqpYdbyJ2sfBLcwBKATsOWmQFoyMofgfFZTR+21ITqX+J8rcrHdj3XzSKSSYnq+8zRgF6ow==",
 			"license": "Apache-2.0",
 			"peer": true,
 			"peerDependencies": {
-				"@dfinity/agent": "3.2.0",
-				"@dfinity/candid": "3.2.0",
-				"@dfinity/principal": "3.2.0",
+				"@dfinity/agent": "3.2.4",
+				"@dfinity/candid": "3.2.4",
+				"@dfinity/principal": "3.2.4",
 				"@noble/curves": "^1.9.2",
 				"@noble/hashes": "^1.8.0"
 			}
 		},
 		"node_modules/@dfinity/ledger-icp": {
-			"version": "5.0.0-beta-2025-08-13",
-			"resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-5.0.0-beta-2025-08-13.tgz",
-			"integrity": "sha512-1u3zEtpjjOXxpaYB+VbmVSOuHNGOUdcZ4J0hYo0JGUnqqfKghw5gNAmYZQS0hWcIjqOxCbJSyxH2tuS3qp99iQ==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-5.0.0.tgz",
+			"integrity": "sha512-WlYS+WuvHqxNLkKpk22WXbfVeecYxcKLmj6HooXzKmaimjuO5QglEEva7jyXaydWa/5eMFpehaer+Rg7/b7aPg==",
 			"license": "Apache-2.0",
 			"peerDependencies": {
-				"@dfinity/agent": "*",
-				"@dfinity/candid": "*",
-				"@dfinity/principal": "*",
-				"@dfinity/utils": "*"
+				"@dfinity/agent": "^3",
+				"@dfinity/candid": "^3",
+				"@dfinity/principal": "^3",
+				"@dfinity/utils": "^3"
 			}
 		},
 		"node_modules/@dfinity/ledger-icrc": {
-			"version": "3.0.0-beta-2025-08-13",
-			"resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-3.0.0-beta-2025-08-13.tgz",
-			"integrity": "sha512-RCqiZTS50pHPlscRabFGMzjfQvjOPI4JF6+ci/o+jtLuXeNUpz0DFyFs8uG2emontxXv0QU/V4Z0o4jLlXZNmQ==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-3.0.0.tgz",
+			"integrity": "sha512-2T5JQ198vnhUv3o08SS4T2Je70QsKuZ2RkKw4Sm7GW1lEFc0228/rzcAMguwoOh9+CoYpUbnh645ZGs+gOHzSg==",
 			"license": "Apache-2.0",
 			"peerDependencies": {
-				"@dfinity/agent": "*",
-				"@dfinity/candid": "*",
-				"@dfinity/principal": "*",
-				"@dfinity/utils": "*"
+				"@dfinity/agent": "^3",
+				"@dfinity/candid": "^3",
+				"@dfinity/principal": "^3",
+				"@dfinity/utils": "^3"
 			}
 		},
 		"node_modules/@dfinity/oisy-wallet-signer-demo-relying-party-frontend": {
@@ -641,23 +641,23 @@
 			"link": true
 		},
 		"node_modules/@dfinity/principal": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-3.2.0.tgz",
-			"integrity": "sha512-2VY3dLKLCxiZdJmgj+5LPZxb5DeJ0EJABUXGeYitAx6EikRpNYnpZUOXpb6TjPOUT67AednA7aLAP6xnXNV3nA==",
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-3.2.4.tgz",
+			"integrity": "sha512-7qTjDb9k/J/55k0/ZnD8s2+L+IgfG6K1lC7iywhQQL/4Qe0UIljUTasDk85kooY2QeNvWSl7MsLWp69LPBiYjw==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@noble/hashes": "^1.8.0"
 			}
 		},
 		"node_modules/@dfinity/utils": {
-			"version": "3.0.0-beta-2025-08-13",
-			"resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-3.0.0-beta-2025-08-13.tgz",
-			"integrity": "sha512-GMZe/XMix1LiWrh66emIZLvtND75oy0LPARzNUPB18gZ0qhoUZ399J9l8sd1zQzLOmbzDfTsRRQglQJ9fiC/3Q==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-3.0.1.tgz",
+			"integrity": "sha512-C1YS9tvqSsYRXS09FtAKvqt+QDwFFePomAHfzCFj/HM52NW/rHGZh2qhNs44bh8m/LHNUDlZxf7daZTxnUeInA==",
 			"license": "Apache-2.0",
 			"peerDependencies": {
-				"@dfinity/agent": "*",
-				"@dfinity/candid": "*",
-				"@dfinity/principal": "*"
+				"@dfinity/agent": "^3",
+				"@dfinity/candid": "^3",
+				"@dfinity/principal": "^3"
 			}
 		},
 		"node_modules/@dfinity/zod-schemas": {

--- a/demo/package.json
+++ b/demo/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dfinity/oisy-wallet-signer-demo",
-	"version": "0.0.1",
+	"version": "0.4.0",
 	"private": true,
 	"workspaces": [
 		"src/relying_party_frontend",
@@ -50,13 +50,13 @@
 	},
 	"type": "module",
 	"dependencies": {
-		"@dfinity/agent": "^3.2.0",
-		"@dfinity/auth-client": "^3.2.0",
-		"@dfinity/candid": "^3.2.0",
-		"@dfinity/ledger-icp": "^5.0.0-next-2025-08-14",
-		"@dfinity/ledger-icrc": "^3.0.0-next-2025-08-14",
-		"@dfinity/principal": "^3.2.0",
-		"@dfinity/utils": "3.0.0-beta-2025-08-13",
+		"@dfinity/agent": "^3.2.4",
+		"@dfinity/auth-client": "^3.2.4",
+		"@dfinity/candid": "^3.2.4",
+		"@dfinity/ledger-icp": "^5.0.0",
+		"@dfinity/ledger-icrc": "^3.0.0",
+		"@dfinity/principal": "^3.2.4",
+		"@dfinity/utils": "^3.0.1",
 		"@dfinity/zod-schemas": "^1.1.0",
 		"zod": "^3.25"
 	},

--- a/demo/package.json
+++ b/demo/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@dfinity/oisy-wallet-signer-demo",
-	"version": "0.0.1",
+	"version": "0.4.0",
 	"private": true,
 	"workspaces": [
 		"src/relying_party_frontend",
@@ -50,13 +50,13 @@
 	},
 	"type": "module",
 	"dependencies": {
-		"@dfinity/agent": "^3.2.0",
-		"@dfinity/auth-client": "^3.2.0",
-		"@dfinity/candid": "^3.2.0",
-		"@dfinity/ledger-icp": "5.0.0-beta-2025-08-13",
-		"@dfinity/ledger-icrc": "3.0.0-beta-2025-08-13",
-		"@dfinity/principal": "^3.2.0",
-		"@dfinity/utils": "3.0.0-beta-2025-08-13",
+		"@dfinity/agent": "^3.2.4",
+		"@dfinity/auth-client": "^3.2.4",
+		"@dfinity/candid": "^3.2.4",
+		"@dfinity/ledger-icp": "^5.0.0",
+		"@dfinity/ledger-icrc": "^3.0.0",
+		"@dfinity/principal": "^3.2.4",
+		"@dfinity/utils": "^3.0.1",
 		"@dfinity/zod-schemas": "^1.1.0",
 		"zod": "^3.25"
 	},

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@dfinity/oisy-wallet-signer",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dfinity/oisy-wallet-signer",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@dfinity/eslint-config-oisy-wallet": "^0.2.2",
-        "@dfinity/identity": "^3.2.0",
+        "@dfinity/identity": "^3",
         "@dfinity/internet-identity-playwright": "^2.0.0",
         "@playwright/test": "^1.53.2",
         "@types/jest": "^30.0.0",
@@ -29,10 +29,10 @@
       "peerDependencies": {
         "@dfinity/agent": "^3",
         "@dfinity/candid": "^3",
-        "@dfinity/ledger-icp": "^5.0.0-next-2025-08-14",
-        "@dfinity/ledger-icrc": "^3.0.0-next-2025-08-14",
+        "@dfinity/ledger-icp": "^5",
+        "@dfinity/ledger-icrc": "^3",
         "@dfinity/principal": "^3",
-        "@dfinity/utils": "3.0.0-beta-2025-08-13",
+        "@dfinity/utils": "^3",
         "@dfinity/zod-schemas": "^1.1.0",
         "zod": "^3.25"
       }
@@ -192,9 +192,9 @@
       }
     },
     "node_modules/@dfinity/agent": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-3.2.0.tgz",
-      "integrity": "sha512-GIobACWPxhjdnFMKR7GS4nMqlq1rMYEImYvSWfNAtPbAAwNqfNk7Sgr6/2qLt4XWxiRhbShk65w+hLJGor0xlw==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-3.2.4.tgz",
+      "integrity": "sha512-2TpFyaInmdRemQ8QlP4yZusO+6Dqe98SBvSSGOWcCL2zQ7u/dgKA1jXwXb7tdHHMXvdC1bXFjeyBGqpqTG6avA==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
@@ -202,19 +202,19 @@
         "@noble/curves": "^1.9.2"
       },
       "peerDependencies": {
-        "@dfinity/candid": "3.2.0",
-        "@dfinity/principal": "3.2.0",
+        "@dfinity/candid": "3.2.4",
+        "@dfinity/principal": "3.2.4",
         "@noble/hashes": "^1.8.0"
       }
     },
     "node_modules/@dfinity/candid": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-3.2.0.tgz",
-      "integrity": "sha512-HbyXp1QGHU/xa2lBSL9GjoHFAGbPiFrgJwabK0/VZzrcjQPKjv7G/krMKCIMm4pfaGl3ChWan9FyV9Ax/an3/g==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-3.2.4.tgz",
+      "integrity": "sha512-VpzY4mFHmm/F4iuqW3AMehKEsTeFbM5CDkRqp0IHS2gqxBm0XDkreJhIyv5S4P93NxGx1QzPCN1wzO5wPuH8OA==",
       "license": "Apache-2.0",
       "peer": true,
       "peerDependencies": {
-        "@dfinity/principal": "3.2.0"
+        "@dfinity/principal": "3.2.4"
       }
     },
     "node_modules/@dfinity/cbor": {
@@ -254,15 +254,15 @@
       }
     },
     "node_modules/@dfinity/identity": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@dfinity/identity/-/identity-3.2.0.tgz",
-      "integrity": "sha512-sZ4130KIxcqguK1heS+BPHCdN8Pnaisz6qYJoI+mEH3g7EmE8l/5GlxlZHmhX12KMloHIDd5UFHBSXlLL96vJw==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@dfinity/identity/-/identity-3.2.4.tgz",
+      "integrity": "sha512-+QUvC0rbWh0zRcHyqpYdbyJ2sfBLcwBKATsOWmQFoyMofgfFZTR+21ITqX+J8rcrHdj3XzSKSSYnq+8zRgF6ow==",
       "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@dfinity/agent": "3.2.0",
-        "@dfinity/candid": "3.2.0",
-        "@dfinity/principal": "3.2.0",
+        "@dfinity/agent": "3.2.4",
+        "@dfinity/candid": "3.2.4",
+        "@dfinity/principal": "3.2.4",
         "@noble/curves": "^1.9.2",
         "@noble/hashes": "^1.8.0"
       }
@@ -281,35 +281,35 @@
       }
     },
     "node_modules/@dfinity/ledger-icp": {
-      "version": "5.0.0-next-2025-08-14",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-5.0.0-next-2025-08-14.tgz",
-      "integrity": "sha512-leIBAgY/iDLKH8sxuYoyT2ojdo734DYRm9WWkeTGAUHuIqBS+SPHAYPkxIcoDoDNhL56SZM78hMpcCUoGMXeQA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-5.0.0.tgz",
+      "integrity": "sha512-WlYS+WuvHqxNLkKpk22WXbfVeecYxcKLmj6HooXzKmaimjuO5QglEEva7jyXaydWa/5eMFpehaer+Rg7/b7aPg==",
       "license": "Apache-2.0",
       "peer": true,
       "peerDependencies": {
-        "@dfinity/agent": "*",
-        "@dfinity/candid": "*",
-        "@dfinity/principal": "*",
-        "@dfinity/utils": "*"
+        "@dfinity/agent": "^3",
+        "@dfinity/candid": "^3",
+        "@dfinity/principal": "^3",
+        "@dfinity/utils": "^3"
       }
     },
     "node_modules/@dfinity/ledger-icrc": {
-      "version": "3.0.0-next-2025-08-14",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-3.0.0-next-2025-08-14.tgz",
-      "integrity": "sha512-pIusjXeid4Z4JqMfK7tKR1TOkK1PZ101FWSAfsdNlwMX4IS1LsOtS82H2bH+K3MkuS3uvz5cXOIOThv5++jCjQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-3.0.0.tgz",
+      "integrity": "sha512-2T5JQ198vnhUv3o08SS4T2Je70QsKuZ2RkKw4Sm7GW1lEFc0228/rzcAMguwoOh9+CoYpUbnh645ZGs+gOHzSg==",
       "license": "Apache-2.0",
       "peer": true,
       "peerDependencies": {
-        "@dfinity/agent": "*",
-        "@dfinity/candid": "*",
-        "@dfinity/principal": "*",
-        "@dfinity/utils": "*"
+        "@dfinity/agent": "^3",
+        "@dfinity/candid": "^3",
+        "@dfinity/principal": "^3",
+        "@dfinity/utils": "^3"
       }
     },
     "node_modules/@dfinity/principal": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-3.2.0.tgz",
-      "integrity": "sha512-2VY3dLKLCxiZdJmgj+5LPZxb5DeJ0EJABUXGeYitAx6EikRpNYnpZUOXpb6TjPOUT67AednA7aLAP6xnXNV3nA==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-3.2.4.tgz",
+      "integrity": "sha512-7qTjDb9k/J/55k0/ZnD8s2+L+IgfG6K1lC7iywhQQL/4Qe0UIljUTasDk85kooY2QeNvWSl7MsLWp69LPBiYjw==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
@@ -317,15 +317,15 @@
       }
     },
     "node_modules/@dfinity/utils": {
-      "version": "3.0.0-beta-2025-08-13",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-3.0.0-beta-2025-08-13.tgz",
-      "integrity": "sha512-GMZe/XMix1LiWrh66emIZLvtND75oy0LPARzNUPB18gZ0qhoUZ399J9l8sd1zQzLOmbzDfTsRRQglQJ9fiC/3Q==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-3.0.1.tgz",
+      "integrity": "sha512-C1YS9tvqSsYRXS09FtAKvqt+QDwFFePomAHfzCFj/HM52NW/rHGZh2qhNs44bh8m/LHNUDlZxf7daZTxnUeInA==",
       "license": "Apache-2.0",
       "peer": true,
       "peerDependencies": {
-        "@dfinity/agent": "*",
-        "@dfinity/candid": "*",
-        "@dfinity/principal": "*"
+        "@dfinity/agent": "^3",
+        "@dfinity/candid": "^3",
+        "@dfinity/principal": "^3"
       }
     },
     "node_modules/@dfinity/zod-schemas": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,8 +28,8 @@
       "peerDependencies": {
         "@dfinity/agent": "^3",
         "@dfinity/candid": "^3",
-        "@dfinity/ledger-icp": "^6",
-        "@dfinity/ledger-icrc": "^4",
+        "@dfinity/ledger-icp": "^5",
+        "@dfinity/ledger-icrc": "^3",
         "@dfinity/principal": "^3",
         "@dfinity/utils": "^3",
         "@dfinity/zod-schemas": "^1.1.0",
@@ -280,9 +280,9 @@
       }
     },
     "node_modules/@dfinity/ledger-icp": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-6.0.0.tgz",
-      "integrity": "sha512-PoS8fwJuOJIRX6Coaq+tZJJ553IW++7CVFmR0OdHBE5fmvJEJ2ID2hARcKkyf1vvTCu8uOeIVWQ3hJA1AA0bSg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-5.0.0.tgz",
+      "integrity": "sha512-WlYS+WuvHqxNLkKpk22WXbfVeecYxcKLmj6HooXzKmaimjuO5QglEEva7jyXaydWa/5eMFpehaer+Rg7/b7aPg==",
       "license": "Apache-2.0",
       "peer": true,
       "peerDependencies": {
@@ -293,9 +293,9 @@
       }
     },
     "node_modules/@dfinity/ledger-icrc": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-4.0.0.tgz",
-      "integrity": "sha512-Pdi2p3CiUfV5b6v654cj9kxd6ZlZKtXWbQyj/FOaJgu0vmkdhDMfDOd7+9J4/jR4XZAldCRg7EGOKI5TK7YZ3g==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-3.0.0.tgz",
+      "integrity": "sha512-2T5JQ198vnhUv3o08SS4T2Je70QsKuZ2RkKw4Sm7GW1lEFc0228/rzcAMguwoOh9+CoYpUbnh645ZGs+gOHzSg==",
       "license": "Apache-2.0",
       "peer": true,
       "peerDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@dfinity/eslint-config-oisy-wallet": "^0.2.2",
-        "@dfinity/identity": "^3.2.0",
+        "@dfinity/identity": "^3",
         "@dfinity/internet-identity-playwright": "^2.0.0",
         "@playwright/test": "^1.53.2",
         "@types/jest": "^30.0.0",
@@ -28,10 +28,10 @@
       "peerDependencies": {
         "@dfinity/agent": "^3",
         "@dfinity/candid": "^3",
-        "@dfinity/ledger-icp": "5.0.0-beta-2025-08-13",
-        "@dfinity/ledger-icrc": "3.0.0-beta-2025-08-13",
+        "@dfinity/ledger-icp": "^6",
+        "@dfinity/ledger-icrc": "^4",
         "@dfinity/principal": "^3",
-        "@dfinity/utils": "3.0.0-beta-2025-08-13",
+        "@dfinity/utils": "^3",
         "@dfinity/zod-schemas": "^1.1.0",
         "zod": "^3.25"
       }
@@ -191,9 +191,9 @@
       }
     },
     "node_modules/@dfinity/agent": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-3.2.0.tgz",
-      "integrity": "sha512-GIobACWPxhjdnFMKR7GS4nMqlq1rMYEImYvSWfNAtPbAAwNqfNk7Sgr6/2qLt4XWxiRhbShk65w+hLJGor0xlw==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-3.2.4.tgz",
+      "integrity": "sha512-2TpFyaInmdRemQ8QlP4yZusO+6Dqe98SBvSSGOWcCL2zQ7u/dgKA1jXwXb7tdHHMXvdC1bXFjeyBGqpqTG6avA==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
@@ -201,19 +201,19 @@
         "@noble/curves": "^1.9.2"
       },
       "peerDependencies": {
-        "@dfinity/candid": "3.2.0",
-        "@dfinity/principal": "3.2.0",
+        "@dfinity/candid": "3.2.4",
+        "@dfinity/principal": "3.2.4",
         "@noble/hashes": "^1.8.0"
       }
     },
     "node_modules/@dfinity/candid": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-3.2.0.tgz",
-      "integrity": "sha512-HbyXp1QGHU/xa2lBSL9GjoHFAGbPiFrgJwabK0/VZzrcjQPKjv7G/krMKCIMm4pfaGl3ChWan9FyV9Ax/an3/g==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@dfinity/candid/-/candid-3.2.4.tgz",
+      "integrity": "sha512-VpzY4mFHmm/F4iuqW3AMehKEsTeFbM5CDkRqp0IHS2gqxBm0XDkreJhIyv5S4P93NxGx1QzPCN1wzO5wPuH8OA==",
       "license": "Apache-2.0",
       "peer": true,
       "peerDependencies": {
-        "@dfinity/principal": "3.2.0"
+        "@dfinity/principal": "3.2.4"
       }
     },
     "node_modules/@dfinity/cbor": {
@@ -253,15 +253,15 @@
       }
     },
     "node_modules/@dfinity/identity": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@dfinity/identity/-/identity-3.2.0.tgz",
-      "integrity": "sha512-sZ4130KIxcqguK1heS+BPHCdN8Pnaisz6qYJoI+mEH3g7EmE8l/5GlxlZHmhX12KMloHIDd5UFHBSXlLL96vJw==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@dfinity/identity/-/identity-3.2.4.tgz",
+      "integrity": "sha512-+QUvC0rbWh0zRcHyqpYdbyJ2sfBLcwBKATsOWmQFoyMofgfFZTR+21ITqX+J8rcrHdj3XzSKSSYnq+8zRgF6ow==",
       "dev": true,
       "license": "Apache-2.0",
       "peerDependencies": {
-        "@dfinity/agent": "3.2.0",
-        "@dfinity/candid": "3.2.0",
-        "@dfinity/principal": "3.2.0",
+        "@dfinity/agent": "3.2.4",
+        "@dfinity/candid": "3.2.4",
+        "@dfinity/principal": "3.2.4",
         "@noble/curves": "^1.9.2",
         "@noble/hashes": "^1.8.0"
       }
@@ -280,35 +280,35 @@
       }
     },
     "node_modules/@dfinity/ledger-icp": {
-      "version": "5.0.0-beta-2025-08-13",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-5.0.0-beta-2025-08-13.tgz",
-      "integrity": "sha512-1u3zEtpjjOXxpaYB+VbmVSOuHNGOUdcZ4J0hYo0JGUnqqfKghw5gNAmYZQS0hWcIjqOxCbJSyxH2tuS3qp99iQ==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-6.0.0.tgz",
+      "integrity": "sha512-PoS8fwJuOJIRX6Coaq+tZJJ553IW++7CVFmR0OdHBE5fmvJEJ2ID2hARcKkyf1vvTCu8uOeIVWQ3hJA1AA0bSg==",
       "license": "Apache-2.0",
       "peer": true,
       "peerDependencies": {
-        "@dfinity/agent": "*",
-        "@dfinity/candid": "*",
-        "@dfinity/principal": "*",
-        "@dfinity/utils": "*"
+        "@dfinity/agent": "^3",
+        "@dfinity/candid": "^3",
+        "@dfinity/principal": "^3",
+        "@dfinity/utils": "^3"
       }
     },
     "node_modules/@dfinity/ledger-icrc": {
-      "version": "3.0.0-beta-2025-08-13",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-3.0.0-beta-2025-08-13.tgz",
-      "integrity": "sha512-RCqiZTS50pHPlscRabFGMzjfQvjOPI4JF6+ci/o+jtLuXeNUpz0DFyFs8uG2emontxXv0QU/V4Z0o4jLlXZNmQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-4.0.0.tgz",
+      "integrity": "sha512-Pdi2p3CiUfV5b6v654cj9kxd6ZlZKtXWbQyj/FOaJgu0vmkdhDMfDOd7+9J4/jR4XZAldCRg7EGOKI5TK7YZ3g==",
       "license": "Apache-2.0",
       "peer": true,
       "peerDependencies": {
-        "@dfinity/agent": "*",
-        "@dfinity/candid": "*",
-        "@dfinity/principal": "*",
-        "@dfinity/utils": "*"
+        "@dfinity/agent": "^3",
+        "@dfinity/candid": "^3",
+        "@dfinity/principal": "^3",
+        "@dfinity/utils": "^3"
       }
     },
     "node_modules/@dfinity/principal": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-3.2.0.tgz",
-      "integrity": "sha512-2VY3dLKLCxiZdJmgj+5LPZxb5DeJ0EJABUXGeYitAx6EikRpNYnpZUOXpb6TjPOUT67AednA7aLAP6xnXNV3nA==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@dfinity/principal/-/principal-3.2.4.tgz",
+      "integrity": "sha512-7qTjDb9k/J/55k0/ZnD8s2+L+IgfG6K1lC7iywhQQL/4Qe0UIljUTasDk85kooY2QeNvWSl7MsLWp69LPBiYjw==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
@@ -316,15 +316,15 @@
       }
     },
     "node_modules/@dfinity/utils": {
-      "version": "3.0.0-beta-2025-08-13",
-      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-3.0.0-beta-2025-08-13.tgz",
-      "integrity": "sha512-GMZe/XMix1LiWrh66emIZLvtND75oy0LPARzNUPB18gZ0qhoUZ399J9l8sd1zQzLOmbzDfTsRRQglQJ9fiC/3Q==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-3.0.1.tgz",
+      "integrity": "sha512-C1YS9tvqSsYRXS09FtAKvqt+QDwFFePomAHfzCFj/HM52NW/rHGZh2qhNs44bh8m/LHNUDlZxf7daZTxnUeInA==",
       "license": "Apache-2.0",
       "peer": true,
       "peerDependencies": {
-        "@dfinity/agent": "*",
-        "@dfinity/candid": "*",
-        "@dfinity/principal": "*"
+        "@dfinity/agent": "^3",
+        "@dfinity/candid": "^3",
+        "@dfinity/principal": "^3"
       }
     },
     "node_modules/@dfinity/zod-schemas": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dfinity/oisy-wallet-signer",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dfinity/oisy-wallet-signer",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@dfinity/eslint-config-oisy-wallet": "^0.2.2",

--- a/package.json
+++ b/package.json
@@ -89,8 +89,8 @@
   "peerDependencies": {
     "@dfinity/agent": "^3",
     "@dfinity/candid": "^3",
-    "@dfinity/ledger-icp": "^6",
-    "@dfinity/ledger-icrc": "^4",
+    "@dfinity/ledger-icp": "^5",
+    "@dfinity/ledger-icrc": "^3",
     "@dfinity/principal": "^3",
     "@dfinity/utils": "^3",
     "@dfinity/zod-schemas": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
   },
   "devDependencies": {
     "@dfinity/eslint-config-oisy-wallet": "^0.2.2",
-    "@dfinity/identity": "^3.2.0",
+    "@dfinity/identity": "^3",
     "@dfinity/internet-identity-playwright": "^2.0.0",
     "@playwright/test": "^1.53.2",
     "@types/jest": "^30.0.0",
@@ -89,10 +89,10 @@
   "peerDependencies": {
     "@dfinity/agent": "^3",
     "@dfinity/candid": "^3",
-    "@dfinity/ledger-icp": "5.0.0-beta-2025-08-13",
-    "@dfinity/ledger-icrc": "3.0.0-beta-2025-08-13",
+    "@dfinity/ledger-icp": "^6",
+    "@dfinity/ledger-icrc": "^4",
     "@dfinity/principal": "^3",
-    "@dfinity/utils": "3.0.0-beta-2025-08-13",
+    "@dfinity/utils": "^3",
     "@dfinity/zod-schemas": "^1.1.0",
     "zod": "^3.25"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/oisy-wallet-signer",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "A library designed to facilitate communication between a dApp and the OISY Wallet on the Internet Computer. ",
   "license": "Apache-2.0",
   "type": "module",
@@ -71,7 +71,7 @@
   },
   "devDependencies": {
     "@dfinity/eslint-config-oisy-wallet": "^0.2.2",
-    "@dfinity/identity": "^3.2.0",
+    "@dfinity/identity": "^3",
     "@dfinity/internet-identity-playwright": "^2.0.0",
     "@playwright/test": "^1.53.2",
     "@types/jest": "^30.0.0",
@@ -90,10 +90,10 @@
   "peerDependencies": {
     "@dfinity/agent": "^3",
     "@dfinity/candid": "^3",
-    "@dfinity/ledger-icp": "^5.0.0-next-2025-08-14",
-    "@dfinity/ledger-icrc": "^3.0.0-next-2025-08-14",
+    "@dfinity/ledger-icp": "^5",
+    "@dfinity/ledger-icrc": "^3",
     "@dfinity/principal": "^3",
-    "@dfinity/utils": "3.0.0-beta-2025-08-13",
+    "@dfinity/utils": "^3",
     "@dfinity/zod-schemas": "^1.1.0",
     "zod": "^3.25"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dfinity/oisy-wallet-signer",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "A library designed to facilitate communication between a dApp and the OISY Wallet on the Internet Computer. ",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
# Motivation

We want to release a version for AgentJS v3.

This PR integrates the compatible version of ic-js ([v73](https://github.com/dfinity/ic-js/releases/tag/v73) - not latest version `v74`, this will release separately), bumps AgentJS to latest (keep v3 as peer dependency in the lib) and set the version numbers for release.

# Changes

- Bump ic-js v73 and agent-js (as described) in library
- Bump ic-js v73 and agent-js (as described) in demo
- Set version for lib release to `v0.4.0`
- Set version to `v0.4.0` in the demo - I'm thinking that we can start versioning the number in sync there as well.