### PR TITLE
build: revert @dfinity/utils from 4.2.1 to 4.0.3 in /demo

### DIFF
--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -12,7 +12,7 @@
 				"src/wallet_frontend"
 			],
 			"dependencies": {
-				"@dfinity/utils": "~4.2.1",
+				"@dfinity/utils": "~4.0.3",
 				"@dfinity/zod-schemas": "^3.0.2",
 				"@icp-sdk/auth": "^4.2.0",
 				"@icp-sdk/canisters": "~3.1.0",
@@ -169,12 +169,12 @@
 			}
 		},
 		"node_modules/@dfinity/utils": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-4.2.1.tgz",
-			"integrity": "sha512-5Rd0fflQzBf3h/doVvllJC0X+mrZPwbe6s9qfJm5jyJz07SEkN+cGmqY0HHMPDlCOohZgjDoAG6uwv+6cOMA+w==",
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/@dfinity/utils/-/utils-4.0.3.tgz",
+			"integrity": "sha512-QE4hI7w67PqTAlSXV60el+ZsGWS/Jm10g/dYDUtDNWDsNSrG2PQSJF0ZUu8LKFEaj13IPDQdcD0Hv19l+QVwCQ==",
 			"license": "Apache-2.0",
 			"peerDependencies": {
-				"@icp-sdk/core": "^5"
+				"@icp-sdk/core": "^4"
 			}
 		},
 		"node_modules/@dfinity/zod-schemas": {

--- a/demo/package.json
+++ b/demo/package.json
@@ -50,7 +50,7 @@
 	},
 	"type": "module",
 	"dependencies": {
-		"@dfinity/utils": "~4.2.1",
+		"@dfinity/utils": "~4.0.3",
 		"@dfinity/zod-schemas": "^3.0.2",
 		"@icp-sdk/auth": "^4.2.0",
 		"@icp-sdk/canisters": "~3.1.0",


### PR DESCRIPTION
# Motivation

Reverts #867, which has broken CI on `main` since it merged (2026-07-15 19:02 UTC).

`@dfinity/utils@4.1+` requires peer `@icp-sdk/core@^5`. #864 deliberately downgraded `@icp-sdk/core` and `@icp-sdk/auth` from v5 to v4 and pinned `@dfinity/utils` to `~4.0.3` precisely for this reason, noting *"(4.1+ requires core v5)"*. That release shipped as the `v6` major.

Dependabot's #867 lifted the pin to `~4.2.1`, dragging the v5 peer requirement back in and partially undoing the downgrade. `npm ci` in `/demo` then fails to resolve:

```
Could not resolve dependency:
peer @icp-sdk/core@"^5" from @dfinity/utils@4.2.1
Conflicting peer dependency: @icp-sdk/core@5.4.0
```

This kills the shared "Prepare Demo" step, so **Demo Checks**, **E2E Tests** and **Deploy to Juno** all fail — on `main` and on every PR opened since, regardless of its contents.

# Changes

- `demo/package.json`: `@dfinity/utils` `~4.2.1` -> `~4.0.3`
- `demo/package-lock.json`: regenerated

# Verification

`npm ci` in `/demo` succeeds again, and the tree resolves back to the v4 line with no v5 anywhere:

```
+-- @dfinity/utils@4.0.3
| `-- @icp-sdk/core@4.2.3 deduped
+-- @icp-sdk/auth@4.2.0
| `-- @icp-sdk/core@4.2.3 deduped
+-- @icp-sdk/canisters@3.1.0
| `-- @icp-sdk/core@4.2.3 deduped
```

# Follow-up

Nothing currently stops Dependabot from doing this again: `.github/dependabot.yml` only ignores `@types/*`, `@typescript-eslint/*` and `eslint*`. The packages pinned by #864 — `@icp-sdk/core`, `@icp-sdk/auth`, `@icp-sdk/canisters`, `@dfinity/utils` — are all exposed, in both the `/` and `/demo` blocks. Worth adding ignore rules in a separate PR.