### PR TITLE
fix: ledger-icrc import from root

### DIFF
--- a/src/api/signer.api.ts
+++ b/src/api/signer.api.ts
@@ -1,6 +1,5 @@
 import {encode, encodeWithSelfDescribedTag} from '@dfinity/cbor';
-import {IcrcLedgerCanister} from '@dfinity/ledger-icrc';
-import type {IcrcTokenMetadataResponse} from '@dfinity/ledger-icrc/dist/types/types/ledger.responses';
+import {type IcrcTokenMetadataResponse, IcrcLedgerCanister} from '@dfinity/ledger-icrc';
 import {Principal} from '@dfinity/principal';
 import {uint8ArrayToBase64} from '@dfinity/utils';
 import type {CustomHttpAgentResponse} from '../agent/custom-http-agent';


### PR DESCRIPTION
# Motivation

I spotted a type incorrectly import from the library `/dist/...` folder instead of from root.

# Changes

- Update import to point to `@dfinity/ledger-icrc` and not `@dfinity/ledger-icrc/dist/...`
