### PR TITLE
ci: pin GitHub Actions to SHAs + enforce with zizmor (pedantic)

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -11,7 +11,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
       with:
         node-version: 24
         registry-url: 'https://registry.npmjs.org'

--- a/.github/actions/setup-e2e-env/action.yml
+++ b/.github/actions/setup-e2e-env/action.yml
@@ -10,7 +10,7 @@ runs:
       shell: bash
 
     - name: Cache Docker layers
-      uses: actions/cache@v3
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
       with:
         path: /home/runner/.docker
         key: ${{ runner.os }}-docker-${{ github.sha }}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,10 +3,21 @@
 
 version: 2
 updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: monthly
+    commit-message:
+      prefix: 'build'
+    cooldown:
+      default-days: 30
+
   - package-ecosystem: npm
     directory: '/'
     schedule:
       interval: monthly
+    cooldown:
+      default-days: 30
     allow:
       - dependency-type: development
     ignore:
@@ -21,6 +32,8 @@ updates:
     directory: '/demo'
     schedule:
       interval: monthly
+    cooldown:
+      default-days: 30
     ignore:
       - dependency-name: '@types/*'
       - dependency-name: '@typescript-eslint/*'

--- a/.github/workflows/demo-checks.yml
+++ b/.github/workflows/demo-checks.yml
@@ -19,7 +19,9 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Prepare
         uses: ./.github/actions/prepare
       - name: Prepare Demo
@@ -38,7 +40,9 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Prepare
         uses: ./.github/actions/prepare
       - name: Prepare Demo

--- a/.github/workflows/demo-checks.yml
+++ b/.github/workflows/demo-checks.yml
@@ -7,8 +7,13 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
+    name: Lint
     runs-on: ubuntu-latest
 
     permissions:
@@ -33,6 +38,7 @@ jobs:
         working-directory: 'demo'
 
   check:
+    name: Check
     runs-on: ubuntu-latest
 
     permissions:
@@ -54,6 +60,7 @@ jobs:
         working-directory: 'demo'
 
   demo-checks-pass:
+    name: demo-checks-pass
     needs: ['check', 'lint']
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/demo-deploy.yaml
+++ b/.github/workflows/demo-deploy.yaml
@@ -7,12 +7,17 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   build:
+    name: Build & Deploy
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write
+      id-token: write # Required for OIDC authentication with Juno when deploying.
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/demo-deploy.yaml
+++ b/.github/workflows/demo-deploy.yaml
@@ -15,7 +15,9 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Prepare
         uses: ./.github/actions/prepare
       - name: Prepare Demo

--- a/.github/workflows/devops-checks.yml
+++ b/.github/workflows/devops-checks.yml
@@ -17,10 +17,6 @@ jobs:
         with:
           persist-credentials: false
 
-      # zizmor statically audits our GitHub Actions workflows and composite
-      # actions. It notably enforces that every third-party action is pinned to
-      # a full commit SHA (unpinned-uses), guarding against supply-chain attacks
-      # via mutable tags. See .github/zizmor.yml for configured exceptions.
       - name: Lint GitHub Actions with zizmor
         run: pipx run zizmor==1.22.0 .github
         env:

--- a/.github/workflows/devops-checks.yml
+++ b/.github/workflows/devops-checks.yml
@@ -25,6 +25,10 @@ jobs:
         uses: zizmorcore/zizmor-action@6599ee8b7a49aef6a770f63d261d214911a7ce02 # v0.6.0
         with:
           persona: pedantic
+          # Pin the zizmor version so the gate is deterministic: a new release
+          # can add audits that would otherwise fail unrelated PRs. Bump this
+          # deliberately and address any new findings in the same change.
+          version: v1.24.0
           # Fail the job on findings instead of only uploading a SARIF report to
           # the Security tab, so unpinned or otherwise unsafe workflow changes
           # block the pull request.

--- a/.github/workflows/devops-checks.yml
+++ b/.github/workflows/devops-checks.yml
@@ -1,0 +1,36 @@
+name: Devops Checks
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  lint-github-actions:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      # zizmor statically audits our GitHub Actions workflows and composite
+      # actions. It notably enforces that every third-party action is pinned to
+      # a full commit SHA (unpinned-uses), guarding against supply-chain attacks
+      # via mutable tags. See .github/zizmor.yml for configured exceptions.
+      - name: Lint GitHub Actions with zizmor
+        run: pipx run zizmor==1.22.0 .github
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  devops-checks-pass:
+    needs: ['lint-github-actions']
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Cleared for merging
+        run: echo OK

--- a/.github/workflows/devops-checks.yml
+++ b/.github/workflows/devops-checks.yml
@@ -6,8 +6,13 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint-github-actions:
+    name: Lint GitHub Actions
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -16,13 +21,17 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-
-      - name: Lint GitHub Actions with zizmor
-        run: pipx run zizmor==1.22.0 .github
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@6599ee8b7a49aef6a770f63d261d214911a7ce02 # v0.6.0
+        with:
+          persona: pedantic
+          # Fail the job on findings instead of only uploading a SARIF report to
+          # the Security tab, so unpinned or otherwise unsafe workflow changes
+          # block the pull request.
+          advanced-security: false
 
   devops-checks-pass:
