### PR TITLE
chore: fix a typo in a CI action

### DIFF
--- a/.github/actions/setup-e2e-env/action.yml
+++ b/.github/actions/setup-e2e-env/action.yml
@@ -1,4 +1,4 @@
-name: Setup E2EEnvironment
+name: Setup E2E Environment
 
 description: Installs the Juno CLI and caches Docker layers
 


### PR DESCRIPTION
# Motivation

I spotted a missing space in a CI action title.