### PR TITLE
lint: resolve no-unnecessary-type-assertion errors after core v4 downgrade

### DIFF
--- a/src/api/agent.api.ts
+++ b/src/api/agent.api.ts
@@ -61,7 +61,7 @@ export abstract class AgentApi {
    * @returns {Promise<HttpAgentProvider>} - A promise that resolves to a default agent instance.
    */
   protected async getDefaultAgent(options: SignerOptions): Promise<HttpAgentProvider> {
-    return (await this.getAgent({options, type: 'default'})) as HttpAgentProvider;
+    return await this.getAgent({options, type: 'default'});
   }
 
   /**

--- a/src/signer.spec.ts
+++ b/src/signer.spec.ts
@@ -114,7 +114,11 @@ describe('Signer', () => {
 
     beforeEach(() => {
       signer = Signer.init(signerOptions);
-      onMessageListenerSpy = vi.spyOn(signer as unknown as {onMessage: () => void}, 'onMessage');
+      onMessageListenerSpy = vi.spyOn(
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion -- required by tsc to spy on the private `onMessage` method
+        signer as unknown as {onMessage: () => void},
+        'onMessage'
+      );
     });
 
     afterEach(() => {
@@ -132,6 +136,7 @@ describe('Signer', () => {
 
     it('should not process message which are not RpcRequest', () => {
       const spyAssertAndSetOrigin = vi.spyOn(
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion -- required by tsc to spy on the private `assertNotUndefinedAndSameOrigin` method
         signer as unknown as {
           assertNotUndefinedAndSameOrigin: (params: {
             origin: Origin;
@@ -512,6 +517,7 @@ describe('Signer', () => {
 
         it('should not handle with busy', async () => {
           const handleWithBusySpy = vi.spyOn(
+            // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion -- required by tsc to spy on the private `handleWithBusy` method
             signer as unknown as {handleWithBusy: () => void},
             'handleWithBusy'
           );
@@ -524,6 +530,7 @@ describe('Signer', () => {
 
         it('should not handle with busy even if the answer to the status message has been notified', async () => {
           const handleWithBusySpy = vi.spyOn(
+            // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion -- required by tsc to spy on the private `handleWithBusy` method
             signer as unknown as {handleWithBusy: () => void},
             'handleWithBusy'
           );
@@ -1179,7 +1186,11 @@ describe('Signer', () => {
           it('should reset to idle', async () => {
             const {confirm} = await prepareConfirm();
 
-            const spy = vi.spyOn(signer as unknown as {setIdle: () => void}, 'setIdle');
+            const spy = vi.spyOn(
+              // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion -- required by tsc to spy on the private `setIdle` method
+              signer as unknown as {setIdle: () => void},
+              'setIdle'
+            );
 
             confirm?.([
               {
@@ -1736,7 +1747,11 @@ describe('Signer', () => {
             it('should reset to idle', async () => {
               const {approve} = await prepareApprove();
 
-              const spy = vi.spyOn(signer as unknown as {setIdle: () => void}, 'setIdle');
+              const spy = vi.spyOn(
+                // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion -- required by tsc to spy on the private `setIdle` method
+                signer as unknown as {setIdle: () => void},
+                'setIdle'
+              );
 
               approve?.(mockAccounts);
 
@@ -2172,7 +2187,11 @@ describe('Signer', () => {
                   let spySetIdle: MockInstance;
 
                   beforeEach(async () => {
-                    spySetIdle = vi.spyOn(signer as unknown as {setIdle: () => void}, 'setIdle');
+                    spySetIdle = vi.spyOn(
+                      // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion -- required by tsc to spy on the private `setIdle` method
+                      signer as unknown as {setIdle: () => void},
+                      'setIdle'
+                    );
 
                     spyCanisterCall = vi
                       .spyOn(SignerApi.prototype, 'call')

--- a/src/utils/call.utils.spec.ts
+++ b/src/utils/call.utils.spec.ts
@@ -132,9 +132,12 @@ describe('call.utils', () => {
 
     describe('With agent root key', () => {
       beforeEach(() => {
-        createSpy = vi.spyOn(agent.HttpAgent, 'create').mockResolvedValue({
-          rootKey: mockLocalIcRootKey
-        } as unknown as agent.HttpAgent);
+        createSpy = vi.spyOn(agent.HttpAgent, 'create').mockResolvedValue(
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion -- required by tsc since this partial mock does not satisfy the full HttpAgent shape
+          {
+            rootKey: mockLocalIcRootKey
+          } as unknown as agent.HttpAgent
+        );
       });
 
       it('should decode success response', async () => {
@@ -173,9 +176,12 @@ describe('call.utils', () => {
 
     describe('Without agent root key', () => {
       beforeEach(() => {
-        createSpy = vi.spyOn(agent.HttpAgent, 'create').mockResolvedValue({
-          rootKey: null
-        } as unknown as agent.HttpAgent);
+        createSpy = vi.spyOn(agent.HttpAgent, 'create').mockResolvedValue(
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion -- required by tsc since this partial mock does not satisfy the full HttpAgent shape
+          {
+            rootKey: null
+          } as unknown as agent.HttpAgent
+        );
       });
 
       it('should throw an exception is agent root key is undefined', async () => {


### PR DESCRIPTION
# Motivation

After #864 downgraded `@icp-sdk/core` and `@icp-sdk/auth` to v4, the v4 type definitions cause `@typescript-eslint/no-unnecessary-type-assertion` to flag 10 type assertions as unnecessary, while `tsc -p tsconfig.spec.json` still **requires** them (private method spies, partial mocks).