+    name: devops-checks-pass
     needs: ['lint-github-actions']
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/e2e-snapshots.yml
+++ b/.github/workflows/e2e-snapshots.yml
@@ -5,11 +5,16 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   update_snapshots:
+    name: Update Snapshots
     runs-on: ubuntu-20.04
     permissions:
-      contents: write
+      contents: write # Required to commit and push the regenerated Playwright snapshots back to the branch.
     steps:
       - name: Fail if branch is main
         if: ${{ github.ref == 'refs/heads/main' }}
@@ -19,6 +24,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Prepare Lib
         uses: ./.github/actions/prepare
       - name: Prepare Demo
@@ -33,6 +40,13 @@ jobs:
           juno emulator start --headless &
           cd ..
           npm run e2e:ci:snapshots
+      # Checkout runs with persist-credentials: false, so re-supply the token to
+      # git (scoped to this local repo) enabling add-and-commit to push.
+      - name: Configure git credentials
+        if: ${{ github.ref != 'refs/heads/main' }}
+        run: git config url."https://github-actions:${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Commit Playwright updated snapshots
         uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5 # v9.1.4
         if: ${{ github.ref != 'refs/heads/main' }}

--- a/.github/workflows/e2e-snapshots.yml
+++ b/.github/workflows/e2e-snapshots.yml
@@ -17,8 +17,11 @@ jobs:
           echo "This workflow should not be triggered with workflow_dispatch on main"
           exit 1
 
+      # persist-credentials is intentionally left at its default (true): the
+      # "Commit Playwright updated snapshots" step below needs the checkout
+      # credentials to push the updated snapshots back to the branch.
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Prepare Lib
         uses: ./.github/actions/prepare
       - name: Prepare Demo
@@ -34,7 +37,7 @@ jobs:
           cd ..
           npm run e2e:ci:snapshots
       - name: Commit Playwright updated snapshots
-        uses: EndBug/add-and-commit@v9
+        uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5 # v9.1.4
         if: ${{ github.ref != 'refs/heads/main' }}
         with:
           add: e2e

--- a/.github/workflows/e2e-snapshots.yml
+++ b/.github/workflows/e2e-snapshots.yml
@@ -17,9 +17,6 @@ jobs:
           echo "This workflow should not be triggered with workflow_dispatch on main"
           exit 1
 
-      # persist-credentials is intentionally left at its default (true): the
-      # "Commit Playwright updated snapshots" step below needs the checkout
-      # credentials to push the updated snapshots back to the branch.
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Prepare Lib

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -15,7 +15,9 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Prepare Lib
         uses: ./.github/actions/prepare
       - name: Prepare Demo
@@ -31,14 +33,14 @@ jobs:
           cd ..
           npm run e2e:ci
       - name: Upload Playwright report on failure
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: ${{ failure() }}
         with:
           name: playwright-report
           path: playwright-report/
           retention-days: 3
       - name: Upload Playwright results on failure
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: ${{ failure() }}
         with:
           name: test-results

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -6,8 +6,13 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   e2e:
+    name: E2E
     runs-on: ubuntu-latest
 
     permissions:
@@ -48,6 +53,7 @@ jobs:
           retention-days: 3
 
   e2e-tests-pass:
+    name: e2e-tests-pass
     needs: ['e2e']
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/lib-checks.yml
+++ b/.github/workflows/lib-checks.yml
@@ -14,7 +14,9 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Prepare
         uses: ./.github/actions/prepare
       - name: Format
@@ -27,7 +29,9 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Prepare
         uses: ./.github/actions/prepare
       - name: Lint
@@ -40,7 +44,9 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Prepare
         uses: ./.github/actions/prepare
       - name: Build

--- a/.github/workflows/lib-checks.yml
+++ b/.github/workflows/lib-checks.yml
@@ -6,8 +6,13 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   format:
+    name: Format
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -23,6 +28,7 @@ jobs:
         run: npm run format:check
 
   lint:
+    name: Lint
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -38,6 +44,7 @@ jobs:
         run: npm run lint -- --max-warnings 0
 
   build:
+    name: Build
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -53,6 +60,7 @@ jobs:
         run: npm run build
 
   lib-checks-pass:
+    name: lib-checks-pass
     needs: ['build', 'lint', 'format']
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/lib-publish.yml
+++ b/.github/workflows/lib-publish.yml
@@ -30,7 +30,9 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Prepare
         uses: ./.github/actions/prepare
@@ -57,7 +59,9 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Prepare
         uses: ./.github/actions/prepare

--- a/.github/workflows/lib-publish.yml
+++ b/.github/workflows/lib-publish.yml
@@ -13,8 +13,13 @@ run-name: >-
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   publish-release:
+    name: Publish Release
     if: github.event_name == 'release'
 
     runs-on: ubuntu-latest
@@ -23,7 +28,7 @@ jobs:
 
     permissions:
       contents: read
-      id-token: write
+      id-token: write # Required for npm provenance, which uses OIDC to sign the published package.
 
     env:
       dist-directory: dist
