### PR TITLE
build: bump ledger-icp and -icrc with ICRC-21 breaking changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,8 +29,8 @@
       "peerDependencies": {
         "@dfinity/agent": "^3",
         "@dfinity/candid": "^3",
-        "@dfinity/ledger-icp": "^5",
-        "@dfinity/ledger-icrc": "^3",
+        "@dfinity/ledger-icp": "^6",
+        "@dfinity/ledger-icrc": "^4",
         "@dfinity/principal": "^3",
         "@dfinity/utils": "^3",
         "@dfinity/zod-schemas": "^1.1.0",
@@ -281,9 +281,9 @@
       }
     },
     "node_modules/@dfinity/ledger-icp": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-5.0.0.tgz",
-      "integrity": "sha512-WlYS+WuvHqxNLkKpk22WXbfVeecYxcKLmj6HooXzKmaimjuO5QglEEva7jyXaydWa/5eMFpehaer+Rg7/b7aPg==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icp/-/ledger-icp-6.0.0.tgz",
+      "integrity": "sha512-PoS8fwJuOJIRX6Coaq+tZJJ553IW++7CVFmR0OdHBE5fmvJEJ2ID2hARcKkyf1vvTCu8uOeIVWQ3hJA1AA0bSg==",
       "license": "Apache-2.0",
       "peer": true,
       "peerDependencies": {
@@ -294,9 +294,9 @@
       }
     },
     "node_modules/@dfinity/ledger-icrc": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-3.0.0.tgz",
-      "integrity": "sha512-2T5JQ198vnhUv3o08SS4T2Je70QsKuZ2RkKw4Sm7GW1lEFc0228/rzcAMguwoOh9+CoYpUbnh645ZGs+gOHzSg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/ledger-icrc/-/ledger-icrc-4.0.0.tgz",
+      "integrity": "sha512-Pdi2p3CiUfV5b6v654cj9kxd6ZlZKtXWbQyj/FOaJgu0vmkdhDMfDOd7+9J4/jR4XZAldCRg7EGOKI5TK7YZ3g==",
       "license": "Apache-2.0",
       "peer": true,
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -90,8 +90,8 @@
   "peerDependencies": {
     "@dfinity/agent": "^3",
     "@dfinity/candid": "^3",
-    "@dfinity/ledger-icp": "^5",
-    "@dfinity/ledger-icrc": "^3",
+    "@dfinity/ledger-icp": "^6",
+    "@dfinity/ledger-icrc": "^4",
     "@dfinity/principal": "^3",
     "@dfinity/utils": "^3",
     "@dfinity/zod-schemas": "^1.1.0",


### PR DESCRIPTION
# Motivation

A breaking change to ICRC-21 was released in ic-js [v74](https://github.com/dfinity/ic-js/releases/tag/v74). `LineDisplay` has been replaced by `FieldsDisplay`. Bumping the library should be fine but, we will need another PR to update the lib because it has it's own declaration files for it.

# Changes

- Bump ledger-icp and ledger-icrc in lib and demo.
