### PR TITLE
fix: guard demo local faucet fetch behind non-PROD build

### DIFF
--- a/demo/src/wallet_frontend/src/lib/GetICP.svelte
+++ b/demo/src/wallet_frontend/src/lib/GetICP.svelte
@@ -1,12 +1,17 @@
 <script lang="ts">
 	import Button from '$core/components/Button.svelte';
+	import { PROD } from '$core/constants/app.constants';
 	import { authStore } from '$core/stores/auth.store';
 	import { emit } from '$core/utils/events.utils';
 
 	const onClick = async () => {
-		await fetch(
-			`http://localhost:5999/ledger/transfer/?to=${$authStore.identity?.getPrincipal() ?? ''}`
-		);
+		// The faucet is a local-only Juno satellite (see demo/docker-compose.yml) used for local
+		// development and E2E. Guard the call so it never fires from a production build.
+		if (!PROD) {
+			await fetch(
+				`http://localhost:5999/ledger/transfer/?to=${$authStore.identity?.getPrincipal() ?? ''}`
+			);
+		}
 
 		emit({
 			message: 'oisyDemoReloadBalance'


### PR DESCRIPTION
## Context

A code-review pass flagged the browser `fetch()` to `http://localhost:5999/ledger/transfer/` in the demo's **Get ICP** button as a web-to-localhost trust-boundary concern.

Investigation showed it is **not a real vulnerability**: `localhost:5999` is a local-only Juno satellite Docker container (see [`demo/docker-compose.yml`](../blob/main/demo/docker-compose.yml)) that acts as a **test-ICP faucet** for local development and E2E. It only exists on a developer's own machine, deals in fake ICP on a local replica, and simply fails to resolve in production.

## Change

Still worth tidying: the call was issued unconditionally. This guards it behind the existing `PROD` flag so the loopback request can never fire from a production build. Two-line, behavior-preserving for local dev/E2E.

## Test plan

- [x] Local dev / E2E: faucet still called, balance reload unchanged.
- [x] Production build: fetch is skipped; `emit` still fires.