@@ -44,6 +49,7 @@ jobs:
         working-directory: ${{env.dist-directory}}
 
   publish-next:
+    name: Publish Next
     if: github.event_name == 'workflow_dispatch'
 
     runs-on: ubuntu-latest
@@ -52,7 +58,7 @@ jobs:
 
     permissions:
       contents: read
-      id-token: write
+      id-token: write # Required for npm provenance, which uses OIDC to sign the published package.
 
     env:
       dist-directory: dist

--- a/.github/workflows/lib-tests.yml
+++ b/.github/workflows/lib-tests.yml
@@ -14,7 +14,9 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Prepare
         uses: ./.github/actions/prepare
       - name: Tests

--- a/.github/workflows/lib-tests.yml
+++ b/.github/workflows/lib-tests.yml
@@ -6,8 +6,13 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   tests:
+    name: Tests
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -23,6 +28,7 @@ jobs:
         run: npm run test
 
   lib-tests-pass:
+    name: lib-tests-pass
     needs: ['tests']
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -11,6 +11,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check-pr-title:
     name: 'check-pr-title:required'

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,9 +1,0 @@
-rules:
-  artipacked:
-    ignore:
-      # The "Update Snapshots" workflow commits and pushes the regenerated
-      # Playwright snapshots back to the branch via EndBug/add-and-commit,
-      # which needs the checkout credentials to persist. It is a manually
-      # dispatched maintenance workflow that never runs on main, so keeping
-      # the default persist-credentials behaviour here is acceptable.
-      - e2e-snapshots.yml

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,9 @@
+rules:
+  artipacked:
+    ignore:
+      # The "Update Snapshots" workflow commits and pushes the regenerated
+      # Playwright snapshots back to the branch via EndBug/add-and-commit,
+      # which needs the checkout credentials to persist. It is a manually
+      # dispatched maintenance workflow that never runs on main, so keeping
+      # the default persist-credentials behaviour here is acceptable.
+      - e2e-snapshots.yml


### PR DESCRIPTION
## Motivation

Two goals: pin every GitHub Action to an immutable commit SHA (as [`oisy-wallet`](https://github.com/dfinity/oisy-wallet) does) so a hijacked mutable tag can't alter our CI, and add a **hard-fail CI gate** that keeps it that way plus enforces broader workflow-security hygiene.

## Changes

### 1. Pin every action to a commit SHA

| Action | Before | After |
| --- | --- | --- |
| `actions/checkout` | `@v4` | `@de0fac2…` # v6.0.2 |
| `actions/setup-node` | `@v4` | `@cdca736…` # v4.3.0 |
| `actions/cache` | `@v3` | `@5a3ec84…` # v4.2.3 |
| `actions/upload-artifact` | `@v4` | `@ea165f8…` # v4.6.2 |
| `EndBug/add-and-commit` | `@v9` | `@a94899b…` # v9.1.4 |

Each SHA was verified against its tag with `git ls-remote`. `actions/cache@v3` also jumps to v4 (the v3 backend is deprecated). Checkouts now set `persist-credentials: false`.

### 2. New `Devops Checks` gate — zizmor via the official action

`.github/workflows/devops-checks.yml` runs [`zizmorcore/zizmor-action`](https://github.com/zizmorcore/zizmor-action) (pinned to a SHA, dependabot-maintained) on every PR:

- **`persona: pedantic`** — the strictest ruleset.
- **`advanced-security: false`** — findings **fail the job** (rather than only uploading a SARIF report), making it a real merge gate.
- **`version: v1.24.0`** — the zizmor version is pinned so the gate is deterministic. `version: latest` proved fragile: CI pulled a newer zizmor whose new pedantic audits hard-failed unrelated pre-existing steps. v1.24.0 is the newest release that audits this repo cleanly; bumps are deliberate and address new findings in the same change.

> Chose the official action over porting oisy-wallet's `scripts/setup` + `dev-tools.json` scaffolding: same guarantees, far less machinery for a single linter.

### 3. Fixed every pedantic finding — no ignores

The repo now passes `zizmor --persona pedantic` cleanly (0 findings, no `zizmor.yml` ignore file):

- **Concurrency groups** on all workflows (`cancel-in-progress: false` for publish/deploy/snapshot workflows so they're never aborted mid-run; `true` for checks/tests).
- **Job names** on every job. The required `*-pass` gates (`lib-checks-pass`, `lib-tests-pass`, `e2e-tests-pass`) keep their id as the name, so branch-protection status checks are unaffected.
- **Documented permissions** — inline comments on every `id-token: write` / `contents: write`.
- **`e2e-snapshots.yml`** switched to `persist-credentials: false`; the token is re-supplied to git so `add-and-commit` can still push the regenerated snapshots — replacing the previous `artipacked` ignore.

### 4. Dependabot

Added a `github-actions` ecosystem (keeps the pinned SHAs current) and a 30-day `cooldown` on the update configs.

## Notes

- `e2e-snapshots.yml` still targets the retired `ubuntu-20.04` runner (pre-existing, unrelated to this PR). Worth bumping to `ubuntu-latest` in a follow-up.