### PR TITLE
feat: adds a manifest to the demo app

### DIFF
--- a/demo/src/wallet_frontend/src/app.html
+++ b/demo/src/wallet_frontend/src/app.html
@@ -6,6 +6,8 @@
 		<link rel="icon" href="%sveltekit.assets%/favicon.png" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		%sveltekit.head%
+
+		<link crossorigin="anonymous" href="/manifest.webmanifest" rel="manifest" />
 	</head>
 	<body data-sveltekit-preload-data="hover" class="bg-white dark:bg-black">
 		<div style="display: contents">%sveltekit.body%</div>

--- a/demo/src/wallet_frontend/static/manifest.webmanifest
+++ b/demo/src/wallet_frontend/static/manifest.webmanifest
@@ -1,0 +1,24 @@
+{
+	"name": "OISY Wallet Signer Demo",
+	"short_name": "OISY Demo",
+	"start_url": ".",
+	"display": "standalone",
+	"theme_color": "#FFFFFF",
+	"background_color": "#FFFFFF",
+	"description": "A demo app showcasing communication between dApps and the OISY Wallet on the Internet Computer",
+	"orientation": "portrait-primary",
+	"prefer_related_applications": false,
+	"categories": ["finance"],
+	"icons": [
+		{
+			"src": "./favicon.png",
+			"sizes": "192x192",
+			"type": "image/png"
+		},
+		{
+			"src": "./favicon.png",
+			"sizes": "512x512",
+			"type": "image/png"
+		}
+	]
+}


### PR DESCRIPTION
# Motivation

It should be possible to install the demo app as a PWA standalone, so we added a manifest definition.
