### PR TITLE
refactor: bind demo SendICP transfer to the displayed wallet account

### DIFF
--- a/demo/src/relying_party_frontend/src/lib/components/SendICP.svelte
+++ b/demo/src/relying_party_frontend/src/lib/components/SendICP.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { IcpWallet } from '@dfinity/oisy-wallet-signer/icp-wallet';
+	import type { IcrcAccount } from '@dfinity/oisy-wallet-signer';
 	import { createAgent, isNullish } from '@dfinity/utils';
 	import { IcpLedgerCanister } from '@icp-sdk/canisters/ledger/icp';
 	import { Principal } from '@icp-sdk/core/principal';
@@ -8,10 +8,13 @@
 	import { alertStore } from '$core/stores/alert.store';
 	import { authStore } from '$core/stores/auth.store';
 	import { emit } from '$core/utils/events.utils';
-	import { walletUrlStore } from '$lib/stores/wallet.store';
 	import { getTransferRequest } from '$lib/utils/transfer.utils';
 
-	let wallet = $state<IcpWallet | undefined>(undefined);
+	interface Props {
+		account: IcrcAccount;
+	}
+
+	let { account }: Props = $props();
 
 	const onclick = async () => {
 		try {
@@ -22,26 +25,6 @@
 				});
 				return;
 			}
-
-			wallet = await IcpWallet.connect({
-				url: $walletUrlStore
-			});
-
-			const accounts = await wallet?.accounts();
-
-			const account = accounts?.[0];
-
-			if (isNullish(account)) {
-				await wallet?.disconnect();
-
-				alertStore.set({
-					type: 'error',
-					message: 'The wallet did not provide any account.'
-				});
-				return;
-			}
-
-			await wallet?.disconnect();
 
 			const agent = await createAgent({
 				...(DEV && { host: LOCAL_REPLICA_URL, fetchRootKey: true }),

--- a/demo/src/relying_party_frontend/src/routes/+page.svelte
+++ b/demo/src/relying_party_frontend/src/routes/+page.svelte
@@ -35,7 +35,7 @@
 		<div class="md:min-h-20">
 			{#if nonNullish(account)}
 				<div in:fade>
-					<SendICP />
+					<SendICP {account} />
 				</div>
 			{/if}
 		</div>


### PR DESCRIPTION
# Motivation

In the relying-party demo, `SendICP` re-connected to the wallet and independently resolved `accounts[0]` as the transfer destination — ignoring the account already established by `ConnectAndRequestAccount` and displayed in the `Wallet` card ("Your Oisy Wallet ID"). The destination actually used was therefore never bound to the one shown to the user.

This was flagged as a "TOCTOU trust flaw." It is **not** a fund-theft vulnerability: this is demo code, and the only actor who could exploit the display-vs-send divergence is a malicious wallet signer, which is outside the relying party's threat model (the wallet is the trusted key-holder by design). The legitimate kernel is a correctness / UX-integrity issue — the component resolved the destination twice and used a different resolution than the one it displayed.

# Changes

- `SendICP.svelte`: accept `account: IcrcAccount` as a prop and transfer to it; remove the internal `IcpWallet.connect()` / `accounts()` / `disconnect()` round-trip and the now-unused `IcpWallet` / `walletUrlStore` imports.
- `+page.svelte`: pass `{account}` to `<SendICP />` (already rendered only inside `{#if nonNullish(account)}`), mirroring how `<Wallet {account} />` is wired.

# Tests

- `npm run check:party` — 0 errors, 0 warnings.
- Prettier clean on both changed files.
- No behavioural change to the happy path: the ICP is still sent to the wallet account, now guaranteed to be the one displayed on the page.