### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/demo-checks.yml
+++ b/.github/workflows/demo-checks.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Prepare
         uses: ./.github/actions/prepare
       - name: Prepare Demo
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Prepare
         uses: ./.github/actions/prepare
       - name: Prepare Demo

--- a/.github/workflows/demo-deploy.yaml
+++ b/.github/workflows/demo-deploy.yaml
@@ -15,7 +15,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Prepare
         uses: ./.github/actions/prepare
       - name: Prepare Demo

--- a/.github/workflows/e2e-snapshots.yml
+++ b/.github/workflows/e2e-snapshots.yml
@@ -18,7 +18,7 @@ jobs:
           exit 1
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Prepare Lib
         uses: ./.github/actions/prepare
       - name: Prepare Demo
@@ -34,7 +34,7 @@ jobs:
           cd ..
           npm run e2e:ci:snapshots
       - name: Commit Playwright updated snapshots
-        uses: EndBug/add-and-commit@v9
+        uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5 # v9.1.4
         if: ${{ github.ref != 'refs/heads/main' }}
         with:
           add: e2e

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Prepare Lib
         uses: ./.github/actions/prepare
       - name: Prepare Demo
@@ -31,14 +31,14 @@ jobs:
           cd ..
           npm run e2e:ci
       - name: Upload Playwright report on failure
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: ${{ failure() }}
         with:
           name: playwright-report
           path: playwright-report/
           retention-days: 3
       - name: Upload Playwright results on failure
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: ${{ failure() }}
         with:
           name: test-results

--- a/.github/workflows/lib-checks.yml
+++ b/.github/workflows/lib-checks.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Prepare
         uses: ./.github/actions/prepare
       - name: Format
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Prepare
         uses: ./.github/actions/prepare
       - name: Lint
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Prepare
         uses: ./.github/actions/prepare
       - name: Build

--- a/.github/workflows/lib-publish.yml
+++ b/.github/workflows/lib-publish.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Prepare
         uses: ./.github/actions/prepare
@@ -57,7 +57,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Prepare
         uses: ./.github/actions/prepare

--- a/.github/workflows/lib-tests.yml
+++ b/.github/workflows/lib-tests.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Prepare
         uses: ./.github/actions/prepare
       - name: Tests


### PR DESCRIPTION
## Pin GitHub Actions to commit SHAs

GitHub Actions referenced by tag (e.g. `actions/checkout@v4`) use a mutable pointer — the tag owner can move it to a different commit at any time, including a malicious one. This is the attack vector used in the tj-actions/changed-files incident (CVE-2025-30066).

Pinning to a full 40-character commit SHA makes the reference immutable. The `# tag` comment preserves human readability so reviewers can tell which version is pinned.

Important: a SHA can also originate from a forked repository. A malicious actor can fork an action, push a compromised commit to the fork, and the SHA will resolve — but it won't exist in the upstream canonical repo. Each SHA in this PR was verified against the action's canonical repository (not a fork).

### Changes

- `actions/checkout@v4` -> `actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1`
  - Version: v4.3.1 | Latest: v6.0.2 | Release age: 90d
  - Commit: https://github.com/actions/checkout/commit/34e114876b0b11c390a56381ad16ebd13914f8d5

- `EndBug/add-and-commit@v9` -> `EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5 # v9.1.4`
  - Version: v9.1.4 | Latest: v10.0.0 | Release age: 18d
  - Commit: https://github.com/EndBug/add-and-commit/commit/a94899bca583c204427a224a7af87c02f9b325d5

- `actions/upload-artifact@v4` -> `actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2`
  - Version: v4.6.2 | Latest: v3.2.2 | Release age: 23d
  - Commit: https://github.com/actions/upload-artifact/commit/ea165f8d65b6e75b540449e92b4886f43607fa02


### Files modified

- `.github/workflows/demo-checks.yml`
- `.github/workflows/demo-deploy.yaml`
- `.github/workflows/e2e-snapshots.yml`
- `.github/workflows/e2e-tests.yml`
- `.github/workflows/lib-checks.yml`
- `.github/workflows/lib-publish.yml`
- `.github/workflows/lib-tests.yml`